### PR TITLE
ACMS-580: disable big pipe module.

### DIFF
--- a/acquia_cms.info.yml
+++ b/acquia_cms.info.yml
@@ -21,7 +21,6 @@ install:
   - acquia_purge
   - address
   - admin_toolbar_tools
-  - big_pipe
   - captcha
   - cohesion
   - cohesion_base_styles


### PR DESCRIPTION
JIRA TICKET: https://backlog.acquia.com/browse/ACMS-580

In this PR:
- Disabled big pipe module. 