### PR TITLE
ACMS-000: Set version constraint for memcache settings

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
         "acquia/cohesion": "6.1.2",
         "acquia/cohesion-theme": "6.1.2",
         "acquia/drupal-environment-detector": "^1",
-        "acquia/memcache-settings": "dev-master",
+        "acquia/memcache-settings": "^1",
         "cweagans/composer-patches": "^1.6",
         "drupal/acquia_connector": "^2",
         "drupal/acquia_purge": "^1",


### PR DESCRIPTION
Related to #103, setting a minimum version constraint for the acquia/memcache-settings package now that it has a release.