### PR TITLE
ACMS-480: Fix white space to the left of the dropdown button.

### DIFF
--- a/themes/acquia_claro/css/styles.css
+++ b/themes/acquia_claro/css/styles.css
@@ -77,6 +77,10 @@ ul.list-with-striped li:nth-child(odd) {
   background: #d7dde2;
 }
 
+ul.dropbutton {
+  padding-left: 0;
+}
+
 html,
 body {
   font-family: "Proxima Nova", "Open Sans", "Helvetica Neue", sans-serif;

--- a/themes/acquia_claro/scss/01-base/_base-modifiers.scss
+++ b/themes/acquia_claro/scss/01-base/_base-modifiers.scss
@@ -26,4 +26,8 @@ ul {
       background: $gray-300;
     }
   }
+
+  &.dropbutton {
+    padding-left: 0;
+  }
 }


### PR DESCRIPTION
**Jira ticket:** 
 https://backlog.acquia.com/browse/ACMS-480

**In this PR:**
- Fixed white space to the left of the dropdown button.

**Screenshot:**

<img width="1679" alt="Screenshot 2020-12-09 at 2 34 46 PM" src="https://user-images.githubusercontent.com/29912076/101608536-d6ff6a80-3a2b-11eb-85c1-5427f791f1ff.png">

<img width="1599" alt="Screenshot 2020-12-09 at 2 35 27 PM" src="https://user-images.githubusercontent.com/29912076/101608559-dbc41e80-3a2b-11eb-8cf0-c71c3738cfcf.png">

