### PR TITLE
ACMS-207: Metatag upgraded to 1.7, patches removed.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -36,7 +36,7 @@
         "drupal/recaptcha": "^3",
         "drupal/redirect": "^1",
         "drupal/responsive_preview": "^1.0@beta",
-        "drupal/schema_metatag": "1.6",
+        "drupal/schema_metatag": "^1.7",
         "drupal/search_api_autocomplete": "1.x-dev",
         "drupal/search_api_solr": "^4",
         "drupal/seckit": "^2",
@@ -116,10 +116,6 @@
             },
             "drupal/imce": {
                 "Remove theme declaration for imce_page": "https://www.drupal.org/files/issues/2020-06-05/3146463-2--remove_imce_page_theme_declaration.patch"
-            },
-            "drupal/schema_metatag": {
-                "Schema metatag for place": "https://www.drupal.org/files/issues/2020-07-06/schema_metatag-place_group_missing-3012037-8.patch",
-                "Schema metatag for place with D9 compatible": "https://www.drupal.org/files/issues/2020-07-21/d9_compatible-3160458-2.patch"
             },
             "drupal/focal_point": {
                 "Integrate focal point with media_library": "https://www.drupal.org/files/issues/2020-05-26/3094478-38.patch"


### PR DESCRIPTION
* Removes the below patches
  * Patch for Schema Metatag Place - https://www.drupal.org/files/issues/2020-07-06/schema_metatag-place_group_missing-3012037-8.patch
  * D9 Compatibility for schema place - https://www.drupal.org/files/issues/2020-07-21/d9_compatible-3160458-2.patch