### PR TITLE
ACMS-16: Expand test coverage of Page content type settings

### DIFF
--- a/modules/acquia_cms_common/config/install/user.role.content_author.yml
+++ b/modules/acquia_cms_common/config/install/user.role.content_author.yml
@@ -7,5 +7,6 @@ label: 'Content Author'
 weight: 3
 is_admin: null
 permissions:
+  - 'administer menu'
   - 'use editorial transition create_new_draft'
   - 'view own unpublished content'


### PR DESCRIPTION
We currently have no test coverage of things like the Page content type's preview and menu configuration. Let's add some.