### PR TITLE
ACMS-638: Pin search_api.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -50,6 +50,7 @@
         "drupal/responsive_preview": "^1.0",
         "drupal/scheduler_content_moderation_integration": "^1.3",
         "drupal/schema_metatag": "^1.7",
+        "drupal/search_api": "1.18",
         "drupal/search_api_autocomplete": "^1.4",
         "drupal/search_api_solr": "^4",
         "drupal/seckit": "^2",


### PR DESCRIPTION
Search Api had a new release, and we get errors preventing install. Let's pin to previous version while we work on it.