### PR TITLE
AMCS-000: Regression issue, javascript test not running on local

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -85,8 +85,7 @@
                 "drupal/core"
             ],
             "locations": {
-                "web-root": "./docroot",
-                "project-root": "."
+                "web-root": "./docroot"
             },
             "file-mapping": {
                 "[project-root]/.gitattributes": false,


### PR DESCRIPTION
https://backlog.acquia.com/browse/ACMS-582
Getting 1 regression issue
Functional runs fine, but javascript tests failing with below error
**command used:**  ../vendor/bin/phpunit -c core --debug ../tests/src/ExistingSiteJavascript/AccordionComponentTest.php

**PHP Fatal error:** Uncaught Error: Class 'Drupal\Tests\acquia_cms\ExistingSiteJavascript\CohesionComponentTestBase' not found in /Users/saurabh.tripathi/Desktop/acquia_cms/tests/src/ExistingSiteJavascript/AccordionComponentTest.php:10
 
Root cause:
"project-root": "." removing this line from composer.json this was added in PR https://github.com/acquia/acquia_cms/pull/554/files#diff-d2ab9925cad7eac58e0ff4cc0d251a937ecf49e4b6bf57f8b95aab76648a9d34
 