### PR TITLE
ACMS-584: updated drupal core to 9.1.0-alpha1 and updated patch for m…

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
         "drupal/checklistapi": "^2.0",
         "drupal/collapsiblock": "^3",
         "drupal/config_rewrite": "1.3",
-        "drupal/core": "^9.0.8",
+        "drupal/core": "^9.1",
         "drupal/default_content": "^2",
         "drupal/diff": "^1",
         "drupal/entity_clone": "^1.0-beta4",
@@ -137,7 +137,7 @@
             },
             "drupal/core": {
                 "SQLite database locking errors cause fatal errors": "https://www.drupal.org/files/issues/1120020-59.patch",
-                "Media Library widget produces error this value should not be null when field is required": "https://www.drupal.org/files/issues/2020-08-11/media-library-not-null-3160238-10.patch",
+                "Media Library widget produces error this value should not be null when field is required": "https://www.drupal.org/files/issues/2020-10-08/3160238-25.patch",
                 "It is possible to overflow the number of items allowed in Media Library": "https://www.drupal.org/files/issues/2019-12-28/3082690-80.patch"
             },
             "drupal/acquia_telemetry-acquia_telemetry": {


### PR DESCRIPTION
…edia library.

https://backlog.acquia.com/browse/ACMS-584
have now updated to 9.1.0-alpha1 , the already existing patch did not work on this, but there was 1 patch available for 9.1x and that worked
Patch applied : https://www.drupal.org/files/issues/2020-10-08/3160238-25.patch
<img width="1194" alt="Screenshot 2020-12-04 at 1 09 02 PM" src="https://user-images.githubusercontent.com/50393153/101136167-ec8f2180-3632-11eb-8a6c-617ec4521600.png">
<img width="1273" alt="Screenshot 2020-12-04 at 12 09 00 PM" src="https://user-images.githubusercontent.com/50393153/101136181-f2850280-3632-11eb-9f69-d00e8cb44129.png">
