### PR TITLE
Fix InstallStateTest

### DIFF
--- a/tests/src/Functional/InstallStateTest.php
+++ b/tests/src/Functional/InstallStateTest.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace Drupal\Tests\acquia_cms\ExistingSite;
+namespace Drupal\Tests\acquia_cms\Functional;
 
+use Drupal\taxonomy\Entity\Vocabulary;
 use Drupal\Tests\BrowserTestBase;
-use Drupal\user\Entity\User;
 
 /**
  * Tests config values that are set at install.
@@ -18,18 +18,43 @@ class InstallStateTest extends BrowserTestBase {
   protected $profile = 'acquia_cms';
 
   /**
+   * Disable strict config schema checks.
+   *
+   * Cohesion has several minor flaws in their config schema, and until the
+   * following issues are fixed upstream, this test cannot do strict config
+   * schema checks:
+   *
+   * - cohesion_settings.image_browser has no schema.
+   * - field.storage_settings.cohesion_entity_reference_revisions has no schema.
+   * - The cohesion_template:custom property has 'bool' as its type, but it
+   *   be 'boolean'.
+   * - The cohesion_templates.cohesion_content_templates.*:default property has
+   *   'bool' as its type, but it should be 'boolean'.
+   *
+   * @var bool
+   */
+  protected $strictConfigSchema = FALSE;
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp() {
+    // At the moment, this test does not work if Cohesion will be installed due
+    // to a bizarre permissions issue when drupal_valid_test_ua() tries to
+    // create a .htkey file in the test site's files directory. To disable
+    // Cohesion in a non-interactive installation, we need to ensure that the
+    // COHESION_API_KEY and COHESION_ORG_KEY environment variables are not set.
+    putenv('COHESION_API_KEY');
+    putenv('COHESION_ORG_KEY');
+    parent::setUp();
+  }
+
+  /**
    * Assert that all install tasks have done what they should do.
    *
    * See acquia_cms_install_tasks().
    */
   public function testConfig() {
-    // Check that the admin role has been created, and that user 1
-    // is set as an admin.
-    $account = User::load(1);
-    $this->assertInstanceOf(User::class, $account);
-    /** @var \Drupal\user\UserInterface $account */
-    $this->assertTrue($account->hasRole('administrator'));
-
     // Check that the default and admin themes are set as expected.
     $theme_config = $this->config('system.theme');
     $this->assertSame('cohesion_theme', $theme_config->get('default'));
@@ -38,34 +63,31 @@ class InstallStateTest extends BrowserTestBase {
     // Check that the node create form is using the admin theme.
     $this->assertTrue($this->config('node.settings')->get('use_admin_theme'));
 
-    // Check that the Cohesion API keys are set.
-    $api_key = getenv('COHESION_API_KEY');
-    $org_key = getenv('COHESION_ORG_KEY');
-    $this->assertNotEmpty($api_key);
-    $this->assertNotEmpty($org_key);
-    $cohesion_config = $this->config('cohesion.settings');
-    $this->assertSame($api_key, $cohesion_config->get('api_key'));
-    $this->assertSame($org_key, $cohesion_config->get('organization_key'));
+    // Check that the Categories and Tags vocabularies exist.
+    $this->assertInstanceOf(Vocabulary::class, Vocabulary::load('categories'));
+    $this->assertInstanceOf(Vocabulary::class, Vocabulary::load('tags'));
 
-    $this->doArticleContentTypeTest();
+    $this->doPageContentTypeTest();
   }
 
   /**
-   * Tests the Article content type that ships with Acquia CMS.
+   * Tests the Page content type that ships with Acquia CMS.
    */
-  private function doArticleContentTypeTest() {
+  private function doPageContentTypeTest() {
     $assert_session = $this->assertSession();
     $this->drupalLogin($this->rootUser);
 
     $node = $this->createNode([
-      'type' => 'article',
-      'title' => 'Article Test Title',
+      'type' => 'page',
+      'title' => 'Page Test Title',
       'moderation_state' => 'published',
     ]);
+    $this->assertTrue($node->hasField('field_categories'));
+    $this->assertTrue($node->hasField('field_tags'));
     $this->drupalGet($node->toUrl());
-    // Test that pathauto is working as expected.
+    // Test that Pathauto is working as expected.
     $assert_session->statusCodeEquals(200);
-    $assert_session->addressEquals('/article/article-test-title');
+    $assert_session->addressEquals('/page-test-title');
   }
 
 }


### PR DESCRIPTION
Right now in HEAD, InstallStateTest doesn't pass. This was due to how weird the installer was, and Cohesion itself not really being super compatible with an isolated PHPUnit functional test. Now that it's possible to control Cohesion's presence by means of environment variables, this PR makes InstallStateTest pass correctly and narrows its scope -- it tests that Acquia CMS, installed without importing Cohesion data, sets up its configuration as expected.