### PR TITLE
ACMS-598: Patch TwigExtension.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,8 +4,8 @@
     "description": "An implementation of Drupal 9 for running custom, low code websites on the Acquia platform.",
     "license": "GPL-2.0-or-later",
     "require": {
-        "acquia/cohesion": "^6.3",
-        "acquia/cohesion-theme": "^6.3",
+        "acquia/cohesion": "6.4",
+        "acquia/cohesion-theme": "6.4",
         "acquia/drupal-environment-detector": "^1",
         "acquia/memcache-settings": "^1",
         "cweagans/composer-patches": "^1.7",


### PR DESCRIPTION
This patch (from this Cohesion issue: https://github.com/acquia/cohesion-dev/pull/263) should get past the TwigExtension error.