### PR TITLE
ACMS-53: As a content administrator I want tags and categories exposed on admin dashboards so I can easily filter my content

### DIFF
--- a/config/optional/views.view.content.yml
+++ b/config/optional/views.view.content.yml
@@ -589,7 +589,7 @@ display:
             default_group_multiple: {  }
             group_items: {  }
           reduce_duplicates: false
-          type: textfield
+          type: select
           limit: true
           vid: categories
           hierarchy: false

--- a/config/optional/views.view.media.yml
+++ b/config/optional/views.view.media.yml
@@ -878,7 +878,7 @@ display:
             default_group_multiple: {  }
             group_items: {  }
           reduce_duplicates: false
-          type: textfield
+          type: select
           limit: true
           vid: categories
           hierarchy: false


### PR DESCRIPTION
Ticket: https://backlog.acquia.com/browse/ACMS-53

As a content administrator I want tags and categories exposed on admin dashboards so I can easily filter my content
