### PR TITLE
ACMS-73: Integrate Google Analytics and Tag Manager

### DIFF
--- a/acquia_cms.info.yml
+++ b/acquia_cms.info.yml
@@ -23,6 +23,8 @@ install:
   - default_content
   - dblog
   - environment_indicator
+  - google_analytics
+  - google_tag
   - history
   - menu_ui
   - options

--- a/modules/acquia_cms_tour/src/Controller/TourController.php
+++ b/modules/acquia_cms_tour/src/Controller/TourController.php
@@ -3,6 +3,10 @@
 namespace Drupal\acquia_cms_tour\Controller;
 
 use Drupal\Core\Controller\ControllerBase;
+use Drupal\Core\Link;
+use Drupal\Core\Url;
+use Drupal\google_tag\Entity\ContainerManager;
+use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
  * Defines a route controller providing a simple tour of Acquia CMS.
@@ -10,12 +14,124 @@ use Drupal\Core\Controller\ControllerBase;
 final class TourController extends ControllerBase {
 
   /**
+   * The Google tag container manager.
+   *
+   * @var \Drupal\google_tag\Entity\ContainerManager
+   */
+  protected $googleTagContainerManager;
+
+  /**
+   * Class constructor.
+   */
+  public function __construct(ContainerManager $conainer_manager) {
+    $this->googleTagContainerManager = $conainer_manager;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container) {
+    return new static(
+      $container->get('google_tag.container_manager')
+    );
+  }
+
+  /**
    * Returns a renderable array for a tour page.
    */
   public function tour() {
-    return [
-      '#markup' => $this->t('Hello World!'),
-    ];
+    $tour = [];
+    $tour['google_analytics'] = $this->buildGoogleAnalyticsSection();
+    $tour['google_tag_manager'] = $this->buildGoogleTagManagerSection();
+    return $tour;
+  }
+
+  /**
+   * Add link to the google analytics configuration page.
+   */
+  protected function buildGoogleAnalyticsSection() {
+    $link = [];
+    if ($this->moduleHandler()->moduleExists('google_analytics')) {
+      $ga_account = $this->config('google_analytics.settings')->get('account');
+      $user_has_ga_permission = $this->currentUser()->hasPermission('administer google analytics');
+      $message = $this->t('Google Analytics is enabled');
+      if ($user_has_ga_permission) {
+        $link['details'] = [
+          '#type' => 'details',
+          '#open' => $ga_account ? FALSE : TRUE,
+          '#title' => $this->t('Google Analytics'),
+        ];
+        $link['details']['link'] = [
+          '#title' => $this->t('Google Analytics'),
+          '#type' => 'link',
+          '#url' => Url::fromRoute('google_analytics.admin_settings_form'),
+        ];
+        $message = $this->t('Google Analytics is enabled. @link', [
+          '@link' => Link::createFromRoute('Please configure the API key.', 'google_analytics.admin_settings_form')->toString(),
+        ]);
+      }
+      if ($ga_account) {
+        $this->messenger()->addStatus($this->t('Google Analytics is enabled and configured.'));
+      }
+      else {
+        $this->messenger()->addWarning($message);
+      }
+    }
+    else {
+      $user_has_module_permission = $this->currentUser()->hasPermission('administer modules');
+      $message = $this->t('Google Analytics is disabled');
+      if ($user_has_module_permission) {
+        $message = $this->t('Google Analytics is disabled. @link.', [
+          '@link' => Link::createFromRoute('Visit the Modules page to enable it', 'system.modules_list')->toString(),
+        ]);
+      }
+      $this->messenger()->addWarning($message);
+    }
+    return $link;
+  }
+
+  /**
+   * Add link to the google tag manager configuation page.
+   */
+  protected function buildGoogleTagManagerSection() {
+    $link = [];
+    if ($this->moduleHandler->moduleExists('google_tag')) {
+      $gtm_container_id = $this->googleTagContainerManager->loadContainerIDs();
+      $user_has_gtm_permission = $this->currentUser()->hasPermission('administer google tag manager');
+      $message = $this->t('Google Tag Manager is enabled');
+      if ($user_has_gtm_permission) {
+        $message = $this->t('Google Tag Manager is enabled. @link', [
+          '@link' => Link::createFromRoute('Please configure the API key.', 'entity.google_tag_container.collection')->toString(),
+        ]);
+        $link['details'] = [
+          '#type' => 'details',
+          '#open' => empty($gtm_container_id) ? TRUE : FALSE,
+          '#title' => $this->t('Google Tag Manager'),
+        ];
+        $link['details']['link'] = [
+          '#title' => $this->t('Google Tag Manager'),
+          '#type' => 'link',
+          '#url' => Url::fromRoute('entity.google_tag_container.collection'),
+        ];
+      }
+      if (!empty($gtm_container_id)) {
+        $this->messenger()->addStatus($this->t('Google Tag Manager is enabled and configured.'));
+      }
+      else {
+        $this->messenger()->addWarning($message);
+      }
+    }
+    else {
+      $user_has_module_permission = $this->currentUser()->hasPermission('administer modules');
+      $message = $this->t('Google Tag Manager is disabled');
+      if ($user_has_module_permission) {
+        $message = $this->t('Google Tag Manager is disabled. @link.', [
+          '@link' => Link::createFromRoute('Visit the Modules page to enable it', 'system.modules_list')->toString(),
+        ]);
+      }
+      $this->messenger()->addWarning($message);
+    }
+    return $link;
   }
 
 }

--- a/modules/acquia_cms_tour/tests/src/Functional/GoogleAnalyticsAndGoogleTagManagerTest.php
+++ b/modules/acquia_cms_tour/tests/src/Functional/GoogleAnalyticsAndGoogleTagManagerTest.php
@@ -1,0 +1,122 @@
+<?php
+
+namespace Drupal\Tests\acquia_cms_tour\Functional;
+
+use Drupal\Tests\BrowserTestBase;
+
+/**
+ * Tests tour page permissions for the user roles included with Acquia CMS.
+ *
+ * @group acquia_cms_tour
+ * @group acquia_cms
+ */
+class GoogleAnalyticsAndGoogleTagManagerTest extends BrowserTestBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected $defaultTheme = 'stark';
+
+  /**
+   * {@inheritdoc}
+   */
+  protected static $modules = [
+    'acquia_cms_tour',
+    'google_analytics',
+    'google_tag',
+    'toolbar',
+  ];
+
+  /**
+   * Disable strict config schema checks in this test.
+   *
+   * Cohesion has a lot of config schema errors, and until they are all fixed,
+   * this test cannot pass unless we disable strict config schema checking
+   * altogether. Since strict config schema isn't critically important in
+   * testing this functionality, it's okay to disable it for now, but it should
+   * be re-enabled (i.e., this property should be removed) as soon as possible.
+   *
+   * @var bool
+   */
+  // @codingStandardsIgnoreStart
+  protected $strictConfigSchema = FALSE;
+  // @codingStandardsIgnoreEnd
+
+  /**
+   * Tests Google Analytics & Google Tag Manager integration.
+   */
+  public function testGoogleAnalyticsAndTagManagerIntegration() {
+    $session = $this->getSession();
+    $page = $session->getPage();
+    $assert_session = $this->assertSession();
+
+    $account = $this->drupalCreateUser([
+      'access acquia cms tour',
+      'administer google analytics',
+      'administer google tag manager',
+      'access toolbar',
+    ]);
+    $this->drupalLogin($account);
+
+    // Visit the tour page.
+    $this->drupalGet('/admin/tour');
+    $assert_session->statusCodeEquals(200);
+
+    // Assert that a link to the Google Analytics configuration page appears.
+    $assert_session->linkExists('Google Analytics');
+
+    // Assert that a status message appears warning the user that the API key
+    // is not set for both GA & GTM.
+    $assert_session->pageTextContains('Google Analytics is enabled. Please configure the API key.');
+    $assert_session->pageTextContains('Google Tag Manager is enabled. Please configure the API key.');
+
+    // Visit Google Analytics configuration page and set the API key.
+    $page->clickLink('Google Analytics');
+    $assert_session->statusCodeEquals(200);
+    $assert_session->fieldExists('Web Property ID');
+    $page->fillField('Web Property ID', 'UA-334567-6789078908');
+    $page->pressButton('Save configuration');
+    $assert_session->pageTextContains('The configuration options have been saved.');
+
+    // Go back to the tour.
+    $this->drupalGet('/admin/tour');
+    $assert_session->statusCodeEquals(200);
+
+    // Assert that a link to the Google Analytics configuration page appears.
+    $assert_session->linkExists('Google Analytics');
+
+    // Assert that the status warning does NOT appear for GA.
+    $assert_session->pageTextNotContains('Google Analytics is enabled. Please configure the API key here.');
+    $assert_session->pageTextContains('Google Analytics is enabled and configured.');
+
+    // Visit Google Tag Manager configuration page.
+    $page->clickLink('Google Tag Manager');
+    $assert_session->statusCodeEquals(200);
+    $assert_session->pageTextContains('There are no containers yet.');
+
+    // Add Google Tag Manager containers.
+    $this->drupalGet('/admin/config/system/google-tag/add');
+    $assert_session->statusCodeEquals(200);
+    // Assert required field exists.
+    $assert_session->fieldExists('Label');
+    $assert_session->fieldExists('Container ID');
+    $page->fillField('Label', 'Test container');
+    $page->fillField('Machine-readable name', 'test_container');
+    $page->fillField('Container ID', 'GTM-345678');
+
+    $page->pressButton('Save');
+    $assert_session->pageTextContains('Created 3 snippet files for Test container container based on configuration.');
+
+    // Go back to the tour.
+    $this->drupalGet('/admin/tour');
+    $assert_session->statusCodeEquals(200);
+
+    // Assert that a link to the Google Tag Manager configuration page appears.
+    $assert_session->linkExists('Google Tag Manager');
+
+    // Assert that the status warning does NOT appear.
+    $assert_session->pageTextNotContains('Google Tag Manager is enabled. Please configure the API key here.');
+    $assert_session->pageTextContains('Google Tag Manager is enabled and configured.');
+  }
+
+}


### PR DESCRIPTION
As a system administrator I want to provide analytics and tag support so that users of ACMS can interact with Google Analytics and Tag Manager