### PR TITLE
ACMS-000: Fix node teaser link selector for ContentTypeListTestBase.

### DIFF
--- a/modules/acquia_cms_common/tests/src/ExistingSite/ContentTypeListTestBase.php
+++ b/modules/acquia_cms_common/tests/src/ExistingSite/ContentTypeListTestBase.php
@@ -307,14 +307,10 @@ abstract class ContentTypeListTestBase extends ExistingSiteBase {
   protected function getLinks() : array {
     $links = $this->getSession()
       ->getPage()
-      ->findAll('css', 'a[title]');
+      ->findAll('css', 'article a.card-link');
 
     $map = function (ElementInterface $link) {
-      // Our template for node teasers doesn't actually link the title -- which
-      // is probably an accessibility no-no, but let's not get into that now --
-      // but it does include a 'title' attribute in the "read more" link which
-      // contains the actual title of the linked node.
-      return $link->getAttribute('title');
+      return $link->getText();
     };
     return array_map($map, $links);
   }


### PR DESCRIPTION
@kdruckman content type list tests pass for me after correcting the selector for node teasers. Can you give this a quick look over when you have a chance?

```bash
vagrant@template-sandbox:/app/development/acquia_cms$ ./vendor/bin/phpunit -c docroot/core/ docroot/profiles/contrib/acquia_cms/modules/acquia_cms_article/tests/src/ExistingSite/ArticleListTest.php 
PHPUnit 9.4.4 by Sebastian Bergmann and contributors.

Warning:       Your XML configuration validates against a deprecated schema.
Suggestion:    Migrate your XML configuration using "--migrate-configuration"!

Testing Drupal\Tests\acquia_cms_article\ExistingSite\ArticleListTest
....                                                                4 / 4 (100%)

Time: 00:26.775, Memory: 173.00 MB

OK (4 tests, 42 assertions)

Remaining self deprecation notices (369)

Remaining indirect deprecation notices (1)
vagrant@template-sandbox:/app/development/acquia_cms$ ./vendor/bin/phpunit -c docroot/core/ docroot/profiles/contrib/acquia_cms/modules/acquia_cms_event/tests/src/ExistingSite/EventListTest.php 
PHPUnit 9.4.4 by Sebastian Bergmann and contributors.

Warning:       Your XML configuration validates against a deprecated schema.
Suggestion:    Migrate your XML configuration using "--migrate-configuration"!

Testing Drupal\Tests\acquia_cms_event\ExistingSite\EventListTest
....                                                                4 / 4 (100%)

Time: 00:36.304, Memory: 177.00 MB

OK (4 tests, 42 assertions)

Remaining self deprecation notices (477)

Remaining indirect deprecation notices (1)
vagrant@template-sandbox:/app/development/acquia_cms$ ./vendor/bin/phpunit -c docroot/core/ docroot/profiles/contrib/acquia_cms/modules/acquia_cms_person/tests/src/ExistingSite/PersonListTest.php 
PHPUnit 9.4.4 by Sebastian Bergmann and contributors.

Warning:       Your XML configuration validates against a deprecated schema.
Suggestion:    Migrate your XML configuration using "--migrate-configuration"!

Testing Drupal\Tests\acquia_cms_person\ExistingSite\PersonListTest
....                                                                4 / 4 (100%)

Time: 00:34.337, Memory: 173.00 MB

OK (4 tests, 42 assertions)

Remaining self deprecation notices (357)

Remaining indirect deprecation notices (1)
vagrant@template-sandbox:/app/development/acquia_cms$ ./vendor/bin/phpunit -c docroot/core/ docroot/profiles/contrib/acquia_cms/modules/acquia_cms_place/tests/src/ExistingSite/PlaceListTest.php 
PHPUnit 9.4.4 by Sebastian Bergmann and contributors.

Warning:       Your XML configuration validates against a deprecated schema.
Suggestion:    Migrate your XML configuration using "--migrate-configuration"!

Testing Drupal\Tests\acquia_cms_place\ExistingSite\PlaceListTest
....                                                                4 / 4 (100%)

Time: 00:28.419, Memory: 173.00 MB

OK (4 tests, 42 assertions)

Remaining self deprecation notices (357)

Remaining indirect deprecation notices (1)

```