### PR TITLE
Add Categories vocabulary and rename Keywords to Tags

### DIFF
--- a/modules/acquia_cms_common/config/install/field.storage.node.field_categories.yml
+++ b/modules/acquia_cms_common/config/install/field.storage.node.field_categories.yml
@@ -4,8 +4,8 @@ dependencies:
   module:
     - node
     - taxonomy
-id: node.field_keywords
-field_name: field_keywords
+id: node.field_categories
+field_name: field_categories
 entity_type: node
 type: entity_reference
 settings:

--- a/modules/acquia_cms_common/config/install/field.storage.node.field_tags.yml
+++ b/modules/acquia_cms_common/config/install/field.storage.node.field_tags.yml
@@ -1,0 +1,19 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+    - taxonomy
+id: node.field_tags
+field_name: field_tags
+entity_type: node
+type: entity_reference
+settings:
+  target_type: taxonomy_term
+module: core
+locked: false
+cardinality: -1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/modules/acquia_cms_common/config/install/taxonomy.vocabulary.categories.yml
+++ b/modules/acquia_cms_common/config/install/taxonomy.vocabulary.categories.yml
@@ -1,0 +1,7 @@
+langcode: en
+status: true
+dependencies: {  }
+name: Categories
+vid: categories
+description: 'Descriptive metadata, for categorizing content and making search engines happy.'
+weight: 0

--- a/modules/acquia_cms_common/config/install/taxonomy.vocabulary.tags.yml
+++ b/modules/acquia_cms_common/config/install/taxonomy.vocabulary.tags.yml
@@ -1,7 +1,7 @@
 langcode: en
 status: true
 dependencies: {  }
-name: Keywords
-vid: keywords
+name: Tags
+vid: tags
 description: 'Descriptive metadata, for categorizing content and making search engines happy.'
 weight: 0

--- a/modules/acquia_cms_page/config/install/core.entity_form_display.node.page.default.yml
+++ b/modules/acquia_cms_page/config/install/core.entity_form_display.node.page.default.yml
@@ -2,7 +2,7 @@ langcode: en
 status: true
 dependencies:
   config:
-    - field.field.node.page.field_keywords
+    - field.field.node.page.field_tags
     - field.field.node.page.field_layout_canvas
     - node.type.page
     - workflows.workflow.editorial
@@ -21,7 +21,7 @@ content:
     region: content
     settings: {}
     third_party_settings: {}
-  field_keywords:
+  field_tags:
     weight: 123
     settings:
       match_operator: CONTAINS

--- a/modules/acquia_cms_page/config/install/core.entity_view_display.node.page.default.yml
+++ b/modules/acquia_cms_page/config/install/core.entity_view_display.node.page.default.yml
@@ -2,7 +2,7 @@ langcode: en
 status: true
 dependencies:
   config:
-    - field.field.node.page.field_keywords
+    - field.field.node.page.field_tags
     - field.field.node.page.field_layout_canvas
     - node.type.page
   module:
@@ -13,7 +13,7 @@ targetEntityType: node
 bundle: page
 mode: default
 content:
-  field_keywords:
+  field_tags:
     type: entity_reference_label
     weight: 2
     region: content

--- a/modules/acquia_cms_page/config/install/core.entity_view_display.node.page.teaser.yml
+++ b/modules/acquia_cms_page/config/install/core.entity_view_display.node.page.teaser.yml
@@ -3,7 +3,7 @@ status: true
 dependencies:
   config:
     - core.entity_view_mode.node.teaser
-    - field.field.node.page.field_keywords
+    - field.field.node.page.field_tags
     - field.field.node.page.field_layout_canvas
     - node.type.page
   module:
@@ -20,6 +20,6 @@ content:
     third_party_settings: {}
     region: content
 hidden:
-  field_keywords: true
+  field_tags: true
   field_layout_canvas: true
   search_api_excerpt: true

--- a/modules/acquia_cms_page/config/install/field.field.node.page.field_categories.yml
+++ b/modules/acquia_cms_page/config/install/field.field.node.page.field_categories.yml
@@ -2,13 +2,13 @@ langcode: en
 status: true
 dependencies:
   config:
-    - field.storage.node.field_keywords
+    - field.storage.node.field_categories
     - node.type.page
-id: node.page.field_keywords
-field_name: field_keywords
+id: node.page.field_categories
+field_name: field_categories
 entity_type: node
 bundle: page
-label: Keywords
+label: Categories
 description: ''
 required: false
 translatable: true
@@ -16,5 +16,7 @@ default_value: {  }
 default_value_callback: ''
 settings:
   handler: 'default:taxonomy_term'
-  handler_settings: {  }
+  handler_settings:
+    target_bundles:
+      categories: categories
 field_type: entity_reference

--- a/modules/acquia_cms_page/config/install/field.field.node.page.field_tags.yml
+++ b/modules/acquia_cms_page/config/install/field.field.node.page.field_tags.yml
@@ -1,0 +1,22 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_tags
+    - node.type.page
+id: node.page.field_tags
+field_name: field_tags
+entity_type: node
+bundle: page
+label: Tags
+description: ''
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:taxonomy_term'
+  handler_settings:
+    target_bundles:
+      tags: tags
+field_type: entity_reference


### PR DESCRIPTION
Just what it says on the tin. This adds a new taxonomy vocabulary, "Categories" to be shared across all content types. And it renames the "Keywords" vocabulary to "Tags". Functionally they're identical but will serve different semantic purposes.