### PR TITLE
ACMS-222: Patch core to fix error message when submitting a required media field with no values

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -118,6 +118,9 @@
             },
             "drupal/focal_point": {
                 "Integrate focal point with media_library": "https://www.drupal.org/files/issues/2020-05-26/3094478-38.patch"
+            },
+            "drupal/core": {
+                "Media Library widget produces error this value should not be null when field is required": "https://www.drupal.org/files/issues/2020-08-11/media-library-not-null-3160238-10.patch"
             }
         }
     },


### PR DESCRIPTION
Ticket: https://backlog.acquia.com/browse/ACMS-222

Completed:

- D.O issue:  https://www.drupal.org/project/drupal/issues/3160238
- Created the patch https://www.drupal.org/files/issues/2020-08-11/media-library-not-null-3160238-10.patch
- Applied the patch via the composer.
- Verified the test case.
- Instead of **"This value should not be null"** now error message will be **"@field_name field is required."**