### PR TITLE
Put all sub-modules into "Acquia CMS" package

### DIFF
--- a/modules/acquia_cms_article/acquia_cms_article.info.yml
+++ b/modules/acquia_cms_article/acquia_cms_article.info.yml
@@ -1,4 +1,5 @@
-name: "Acquia CMS Article"
+name: "Article"
+package: "Acquia CMS"
 description: "Provides an Article content type and related configuration."
 type: module
 core_version_requirement: ^8.9

--- a/modules/acquia_cms_common/acquia_cms_common.info.yml
+++ b/modules/acquia_cms_common/acquia_cms_common.info.yml
@@ -1,4 +1,5 @@
-name: "Acquia CMS Common"
+name: "Common Functionality"
+package: "Acquia CMS"
 description: "Handles shared functionality for Acquia CMS."
 type: module
 core_version_requirement: ^8.9

--- a/modules/acquia_cms_event/acquia_cms_event.info.yml
+++ b/modules/acquia_cms_event/acquia_cms_event.info.yml
@@ -1,4 +1,5 @@
-name: "Acquia CMS Event"
+name: "Event"
+package: "Acquia CMS"
 description: "Provides an Event content type and related configuration."
 type: module
 core_version_requirement: ^8.9

--- a/modules/acquia_cms_person/acquia_cms_person.info.yml
+++ b/modules/acquia_cms_person/acquia_cms_person.info.yml
@@ -1,4 +1,5 @@
-name: "Acquia CMS Person"
+name: "Person"
+package: "Acquia CMS"
 description: "Provides a Person content type, a structured data representation of people associated with a website or organization."
 type: module
 core_version_requirement: ^8.9

--- a/modules/acquia_cms_place/acquia_cms_place.info.yml
+++ b/modules/acquia_cms_place/acquia_cms_place.info.yml
@@ -1,4 +1,5 @@
-name: "Acquia CMS Place"
+name: "Place"
+package: "Acquia CMS"
 description: "Provides a Place content type and related configuration."
 type: module
 core_version_requirement: ^8.9


### PR DESCRIPTION
Right now, the content type modules of Acquia CMS all have names prefixed with "Acquia CMS" and are (by default) in the "Other" group on the /admin/modules page. This is kinda sloppy -- let's remove the prefixing and put them in a single "Acquia CMS" group, where they can easily be found.