### PR TITLE
ACMS-58: Minor refactoring and touch-ups

### DIFF
--- a/modules/acquia_cms_common/config/schema/acquia_cms_common.schema.yml
+++ b/modules/acquia_cms_common/config/schema/acquia_cms_common.schema.yml
@@ -1,4 +1,4 @@
-node.type.third_party.acquia_cms:
+node.type.*.third_party.acquia_cms:
   type: mapping
   label: 'Acquia CMS settings'
   mapping:

--- a/modules/acquia_cms_search/acquia_cms_search.info.yml
+++ b/modules/acquia_cms_search/acquia_cms_search.info.yml
@@ -4,6 +4,6 @@ description: "Provides powerful search capabilities to the site"
 type: module
 core_version_requirement: ^9
 dependencies:
-  - search_api:search_api
   - drupal:node
   - drupal:views
+  - search_api:search_api

--- a/modules/acquia_cms_search/acquia_cms_search.install
+++ b/modules/acquia_cms_search/acquia_cms_search.install
@@ -11,11 +11,8 @@ use Drupal\node\Entity\NodeType;
  * Implements hook_install().
  */
 function acquia_cms_search_install() {
-  // Invoking ENTITY_TYPE_insert hook implemented in acquia_cms_search
-  // as it's not getting invoked because the module that creates node types
-  // are already getting installed before this search module is getting
-  // enabled.
-  /** @var \Drupal\node\NodeTypeInterface $node_types */
+  // Retroactively enable indexing for any content types that existed before
+  // this module was installed.
   $node_types = NodeType::loadMultiple();
   array_walk($node_types, 'acquia_cms_search_node_type_insert');
 }

--- a/modules/acquia_cms_search/acquia_cms_search.module
+++ b/modules/acquia_cms_search/acquia_cms_search.module
@@ -8,25 +8,24 @@
 use Drupal\acquia_cms_search\Facade\SearchFacade;
 use Drupal\Core\DestructableInterface;
 use Drupal\node\NodeTypeInterface;
+use Drupal\search_api\Entity\Index;
 use Drupal\search_api\ServerInterface;
 
 /**
  * Implements hook_ENTITY_TYPE_insert() for node types.
  */
 function acquia_cms_search_node_type_insert(NodeTypeInterface $node_type) {
-  // Avoid during config sync.
-  if (!Drupal::isConfigSyncing()) {
-    Drupal::classResolver(SearchFacade::class)->addNodeType($node_type);
-  }
+  Drupal::classResolver(SearchFacade::class)->addNodeType($node_type);
 }
 
 /**
  * Implements hook_entity_insert().
  */
 function acquia_cms_search_entity_insert() {
-  // Indexing the node just after the creation. As the nodes created
-  // programmatically are not getting indexed ( Specially in PHPUnit ), so
-  // using this service to destruct and do a indexing of the newly created node.
+  // Normally, content is indexed immediately after it is created or modified,
+  // at the end of the current request. But that means content created
+  // programmatically (i.e., in the PHPUnit tests) are not being indexed. So,
+  // explicitly invoke the indexer whenever an entity is created.
   $indexer = Drupal::service('search_api.post_request_indexing');
   if ($indexer instanceof DestructableInterface) {
     $indexer->destruct();
@@ -34,21 +33,32 @@ function acquia_cms_search_entity_insert() {
 }
 
 /**
- * Implements hook_ENTITY_TYPE_insert() for Search API server.
+ * Implements hook_ENTITY_TYPE_insert() for Search API servers.
  */
 function acquia_cms_search_search_api_server_insert(ServerInterface $server) {
-  // Looking into all the indexs that are there.
-  $index_storage = \Drupal::entityTypeManager()->getStorage('search_api_index');
-  $indexes = $index_storage->loadMultiple();
+  // We don't want to do any secondary config writes during a config sync,
+  // since that can have major, unintentional side effects.
+  if (Drupal::isConfigSyncing()) {
+    return;
+  }
+
+  // Look for an index which is disabled, but wants to passively opt into using
+  // this server.
+  $indexes = Index::loadMultiple();
+  /** @var \Drupal\search_api\IndexInterface $index */
   foreach ($indexes as $index) {
-    if (is_object($index)) {
-      $server_name = $index->getThirdPartySetting('acquia_cms', 'server', []);
-      if (!$index->status() && !$index->isServerEnabled() && ($server->id() == $server_name)) {
-        $index->setServer($server)->enable();
-        // Removing server third-party setting.
-        $index->unsetThirdPartySetting('acquia_cms', 'server');
-        $index->save();
-      }
+    if ($index->status() || $index->isServerEnabled()) {
+      continue;
+    }
+
+    // If the index wants to opt into using this server, grant its wish.
+    $server_name = $index->getThirdPartySetting('acquia_cms', 'search_server');
+    if ($server_name && $server->id() === $server_name) {
+      $index->setServer($server)
+        ->enable()
+        // The third-party setting is only needed once.
+        ->unsetThirdPartySetting('acquia_cms', 'search_server')
+        ->save();
     }
   }
 }
@@ -56,10 +66,12 @@ function acquia_cms_search_search_api_server_insert(ServerInterface $server) {
 /**
  * Implements hook_config_schema_info_alter().
  */
-function acquia_cms_search_config_schema_info_alter(&$definitions) {
-  // Appending search index schema into existing schema of the acquia_cms_common
-  // module.
-  $definitions['node.type.third_party.acquia_cms']['mapping']['search_index'] = [
+function acquia_cms_search_config_schema_info_alter(array &$definitions) {
+  // Allow node types to carry a 'search_index' setting. This is used by our
+  // facade to passively opt the node type into a particular index.
+  // @see acquia_cms_search_node_type_insert()
+  // @see \Drupal\acquia_cms_search\Facade\SearchFacade::addNodeType()
+  $definitions['node.type.*.third_party.acquia_cms']['mapping']['search_index'] = [
     'type' => 'string',
     'label' => 'The machine name of the search index to which this content type should be added',
   ];

--- a/modules/acquia_cms_search/config/install/search_api.index.content.yml
+++ b/modules/acquia_cms_search/config/install/search_api.index.content.yml
@@ -8,7 +8,7 @@ dependencies:
     - core.entity_view_mode.node.search_index
 third_party_settings:
   acquia_cms:
-    server: database
+    search_server: database
 id: content
 name: Content
 description: 'An index of all content in your site.'

--- a/modules/acquia_cms_search/config/schema/acquia_cms_search.schema.yml
+++ b/modules/acquia_cms_search/config/schema/acquia_cms_search.schema.yml
@@ -1,8 +1,8 @@
-index.server.third_party.acquia_cms:
+search_api.index.*.third_party.acquia_cms:
   type: mapping
   label: 'Acquia CMS settings'
   mapping:
-    # See acquia_cms_search_search_api_server_insert()
-    server:
+    # @see acquia_cms_search_search_api_server_insert()
+    search_server:
       type: string
       label: 'Machine name of Search API server to which the index will be attached'

--- a/modules/acquia_cms_search/src/Facade/SearchFacade.php
+++ b/modules/acquia_cms_search/src/Facade/SearchFacade.php
@@ -2,13 +2,15 @@
 
 namespace Drupal\acquia_cms_search\Facade;
 
+use Drupal\Core\Config\ConfigInstallerInterface;
 use Drupal\Core\DependencyInjection\ContainerInjectionInterface;
-use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\Entity\EntityStorageInterface;
 use Drupal\node\NodeTypeInterface;
+use Drupal\search_api\SearchApiException;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
- * Provides a facade for integrating with Seach API.
+ * Provides a facade for integrating with Search API.
  *
  * @internal
  *   This is a totally internal part of Acquia CMS and may be changed in any
@@ -18,73 +20,117 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
 final class SearchFacade implements ContainerInjectionInterface {
 
   /**
-   * The entityTypeManger service.
+   * The config installer service.
    *
-   * @var \Drupal\Core\Entity\EntityTypeManagerInterface
+   * @var \Drupal\Core\Config\ConfigInstallerInterface
    */
-  private $entityTypeManager;
+  private $configInstaller;
+
+  /**
+   * The search index entity storage handler.
+   *
+   * @var \Drupal\Core\Entity\EntityStorageInterface
+   */
+  private $indexStorage;
+
+  /**
+   * The view entity storage handler.
+   *
+   * @var \Drupal\Core\Entity\EntityStorageInterface
+   */
+  private $viewStorage;
 
   /**
    * SearchFacade constructor.
    *
-   * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager
-   *   The entity type manager service.
+   * @param \Drupal\Core\Config\ConfigInstallerInterface $config_installer
+   *   The config installer service.
+   * @param \Drupal\Core\Entity\EntityStorageInterface $index_storage
+   *   The search index entity storage handler.
+   * @param \Drupal\Core\Entity\EntityStorageInterface $view_storage
+   *   The view entity storage handler.
    */
-  public function __construct(EntityTypeManagerInterface $entity_type_manager) {
-    $this->entityTypeManager = $entity_type_manager;
+  public function __construct(ConfigInstallerInterface $config_installer, EntityStorageInterface $index_storage, EntityStorageInterface $view_storage) {
+    $this->configInstaller = $config_installer;
+    $this->indexStorage = $index_storage;
+    $this->viewStorage = $view_storage;
   }
 
   /**
    * {@inheritdoc}
    */
   public static function create(ContainerInterface $container) {
+    $entity_type_manager = $container->get('entity_type.manager');
+
     return new static(
-      $container->get('entity_type.manager')
+      $container->get('config.installer'),
+      $entity_type_manager->getStorage('search_api_index'),
+      $entity_type_manager->getStorage('view')
     );
   }
 
   /**
    * Acts on a newly created node type.
    *
-   * Tries to add the node_type in the list of indexed bundle, as
-   * specified by the 'acquia_cms.search_index' third-party setting.
+   * Tries to add the node type to the list of indexed bundles handled by the
+   * index specified by 'acquia_cms.search_index' third-party setting.
    *
    * @param \Drupal\node\NodeTypeInterface $node_type
    *   The new node type.
    */
   public function addNodeType(NodeTypeInterface $node_type) {
-    $search_index = $node_type->getThirdPartySetting('acquia_cms', 'search_index', []);
+    // We don't want to do any secondary config writes during a config sync,
+    // since that can have major, unintentional side effects.
+    if ($this->configInstaller->isSyncing()) {
+      return;
+    }
 
-    if (!empty($search_index)) {
-      $index_storage = $this->entityTypeManager->getStorage('search_api_index');
-      $index = $index_storage->load($search_index);
-      if (is_object($index)) {
-        // Updating bundles in the datasource.
-        $data_source = $index->getDatasource('entity:node');
-        if ($data_source) {
-          $configuration = $data_source->getConfiguration();
-          $configuration['bundles']['selected'][] = $node_type->id();
-          $data_source->setConfiguration($configuration);
-        }
-      }
-      // Adding view mode in renderer HTML field.
-      $field = $index->getField('rendered_item');
-      if ($field) {
-        $configuration = $field->getConfiguration();
-        $configuration['view_mode']['entity:node'][$node_type->id()] = 'search_index';
-        $field->setConfiguration($configuration);
-      }
-      $index_storage->save($index);
-      // Updating view modes in search view.
-      $view_storage = $this->entityTypeManager->getStorage('view');
-      $view = $view_storage->load('search');
-      if (!empty($view)) {
-        $display = &$view->getDisplay('default');
-        if ($display['display_options']['row']['type'] == 'search_api') {
-          $display['display_options']['row']['options']['view_modes']['entity:node'][$node_type->id()] = 'teaser';
-          $view_storage->save($view);
-        }
-      }
+    $index = $node_type->getThirdPartySetting('acquia_cms', 'search_index');
+    if (empty($index)) {
+      return;
+    }
+
+    /** @var \Drupal\search_api\IndexInterface $index */
+    $index = $this->indexStorage->load($index);
+    if (empty($index)) {
+      return;
+    }
+
+    try {
+      $data_source = $index->getDatasource('entity:node');
+    }
+    catch (SearchApiException $e) {
+      // If the index isn't handling nodes at all, we're in the Twilight Zone
+      // and there's nothing else for us to do.
+      return;
+    }
+    $node_type_id = $node_type->id();
+
+    // Add this node type to the data source.
+    $configuration = $data_source->getConfiguration();
+    $configuration['bundles']['selected'][] = $node_type_id;
+    $data_source->setConfiguration($configuration);
+
+    // Adding view mode in renderer HTML field.
+    $field = $index->getField('rendered_item');
+    if ($field) {
+      $configuration = $field->getConfiguration();
+      $configuration['view_mode']['entity:node'][$node_type_id] = 'search_index';
+      $field->setConfiguration($configuration);
+    }
+    $this->indexStorage->save($index);
+
+    // Update the view mode used for this node type in the Search view.
+    /** @var \Drupal\views\ViewEntityInterface $view */
+    $view = $this->viewStorage->load('search');
+    if (empty($view)) {
+      return;
+    }
+
+    $display = &$view->getDisplay('default');
+    if ($display['display_options']['row']['type'] == 'search_api') {
+      $display['display_options']['row']['options']['view_modes']['entity:node'][$node_type_id] = 'teaser';
+      $this->viewStorage->save($view);
     }
   }
 

--- a/modules/acquia_cms_search/tests/Functional/SearchTest.php
+++ b/modules/acquia_cms_search/tests/Functional/SearchTest.php
@@ -76,23 +76,24 @@ class SearchTest extends BrowserTestBase {
     $this->drupalLogin($account);
 
     $node_types = NodeType::loadMultiple();
-    // Create some published and unpublished nodes to assert search
-    // functionality properly.
+    // Create some published and unpublished nodes to assert that the search
+    // respects the published status of content.
     foreach ($node_types as $type) {
       $published_node = $this->drupalCreateNode([
         'type' => $type->id(),
         'title' => 'Test published ' . $type->label(),
         'moderation_state' => 'published',
       ]);
-      $published_node->setPublished()->save();
+      $this->assertTrue($published_node->isPublished());
+
       $unpublished_node = $this->drupalCreateNode([
         'type' => $type->id(),
         'title' => 'Test unpublished ' . $type->label(),
+        'moderation_state' => 'draft',
       ]);
-      $unpublished_node->setUnpublished()->save();
+      $this->assertFalse($unpublished_node->isPublished());
     }
 
-    // Visit the seach page.
     $this->drupalGet('/search');
     $assert_session->statusCodeEquals(200);
     $page->fillField('Keywords', 'Test');


### PR DESCRIPTION
#115 is great, but there are a few small things it missed. I fixed some config schema errors (which would have been caught by the tests, normally, but Cohesion gets in the way of that), refactored a few things for clarity, and copied the config-sync guard code into our other facades, since that was a big oversight on my part.