### PR TITLE
ACMS-000: Fix timeout error during Composer post-install-cmd script

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -176,7 +176,8 @@
             "ln -s -f $PWD/tests $PROFILE_DIR",
             "find ./docroot/modules -type d -name tests -prune -exec rm -r -f '{}' ';'",
             "cp -f phpunit.xml ./docroot/core",
-            "composer install:frontend"
+            "composer install:frontend",
+            "composer build:frontend"
         ],
         "build:frontend": [
             "cd themes/acquia_claro && npm run build",
@@ -192,8 +193,7 @@
             "rm -rf $TMPDIR/cex"
         ],
         "install:frontend": [
-            "cd themes/acquia_claro && npm install",
-            "composer build:frontend"
+            "cd themes/acquia_claro && npm install"
         ],
         "nuke": "rm -r -f docroot vendor"
     }


### PR DESCRIPTION
In this PR: 
Fixed composer timeout error due to install:frontend.  

`[Symfony\Component\Process\Exception\ProcessTimedOutException]                                    
  The process "'/usr/bin/php' -d allow_url_fopen='1' -d disable_functions='' -d memory_limit='2G'   
  '/usr/local/bin/composer' install:frontend" exceeded the timeout of 10 seconds.                 `