### PR TITLE
Require drupal/memcache ^2.2.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -37,7 +37,7 @@
         "drupal/imagemagick": "^3",
         "drupal/imce": "2.x-dev",
         "drupal/jsonapi_extras": "^3",
-        "drupal/memcache": "2.x-dev",
+        "drupal/memcache": "^2.2",
         "drupal/moderation_dashboard": "^1.0@beta",
         "drupal/moderation_sidebar": "^1.4",
         "drupal/mysql56": "^1.0",


### PR DESCRIPTION
The current minimum version is the latest development snapshot. Previously that was done to apply a patch that has since been removed, 13 days ago, in https://github.com/acquia/acquia_cms/commit/b7bd827200d312a069e7790af220450258e3eb35.

That commit could've already updated us to 2.2, but requiring ^2.2 going forward is wise, since it contains a long-battle-tested-and-fought-for fix for DB transactions & cache tag invalidation: https://www.drupal.org/project/memcache/issues/2996615.