### PR TITLE
ACMS-000: Increase drupal core version requirement to 9.0.8.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
         "drupal/checklistapi": "^2.0",
         "drupal/collapsiblock": "^3",
         "drupal/config_rewrite": "1.3",
-        "drupal/core": "^9.0",
+        "drupal/core": "^9.0.8",
         "drupal/default_content": "^2",
         "drupal/diff": "^1",
         "drupal/entity_clone": "^1.0-beta4",


### PR DESCRIPTION
Require the latest security update.