### PR TITLE
ACMS-523: Pubsec demo sending a ton of spam email on content creation

### DIFF
--- a/acquia_cms.profile
+++ b/acquia_cms.profile
@@ -283,6 +283,7 @@ function acquia_cms_install_additional_modules() {
   $module_installer = Drupal::service('module_installer');
 
   $is_dev = Environment::isAhIdeEnv() || Environment::isLocalEnv();
+  $is_prod = Environment::isAhProdEnv();
 
   if (Environment::isAhOdeEnv() || $is_dev) {
     $module_installer->install(['dblog', 'jsonapi_extras']);
@@ -295,6 +296,9 @@ function acquia_cms_install_additional_modules() {
     $module_installer->install(['autologout']);
   }
 
+  if (!$is_prod) {
+    $module_installer->install(['reroute_email']);
+  }
   // @todo once PF-3025 has been resolved, update this to work on IDEs too.
   if (Environment::isAhEnv() && !Environment::isAhIdeEnv()) {
     $module_installer->install(['imagemagick']);

--- a/composer.json
+++ b/composer.json
@@ -46,6 +46,7 @@
         "drupal/pathauto": "^1",
         "drupal/recaptcha": "^3",
         "drupal/redirect": "^1",
+        "drupal/reroute_email": "2.0",
         "drupal/responsive_preview": "^1.0",
         "drupal/scheduler_content_moderation_integration": "^1.3",
         "drupal/schema_metatag": "^1.7",
@@ -146,6 +147,9 @@
             },
             "drupal/config_rewrite": {
                 "Make config_rewrite/tests/modules compatible with Drupal 9": "https://www.drupal.org/files/issues/2020-08-22/3166694-2.patch"
+            },
+            "drupal/reroute_email": {
+                "Core version needs removing from info file": "https://www.drupal.org/files/issues/2020-11-17/reroute_email-remove-core-version-3182079-5.patch"
             }
         }
     },

--- a/config/optional/reroute_email.settings.yml
+++ b/config/optional/reroute_email.settings.yml
@@ -1,0 +1,6 @@
+enable: true
+description: true
+message: true
+mailkeys: ''
+address: no-reply@acquia.com
+whitelist: ''

--- a/drush/drush.yml
+++ b/drush/drush.yml
@@ -15,3 +15,5 @@ command:
       options:
         # Set a predetermined site-name when using site-install.
         site-name: 'Acquia CMS'
+        site-mail: 'no-reply@acquia.com'
+        account-mail: 'no-reply@acquia.com'

--- a/hooks/common/post-code-deploy/reinstall.sh
+++ b/hooks/common/post-code-deploy/reinstall.sh
@@ -13,5 +13,5 @@ target_env="$2"
 # Fresh install of Acquia CMS. We need to clear cache first in case memcache is
 # enabled, else there will be a collision on site install.
 /usr/local/bin/drush9 @$site.$target_env cr
-/usr/local/bin/drush9 @$site.$target_env site-install acquia_cms --account-pass=admin --yes
+/usr/local/bin/drush9 @$site.$target_env site-install acquia_cms --account-pass=admin --yes --account-mail=no-reply@acquia.com --site-mail=no-reply@acquia.com
 /usr/local/bin/drush9 @$site.$target_env pm-enable acquia_cms_development --yes


### PR DESCRIPTION
https://backlog.acquia.com/browse/ACMS-523
Questions discussed with Mike

For point Enable reroute_email for all non-prod environments, place this piece of code in acquia_cms_development module
Q) Do we need to keep configuration of module in development module? Or
We need to place conditions to Enable reroute_email for all non-prod environments in development module? 
A) Keep config and conditions at profile level only.
Q)I have kept below checkboxes enabled
Show rerouting description in mail body
Display a Drupal status message after rerouting
Hope that is ok.
A) Yes that is ok

On enabling module we get below error:
The 'core_version_requirement' constraint (^9) requires the 'core' key not be set in modules/contrib/reroute_email/reroute_email.info.yml

 Fix is already in dev branch of module

https://www.drupal.org/project/reroute_email/issues/3160335

For now, i have added the patch provided in the above link, since it would not be safe to use the dev version of module.

A) Yes that is correct way.

