### PR TITLE
ACMS-36: Add base test coverage of embedding media

### DIFF
--- a/modules/acquia_cms_common/tests/src/FunctionalJavascript/CkeditorConfigurationTest.php
+++ b/modules/acquia_cms_common/tests/src/FunctionalJavascript/CkeditorConfigurationTest.php
@@ -3,16 +3,18 @@
 namespace Drupal\Tests\acquia_cms_common\FunctionalJavascript;
 
 use Drupal\FunctionalJavascriptTests\WebDriverTestBase;
+use Drupal\Tests\ckeditor\Traits\CKEditorTestTrait;
 use Drupal\Tests\media\Traits\MediaTypeCreationTrait;
 
 /**
  * Tests the CKEditor configuration shipped with Acquia CMS.
  *
- * @todo Add this to the acquia_cms group when Acquia Cloud IDEs support running
- *   functional JavaScript tests.
+ * @todo Add this to the acquia_cms and acquia_cms_common groups when Acquia
+ *   Cloud IDEs support running functional JavaScript tests.
  */
 class CkeditorConfigurationTest extends WebDriverTestBase {
 
+  use CKEditorTestTrait;
   use MediaTypeCreationTrait;
 
   /**
@@ -79,16 +81,12 @@ class CkeditorConfigurationTest extends WebDriverTestBase {
     $formats = $session->evaluateScript('Object.keys(drupalSettings.editor.formats)');
     $this->assertSame(['filtered_html'], $formats);
 
-    // Wait for CKEditor to initialize so we can inspect its commands.
-    $commands = 'CKEDITOR.instances["edit-body-0-value"].commands';
-    $this->assertJsCondition("typeof $commands === 'object'");
-
-    // Ensure that all the expected commands are loaded.
-    $this->assertJsCondition("'drupalmedialibrary' in $commands");
-    $this->assertJsCondition("'justifyleft' in $commands");
-    $this->assertJsCondition("'justifycenter' in $commands");
-    $this->assertJsCondition("'justifyright' in $commands");
-    $this->assertJsCondition("'justifyblock' in $commands");
+    $this->waitForEditor();
+    $this->getEditorButton('justifyleft');
+    $this->getEditorButton('justifycenter');
+    $this->getEditorButton('justifyright');
+    $this->getEditorButton('justifyblock');
+    $this->getEditorButton('drupalmedialibrary');
   }
 
 }

--- a/modules/acquia_cms_common/tests/src/FunctionalJavascript/MediaEmbedTestBase.php
+++ b/modules/acquia_cms_common/tests/src/FunctionalJavascript/MediaEmbedTestBase.php
@@ -1,0 +1,117 @@
+<?php
+
+namespace Drupal\Tests\acquia_cms_common\FunctionalJavascript;
+
+use Drupal\FunctionalJavascriptTests\WebDriverTestBase;
+use Drupal\media\Entity\MediaType;
+use Drupal\Tests\acquia_cms_common\Traits\MediaTestTrait;
+use Drupal\Tests\ckeditor\Traits\CKEditorTestTrait;
+
+/**
+ * Base class for testing CKEditor embeds of a specific media type.
+ */
+abstract class MediaEmbedTestBase extends WebDriverTestBase {
+
+  use CKEditorTestTrait;
+  use MediaTestTrait;
+
+  /**
+   * The machine name of the media type under test.
+   *
+   * This should be overridden by subclasses.
+   *
+   * @var string
+   */
+  protected $mediaType;
+
+  /**
+   * {@inheritdoc}
+   */
+  protected static $modules = [
+    'media_library',
+  ];
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp() {
+    // Ensure that the media type under test has been specified by a subclass.
+    $this->assertNotEmpty($this->mediaType);
+
+    // Do normal set-up and ensure that the media type actually exists.
+    parent::setUp();
+    $media_type = MediaType::load($this->mediaType);
+    $this->assertInstanceOf(MediaType::class, $media_type);
+
+    // Create a media item of the type under test.
+    $this->createMedia([
+      'bundle' => $media_type->id(),
+    ]);
+  }
+
+  /**
+   * Tests embedding media in CKEditor.
+   */
+  public function testEmbedMedia() {
+    $node_type = $this->drupalCreateContentType()->id();
+    user_role_grant_permissions('content_author', [
+      "create $node_type content",
+    ]);
+
+    $account = $this->drupalCreateUser();
+    $account->addRole('content_author');
+    $account->save();
+    $this->drupalLogin($account);
+
+    $this->drupalGet("/node/add/$node_type");
+    $this->openMediaLibrary();
+    $this->selectMedia(0);
+    $this->insertSelectedMedia();
+    $this->assertMediaIsEmbedded();
+  }
+
+  /**
+   * Asserts that an embedded media item is visible in CKEditor.
+   */
+  protected function assertMediaIsEmbedded() {
+    $this->assignNameToCkeditorIframe();
+    $this->getSession()->switchToIFrame('ckeditor');
+
+    $result = $this->assertSession()->waitForElementVisible('css', 'drupal-media');
+    $this->assertNotEmpty($result);
+  }
+
+  /**
+   * Inserts all selected media into CKEditor and closes the media library.
+   */
+  protected function insertSelectedMedia() {
+    $this->assertSession()
+      ->elementExists('css', '.ui-dialog-buttonpane')
+      ->pressButton('Insert selected');
+  }
+
+  /**
+   * Selects a media item in the media library.
+   *
+   * @param int $position
+   *   The zero-based index of the media item to select.
+   */
+  protected function selectMedia(int $position) {
+    $checkbox = $this->assertSession()
+      ->waitForElementVisible('named', ['field', "media_library_select_form[$position]"]);
+    $this->assertNotEmpty($checkbox);
+    $checkbox->check();
+  }
+
+  /**
+   * Opens the media library in CKEditor.
+   */
+  protected function openMediaLibrary() {
+    $this->waitForEditor();
+    $this->pressEditorButton('drupalmedialibrary');
+
+    $result = $this->assertSession()->waitForText('Add or select media');
+    $this->assertNotEmpty($result);
+  }
+
+}

--- a/modules/acquia_cms_common/tests/src/Traits/MediaTestTrait.php
+++ b/modules/acquia_cms_common/tests/src/Traits/MediaTestTrait.php
@@ -1,0 +1,89 @@
+<?php
+
+namespace Drupal\Tests\acquia_cms_common\Traits;
+
+use Drupal\media\Entity\Media;
+use Drupal\media\MediaInterface;
+use Drupal\media\MediaTypeInterface;
+
+/**
+ * Provides helper methods for tests which work with media items.
+ */
+trait MediaTestTrait {
+
+  /**
+   * Creates a media entity.
+   *
+   * @param array $values
+   *   (optional) Values to create the media entity with. If no value is
+   *   provided for the media entity's source field, a randomly generated one
+   *   will be used.
+   *
+   * @return \Drupal\media\MediaInterface
+   *   The new, saved media item.
+   */
+  protected function createMedia(array $values = []) : MediaInterface {
+    $media = Media::create($values);
+    $media_type = $media->bundle->entity;
+
+    $source_field = $media->getSource()
+      ->getSourceFieldDefinition($media_type)
+      ->getName();
+
+    if ($media->get($source_field)->isEmpty()) {
+      $media->set($source_field, $this->generateSourceFieldValue($media_type, FALSE));
+    }
+    $media->save();
+
+    return $media;
+  }
+
+  /**
+   * Generates a random source field value for a media type.
+   *
+   * @param \Drupal\media\MediaTypeInterface $media_type
+   *   The media type.
+   * @param bool $normalize
+   *   (optional) Whether to return only the normalized value, i.e., the value
+   *   of the main property. Defaults to TRUE.
+   *
+   * @return mixed
+   *   The randomly generated field value. If $normalize is TRUE, only the
+   *   "main" value will be returned; for example, the image file referenced by
+   *   the source field. Otherwise, the entire value and all of its properties
+   *   will be returned as an array.
+   */
+  protected function generateSourceFieldValue(MediaTypeInterface $media_type, bool $normalize = TRUE) {
+    $field_definition = $media_type->getSource()
+      ->getSourceFieldDefinition($media_type);
+
+    $generator = [
+      $field_definition->getItemDefinition()->getClass(),
+      'generateSampleValue',
+    ];
+    $value = $generator($field_definition);
+    $this->assertInternalType('array', $value);
+    $this->assertNotEmpty($value);
+
+    if ($normalize) {
+      $storage_definition = $field_definition->getFieldStorageDefinition();
+
+      $property = $storage_definition->getMainPropertyName();
+      $this->assertNotEmpty($property);
+      $this->assertArrayHasKey($property, $value);
+
+      if ($property === 'target_id') {
+        return $this->container->get('entity_type.manager')
+          ->getStorage($storage_definition->getSetting('target_type'))
+          ->load($value[$property]);
+      }
+      else {
+        return $value[$property];
+      }
+    }
+    else {
+      return $value;
+    }
+  }
+
+}

--- a/modules/acquia_cms_image/tests/src/FunctionalJavascript/ImageEmbedTest.php
+++ b/modules/acquia_cms_image/tests/src/FunctionalJavascript/ImageEmbedTest.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Drupal\Tests\acquia_cms_image\Functional;
+
+use Drupal\Tests\acquia_cms_common\FunctionalJavascript\MediaEmbedTestBase;
+
+/**
+ * Tests embedding Image media in CKEditor.
+ *
+ * @todo Add this to the acquia_cms and acquia_cms_image groups when Acquia
+ *   Cloud IDEs support running functional JavaScript tests.
+ */
+class ImageEmbedTest extends MediaEmbedTestBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected static $modules = ['acquia_cms_image'];
+
+  /**
+   * Disable strict config schema checks in this test.
+   *
+   * Cohesion has a lot of config schema errors, and until they are all fixed,
+   * this test cannot pass unless we disable strict config schema checking
+   * altogether. Since strict config schema isn't critically important in
+   * testing this functionality, it's okay to disable it for now, but it should
+   * be re-enabled (i.e., this property should be removed) as soon as possible.
+   *
+   * @var bool
+   */
+  // @codingStandardsIgnoreStart
+  protected $strictConfigSchema = FALSE;
+  // @codingStandardsIgnoreEnd
+
+  /**
+   * {@inheritdoc}
+   */
+  protected $mediaType = 'image';
+
+}


### PR DESCRIPTION
We need to test that media can be embedded in CKEditor. This requires JavaScript tests, which can be complex to write. To facilitate getting this done quickly, let's add a base test class, and an example implementation, for this.