### PR TITLE
[SPIKE]ACMS-556: Removed this dependency, to support composer2, for  9.1.0-b…

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -68,7 +68,6 @@
         "drush/drush": "^10",
         "friendsoftwig/twigcs": "^3.2",
         "oomphinc/composer-installers-extender": "^1.1 || ^2",
-        "vijaycs85/drupal-quality-checker": "^1.2",
         "weitzman/drupal-test-traits": "^1.5"
     },
     "config": {


### PR DESCRIPTION
https://backlog.acquia.com/browse/ACMS-556

Removed this dependency, to support composer2, for  9.1.0
https://docs.google.com/document/d/13wgOWCzndfKRgKWxaG3WBu59S6w9Jjr51oleGwGC06g/edit?usp=sharing
