### PR TITLE
ACMS-177: Update caching to tag based in events view

### DIFF
--- a/modules/acquia_cms_event/config/optional/views.view.events.yml
+++ b/modules/acquia_cms_event/config/optional/views.view.events.yml
@@ -287,7 +287,8 @@ display:
       display_extenders: {  }
       path: events
       cache:
-        type: none
+        type: search_api_tag
+        options: {  }
       defaults:
         cache: false
     cache_metadata:


### PR DESCRIPTION
Update caching to tag based in events view
https://backlog.acquia.com/browse/ACMS-177
Though i cloned articles view, still i observed that tag based caching, config was not there in Events view, have added it in this PR