### PR TITLE
Require Drupal 8.9

### DIFF
--- a/acquia_cms.info.yml
+++ b/acquia_cms.info.yml
@@ -1,5 +1,5 @@
 name: Acquia CMS
-core: 8.x
+core_version_requirement: ^8.9
 type: profile
 description: "An implementation of Lightning for running low code websites in the Acquia platform."
 install:

--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
         "cweagans/composer-patches": "^1.6",
         "drupal/admin_toolbar": "^2.0",
         "drupal/adminimal_admin_toolbar": "^1.10",
-        "drupal/core": "^8.8.5 || ^9",
+        "drupal/core": "^8.9",
         "drupal/default_content": "^1.0@alpha",
         "drupal/environment_indicator": "^3.7",
         "drupal/lightning_api": "^4.4",

--- a/modules/acquia_cms_article/acquia_cms_article.info.yml
+++ b/modules/acquia_cms_article/acquia_cms_article.info.yml
@@ -1,7 +1,7 @@
 name: "Acquia CMS Article"
 description: "Provides an Article content type and related configuration."
 type: module
-core: 8.x
+core_version_requirement: ^8.9
 dependencies:
   - acquia_cms_common
   - acquia_cms_person

--- a/modules/acquia_cms_common/acquia_cms_common.info.yml
+++ b/modules/acquia_cms_common/acquia_cms_common.info.yml
@@ -1,7 +1,7 @@
 name: "Acquia CMS Common"
 description: "Handles shared functionality for Acquia CMS."
 type: module
-core: 8.x
+core_version_requirement: ^8.9
 dependencies:
   - cohesion
   - cohesion_elements

--- a/modules/acquia_cms_demo/acquia_cms_demo.info.yml
+++ b/modules/acquia_cms_demo/acquia_cms_demo.info.yml
@@ -1,7 +1,7 @@
 name: "Acquia CMS Demo"
 description: "Creates Demo Content for Acquia CMS."
 type: module
-core: 8.x
+core_version_requirement: ^8.9
 dependencies:
   - acquia_cms_common
   - acquia_cms_article

--- a/modules/acquia_cms_page/acquia_cms_page.info.yml
+++ b/modules/acquia_cms_page/acquia_cms_page.info.yml
@@ -1,7 +1,7 @@
 name: "Landing Page"
 description: "Provides Landing Page content type and related configuration. An unstructured content type that provides unique landing pages - i.e., a homepage, or marketing event landing page."
 type: module
-core: 8.x
+core_version_requirement: ^8.9
 dependencies:
   - acquia_cms_common
   - cohesion_elements

--- a/modules/acquia_cms_person/acquia_cms_person.info.yml
+++ b/modules/acquia_cms_person/acquia_cms_person.info.yml
@@ -1,7 +1,7 @@
 name: "Acquia CMS Person"
 description: 'Provides Person content type and related configuration. Provides a "Person" content type, a structured data representation of people associated with a website or organization.'
 type: module
-core: 8.x
+core_version_requirement: ^8.9
 dependencies:
   - cohesion_templates
   - field


### PR DESCRIPTION
We've decided to do the initial build of Acquia CMS on Drupal 8, with a transition to Drupal 9 as soon as our dependency tree is ready. To that end, let's begin on the final version of Drupal 8, which is identical to Drupal 9 except for the presence of deprecated APIs.