### PR TITLE
ACMS-243: Ensure acquia_cms_example is deployed to Cloud

### DIFF
--- a/acquia-pipelines.yml
+++ b/acquia-pipelines.yml
@@ -17,6 +17,11 @@ events:
             - mkdir -p docroot/profiles/acquia_cms
             - composer archive --format tar --file acquia_cms
             - tar -x -f acquia_cms.tar -C docroot/profiles/acquia_cms
+            # The acquia_cms_example module is ignored for export in .gitattributes,
+            # but we DO want to deploy it to our Cloud environment for testing.
+            # We can probably remove this, along with the acquia_cms_example module
+            # itself, once we have a permanent demo site in place.
+            - cp -R modules/acquia_cms_example docroot/profiles/acquia_cms/modules
       - cleanup:
           type: script
           script:


### PR DESCRIPTION
Should fix ACMS-243's current problem (the example module is not deployed to Cloud).