### PR TITLE
ACMS-338: Fix Media + Focal Point Preview

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
         "drupal/facets": "^1.5",
         "drupal/facets_pretty_paths": "1.x-dev",
         "drupal/field_group": "^3",
-        "drupal/focal_point": "1.4",
+        "drupal/focal_point": "1.5",
         "drupal/geocoder": "^3",
         "drupal/geofield": "^1",
         "drupal/google_analytics": "^2",
@@ -130,8 +130,7 @@
         },
         "patches": {
             "drupal/focal_point": {
-                "3094478 - Integrate focal point with media_library": "https://www.drupal.org/files/issues/2020-05-26/3094478-38.patch",
-                "3162210 - Preview link accidentally closes the media library": "https://www.drupal.org/files/issues/2020-08-18/3162210-3.patch"
+                "3162210 - Preview link accidentally closes the media library": "https://www.drupal.org/files/issues/2020-10-06/3162210-17.patch"
             },
             "drupal/core": {
                 "SQLite database locking errors cause fatal errors": "https://www.drupal.org/files/issues/1120020-59.patch",


### PR DESCRIPTION
I did some more analysis on this and found that there are following issue currently we have with focal_point, if we do not apply patch (3) https://www.drupal.org/files/issues/2020-08-18/3162210-3.patch:

1. Preview link does not works if we change the position of cross hair icon from its previous position.
2. Closing preview modal accidentally closes the media library modal as well.

What is causing issue (1):
We are updating preview link whenever user changes the focal point on image, while updating preview link we are removing AJAX property like(_wrapper_format) from the link which is causing this issue. I am not sure if that was intentional, or I am overlooking anything.

https://git.drupalcode.org/project/focal_point/-/blob/8.x-1.x/js/focal_point.js#L209

The patch(3) fixes both the issue for media library but breaks for image field, because it does not use the AJAX call, it display preview in new tab.

I have created another patch which fixes issue.