### PR TITLE
ACMS-000: Pin cohesion to avoid breaking update.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,8 +17,8 @@
         }
     ],
     "require": {
-        "acquia/cohesion": "^6.4",
-        "acquia/cohesion-theme": "^6.4",
+        "acquia/cohesion": "6.4.3",
+        "acquia/cohesion-theme": "6.4.3",
         "acquia/drupal-environment-detector": "^1",
         "acquia/memcache-settings": "^1",
         "cweagans/composer-patches": "^1.7",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "2ee3d02675f9a8bc54d8c1201459722f",
+    "content-hash": "901eeaff2501653b7841c41b30248433",
     "packages": [
         {
             "name": "acquia/cohesion",


### PR DESCRIPTION
**Motivation**
<!-- What problem does this solve? Why is it important? What's the context? If this fixes an issue, link to it above. -->
Cohesion 6.5.x is not currently compatible with our integration.

**Proposed changes**
<!-- What does this PR change? How does this impact end users? Are manual or automatic updates required? -->
pin to 6.4.3

**Alternatives considered**
<!-- How else could the original issue / use case be addressed? Why did you choose this solution over any others? -->
No

**Testing steps**
<!-- How can we replicate the issue and verify that this PR fixes it? -->
if it works, acms will install without error.

**Merge requirements**
- [ ] _Major change_, _Minor change_, _Bug_, _Enhancement_, and/or _Chore_ label applied
- [ ] Manual testing by a reviewer
