### PR TITLE
ACMS-39: Add a stub module for the Audio media type

### DIFF
--- a/modules/acquia_cms_audio/acquia_cms_audio.info.yml
+++ b/modules/acquia_cms_audio/acquia_cms_audio.info.yml
@@ -1,0 +1,7 @@
+name: "Audio"
+package: "Acquia CMS"
+description: "Provides an Audio media type and related configuration."
+type: module
+core_version_requirement: ^8.9
+dependencies:
+  - drupal:media

--- a/modules/acquia_cms_audio/composer.json
+++ b/modules/acquia_cms_audio/composer.json
@@ -1,0 +1,5 @@
+{
+    "name": "drupal/acquia_cms_audio",
+    "type": "drupal-module",
+    "description": "Provides an Audio media type and related configuration."
+}


### PR DESCRIPTION
Sets up a place for us to implement ACMS-39 later.