### PR TITLE
Add a Composer post-install script to prepare for local development

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -107,6 +107,12 @@
     "minimum-stability": "dev",
     "prefer-stable": true,
     "scripts": {
-        "nuke": "rm -r -f docroot vendor"
+        "nuke": "rm -r -f docroot vendor",
+        "post-install-cmd": [
+            "mkdir -p ./docroot/profiles/acquia_cms",
+            "@composer archive --file acquia_cms",
+            "tar -x -f acquia_cms.tar -C ./docroot/profiles/acquia_cms",
+            "rm acquia_cms.tar"
+        ]
     }
 }


### PR DESCRIPTION
In order to work on Acquia CMS in a Remote IDE environment, we'll need to ensure that the docroot contains the acquia_cms profile. Lightning already has a system for this; we'll adopt that by having the profile automatically copied into the docroot after Composer completes its install process.