### PR TITLE
ACMS-181: Update view cache tags for person view

### DIFF
--- a/modules/acquia_cms_person/config/optional/views.view.people.yml
+++ b/modules/acquia_cms_person/config/optional/views.view.people.yml
@@ -288,7 +288,8 @@ display:
       display_extenders: {  }
       path: people
       cache:
-        type: none
+        type: search_api_tag
+        options: {  }
       defaults:
         cache: false
     cache_metadata:


### PR DESCRIPTION
I observe the one use case only for search view, when I am adding new content and publishing the same content then Admin can view content immediately but for anonymous user, I need to clear the cache then only content will be visible