### PR TITLE
ACMS-231: Hide the Document media type's source field in the media library

### DIFF
--- a/modules/acquia_cms_common/tests/src/Functional/MediaTypeTestBase.php
+++ b/modules/acquia_cms_common/tests/src/Functional/MediaTypeTestBase.php
@@ -238,13 +238,10 @@ abstract class MediaTypeTestBase extends ContentModelTestBase {
    * @param string[] $expected_order
    *   The machine names of the fields we expect in media type's form display,
    *   in the order we expect them to have.
-   * @param string $form_mode
-   *   The machine name of the form mode in which fields we expect in media
-   *   type's form display, in the order we expect them to have.
    */
-  protected function assertFieldsOrder(array $expected_order, $form_mode = 'default') {
+  protected function assertFieldsOrder(array $expected_order) {
     $display = $this->container->get('entity_display.repository')
-      ->getFormDisplay('media', $this->mediaType, $form_mode);
+      ->getFormDisplay('media', $this->mediaType);
 
     $this->assertDisplayComponentsOrder($display, $expected_order, "The fields of the '$this->mediaType' media type's edit form were not in the expected order.");
   }

--- a/modules/acquia_cms_document/tests/src/Functional/DocumentTest.php
+++ b/modules/acquia_cms_document/tests/src/Functional/DocumentTest.php
@@ -16,7 +16,7 @@ class DocumentTest extends MediaTypeTestBase {
   /**
    * {@inheritdoc}
    */
-  protected static $modules = ['acquia_cms_document', 'media_library'];
+  protected static $modules = ['acquia_cms_document'];
 
   /**
    * Disable strict config schema checks in this test.
@@ -75,14 +75,6 @@ class DocumentTest extends MediaTypeTestBase {
       'field_categories',
       'field_tags',
     ]);
-
-    // Assert that the fields are in the correct order,
-    // for media_library form_mode.
-    $this->assertFieldsOrder([
-      'name',
-      'field_categories',
-      'field_tags',
-    ], 'media_library');
 
     // Submit the form and ensure that we see the expected error message(s).
     $page->pressButton('Save');


### PR DESCRIPTION
Fix/Hide 'field_media_file' from document Media:
When I am uploading document media through WYSIWYG/Media library, I can see File section there without anything in it, mark as required. Though it does not show any error while clicking on save button.