### PR TITLE
ACMS-38: Add a stub module for the Document media type

### DIFF
--- a/modules/acquia_cms_document/acquia_cms_document.info.yml
+++ b/modules/acquia_cms_document/acquia_cms_document.info.yml
@@ -1,0 +1,7 @@
+name: "Document"
+package: "Acquia CMS"
+description: "Provides a Document media type and related configuration."
+type: module
+core_version_requirement: ^8.9
+dependencies:
+  - drupal:media

--- a/modules/acquia_cms_document/composer.json
+++ b/modules/acquia_cms_document/composer.json
@@ -1,0 +1,5 @@
+{
+    "name": "drupal/acquia_cms_document",
+    "type": "drupal-module",
+    "description": "Provides a Document media type and related configuration."
+}


### PR DESCRIPTION
This just sets up a place for us to implement ACMS-38 later.