### PR TITLE
Use acquia/environment-detector instead of BLT classes

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
         "drupal/lightning_workflow": "^3.14",
         "drupal/responsive_preview": "^1.0@beta",
         "drupal/schema_metatag": "^1.4",
-        "acquia/environment-detector": "dev-master"
+        "acquia/drupal-environment-detector": "dev-master"
     },
     "require-dev": {
         "drupal/core-composer-scaffold": "*",
@@ -102,7 +102,7 @@
         },
         "environment-detector": {
             "type": "vcs",
-            "url": "https://github.com/acquia/environment-detector.git",
+            "url": "https://github.com/acquia/drupal-environment-detector.git",
             "no-api": true
         }
     },

--- a/src/Config/ACMSConfigOverrides.php
+++ b/src/Config/ACMSConfigOverrides.php
@@ -2,7 +2,7 @@
 
 namespace Drupal\acquia_cms\Config;
 
-use Acquia\EnvironmentDetector\AcquiaEnvironmentDetector as EnvironmentDetector;
+use Acquia\DrupalEnvironmentDetector\AcquiaDrupalEnvironmentDetector as EnvironmentDetector;
 use Drupal\Core\Cache\CacheableMetadata;
 use Drupal\Core\Config\ConfigFactoryOverrideInterface;
 use Drupal\Core\Config\StorageInterface;


### PR DESCRIPTION
Fixes #32. I confirmed with manual testing that, once this is fixed, Acquia CMS is installable without needing BLT.