### PR TITLE
ACMS-636: Fix php 7.3 Travis jobs.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -68,23 +68,23 @@ matrix:
     # @see https://github.com/acquia/orca/blob/master/docs/understanding-orca.md#continuous-integration
     - { env: ORCA_JOB=STATIC_CODE_ANALYSIS, name: "Static code analysis" }
     - { env: ORCA_JOB=STRICT_DEPRECATED_CODE_SCAN, name: "Strict deprecated code scan" }
-    # The following six jobs are custom ACMS jobs based on the standard isolated
+    # The following nine jobs are custom ACMS jobs based on the standard isolated
     # current dev test.
     # Exclude site_studio tests on this job because we only run them during cron builds.
     - { name: "Isolated test on current dev Drupal core version", env: ACMS_JOB=base ACMS__JOB_EXCLUDE_PHPUNIT_TEST_GROUP="site_studio" ORCA_JOB=ISOLATED_TEST_ON_CURRENT_DEV}
     - { name: "Starter", env: ACMS_JOB=starter ORCA_JOB=ISOLATED_TEST_ON_CURRENT_DEV}
     - { name: "PubSec Demo", env: ACMS_JOB=pubsec ORCA_JOB=ISOLATED_TEST_ON_CURRENT_DEV}
-    # Acquia CMS is going to support both PHP 7.3 and PHP 7.4 until Acquia Cloud
-    # officially stop support for PHP 7.3.
-    # Run the following jobs on PHP 7.3 to make sure it works fine, during cron run.
-    - { php: "7.3", name: "[PHP 7.3] - Isolated test on current dev Drupal core version - Full Install", if: type = cron, env: ACMS_JOB=base ACMS__JOB_EXCLUDE_PHPUNIT_TEST_GROUP="site_studio" ORCA_JOB=ISOLATED_TEST_ON_CURRENT_DEV }
-    - { php: "7.3", name: "[PHP 7.3] - Starter - Full Install", if: type = cron, env: ACMS_JOB=starter ORCA_JOB=ISOLATED_TEST_ON_CURRENT_DEV }
-    - { php: "7.3", name: "[PHP 7.3] - PubSec Demo - Full Install", if: type = cron, env: ACMS_JOB=pubsec ORCA_JOB=ISOLATED_TEST_ON_CURRENT_DEV }
     # The following jobs run only during cron runs, and fully install the site before
     # running tests.
     - { name: "Isolated test on current dev Drupal core version - Full Install", if: type = cron, env: ACMS_JOB=base_full ORCA_JOB=ISOLATED_TEST_ON_CURRENT_DEV}
     - { name: "Starter - Full Install", if: type = cron, env: ACMS_JOB=starter_full ORCA_JOB=ISOLATED_TEST_ON_CURRENT_DEV}
     - { name: "PubSec Demo - Full Install", if: type = cron, env: ACMS_JOB=pubsec_full ORCA_JOB=ISOLATED_TEST_ON_CURRENT_DEV}
+    # Acquia CMS is going to support both PHP 7.3 and PHP 7.4 until Acquia Cloud
+    # officially stop support for PHP 7.3.
+    # Run the following jobs on PHP 7.3 to make sure it works fine, during cron run.
+    - { php: "7.3", name: "[PHP 7.3] - Isolated test on current dev Drupal core version - Full Install", if: type = cron, env: ACMS_JOB=base_full ACMS__JOB_EXCLUDE_PHPUNIT_TEST_GROUP="site_studio" ORCA_JOB=ISOLATED_TEST_ON_CURRENT_DEV }
+    - { php: "7.3", name: "[PHP 7.3] - Starter - Full Install", if: type = cron, env: ACMS_JOB=starter_full ORCA_JOB=ISOLATED_TEST_ON_CURRENT_DEV }
+    - { php: "7.3", name: "[PHP 7.3] - PubSec Demo - Full Install", if: type = cron, env: ACMS_JOB=pubsec_full ORCA_JOB=ISOLATED_TEST_ON_CURRENT_DEV }
     # Uncomment the following four lines to enable the corresponding tests once
     # the next major version of Drupal core has an alpha release or earlier.
     # Until then it's wasteful to use CI jobs on them, even if they exit early.


### PR DESCRIPTION
The overnight jobs for 7.3 weren't quite right, and were causing the jobs to not run as expected and fail. I changed the job names, and updated a comment.

Tested and working here: https://travis-ci.com/github/acquia/acquia_cms/builds/215139977