### PR TITLE
Add a trait for testing standard functionality of all content models

### DIFF
--- a/modules/acquia_cms_common/tests/src/Functional/ContentTypeTestBase.php
+++ b/modules/acquia_cms_common/tests/src/Functional/ContentTypeTestBase.php
@@ -4,12 +4,15 @@ namespace Drupal\Tests\acquia_cms_common\Functional;
 
 use Drupal\node\Entity\Node;
 use Drupal\node\Entity\NodeType;
+use Drupal\Tests\acquia_cms_common\Traits\ContentModelTestTrait;
 use Drupal\Tests\BrowserTestBase;
 
 /**
  * Base class for testing generic functionality of a specific content type.
  */
 abstract class ContentTypeTestBase extends BrowserTestBase {
+
+  use ContentModelTestTrait;
 
   /**
    * The machine name of the content type under test.

--- a/modules/acquia_cms_common/tests/src/Traits/ContentModelTestTrait.php
+++ b/modules/acquia_cms_common/tests/src/Traits/ContentModelTestTrait.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Drupal\Tests\acquia_cms_common\Traits;
+
+/**
+ * Provides helper methods for testing Acquia CMS content models.
+ */
+trait ContentModelTestTrait {
+
+  /**
+   * Asserts that the Categories and Tags fields are visible.
+   *
+   * We expect that:
+   * - Categories will be a select list, and every term in that vocabulary will
+   *   be in it.
+   * - Tags should be an auto-completing text field.
+   * - Both fields should be in a Taxonomy group.
+   */
+  protected function assertCategoriesAndTagsFieldsExist() {
+    $assert_session = $this->assertSession();
+
+    $group = $assert_session->elementExists('css', '#edit-group-taxonomy');
+    $tags_field = $assert_session->fieldExists('Tags', $group);
+    $this->assertTrue($tags_field->hasAttribute('data-autocomplete-path'));
+    $assert_session->selectExists('Categories', $group);
+
+    $categories = $this->container->get('entity_type.manager')
+      ->getStorage('taxonomy_term')
+      ->loadByProperties([
+        'vid' => 'categories',
+      ]);
+
+    /** @var \Drupal\taxonomy\TermInterface $category */
+    foreach ($categories as $category) {
+      $assert_session->optionExists('Categories', $category->label(), $group);
+    }
+  }
+
+}

--- a/modules/acquia_cms_page/tests/src/Functional/PageTest.php
+++ b/modules/acquia_cms_page/tests/src/Functional/PageTest.php
@@ -78,13 +78,8 @@ class PageTest extends ContentTypeTestBase {
     $assert_session->fieldExists('Search Description');
     // The search description should not have a summary.
     $assert_session->fieldNotExists('Summary');
-    // There should be a group for the categories and tags fields, and it should
-    // contain an auto-completing text field to store tags, and a select list
-    // for choosing categories.
-    $taxonomy = $assert_session->elementExists('css', '#edit-group-taxonomy');
-    $tags_field = $assert_session->fieldExists('Tags', $taxonomy);
-    $this->assertTrue($tags_field->hasAttribute('data-autocomplete-path'));
-    $assert_session->optionExists('Categories', 'Rock', $taxonomy);
+    // The standard Categories and Tags fields should be present.
+    $this->assertCategoriesAndTagsFieldsExist();
     // There should be a field to add an image, and it should be using the
     // media library.
     $assert_session->elementExists('css', '#field_page_image-media-library-wrapper');


### PR DESCRIPTION
All the content models in Acquia CMS share certain characteristics (the Categories and Tags, for example). To make these aspects easier to test in a uniform way, let's add a trait for our PHPUnit tests to assert the presence and functionality of these standard features.