### PR TITLE
ACMS-696: Post command hook approach to run rebuild after site install.

### DIFF
--- a/acquia_cms.profile
+++ b/acquia_cms.profile
@@ -46,6 +46,7 @@ function acquia_cms_form_cohesion_account_settings_form_alter(array &$form) {
     // configuration import and cohesion style rebuild functionality into
     // separate submit handlers.
     // @see \Drupal\cohesion_website_settings\Controller\WebsiteSettingsController::batch
+    $form['#submit'][] = 'acquia_cms_rebuild_cohesion';
   }
 }
 

--- a/acquia_cms.profile
+++ b/acquia_cms.profile
@@ -46,7 +46,6 @@ function acquia_cms_form_cohesion_account_settings_form_alter(array &$form) {
     // configuration import and cohesion style rebuild functionality into
     // separate submit handlers.
     // @see \Drupal\cohesion_website_settings\Controller\WebsiteSettingsController::batch
-    $form['#submit'][] = 'acquia_cms_rebuild_cohesion';
   }
 }
 

--- a/drush/Commands/SiteInstallCommands.php
+++ b/drush/Commands/SiteInstallCommands.php
@@ -12,28 +12,31 @@ use Drupal\cohesion\Drush\DX8CommandHelpers;
 class SiteInstallCommands extends DrushCommands {
 
   /**
-   * Do a forceful rebuild whenever site is installed.
+   * Execute site studio rebuild after Acquia CMS site install.
    *
    * @hook post-command site-install
    */
   public function postCommand($result, CommandData $commandData) {
-    $this->yell('Finished rebuilding.');
-    // Forcefully clear the cache after site is installed otherwise site
-    // studio fails to rebuild.
-    drupal_flush_all_caches();
-    // Below code ensure that drush batch process doesn't hang. Unset all the
-    // ealier created batches so that drush_backend_batch_process() can run
-    // without being stuck.
-    // @see https://github.com/drush-ops/drush/issues/3773 for the issue.
-    $batch = &batch_get();
-    $batch = NULL;
-    unset($batch);
-    $this->say(dt('Rebuilding all entities.'));
-    $result = DX8CommandHelpers::rebuild([]);
-    // Output results.
-    $this->yell('Finished rebuilding.');
-    // Status code.
-    return is_array($result) && isset(array_shift($result)['error']) ? CommandResult::exitCode(self::EXIT_FAILURE) : CommandResult::exitCode(self::EXIT_SUCCESS);
+    $arguments = $commandData->arguments();
+    $moduleHandler = \Drupal::service('module_handler');
+    if (isset($arguments['profile'][0]) && $arguments['profile'][0] == 'acquia_cms' && $moduleHandler->moduleExists('cohesion')) {
+      // Forcefully clear the cache after site is installed otherwise site
+      // studio fails to rebuild.
+      drupal_flush_all_caches();
+      // Below code ensures that drush batch process doesn't hang. Unset all the
+      // earlier created batches so that drush_backend_batch_process() can run
+      // without being stuck.
+      // @see https://github.com/drush-ops/drush/issues/3773 for the issue.
+      $batch = &batch_get();
+      $batch = NULL;
+      unset($batch);
+      $this->say(dt('Rebuilding all entities.'));
+      $result = DX8CommandHelpers::rebuild([]);
+      // Output results.
+      $this->yell('Finished rebuilding.');
+      // Status code.
+      return is_array($result) && isset(array_shift($result)['error']) ? CommandResult::exitCode(self::EXIT_FAILURE) : CommandResult::exitCode(self::EXIT_SUCCESS);
+    }
   }
 
 }

--- a/drush/Commands/SiteInstallCommands.php
+++ b/drush/Commands/SiteInstallCommands.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Drush\Commands;
+
+use Consolidation\AnnotatedCommand\CommandData;
+use Consolidation\AnnotatedCommand\CommandResult;
+use Drupal\cohesion\Drush\DX8CommandHelpers;
+
+/**
+ * Rebuild site studio when site is installed via drush.
+ */
+class SiteInstallCommands extends DrushCommands {
+
+  /**
+   * Do a forceful rebuild whenever site is installed.
+   *
+   * @hook post-command site-install
+   */
+  public function postCommand($result, CommandData $commandData) {
+    $this->yell('Finished rebuilding.');
+    // Forcefully clear the cache after site is installed otherwise site
+    // studio fails to rebuild.
+    drupal_flush_all_caches();
+    // Below code ensure that drush batch process doesn't hang. Unset all the
+    // ealier created batches so that drush_backend_batch_process() can run
+    // without being stuck.
+    // @see https://github.com/drush-ops/drush/issues/3773 for the issue.
+    $batch = &batch_get();
+    $batch = NULL;
+    unset($batch);
+    $this->say(dt('Rebuilding all entities.'));
+    $result = DX8CommandHelpers::rebuild([]);
+    // Output results.
+    $this->yell('Finished rebuilding.');
+    // Status code.
+    return is_array($result) && isset(array_shift($result)['error']) ? CommandResult::exitCode(self::EXIT_FAILURE) : CommandResult::exitCode(self::EXIT_SUCCESS);
+  }
+
+}


### PR DESCRIPTION
  https://backlog.acquia.com/browse/ACMS-696 [SPIKE]
**Motivation**
<!-- What problem does this solve? Why is it important? What's the context? If this fixes an issue, link to it above. -->
_We currently rebuild cohesion assets after install in order to avoid timeout errors, but if we can run threaded tasks, we might improve our install experience.
 
_Issue_
 timeout errors

Fixes #NNN

**Proposed changes**
Investigate Symfony libraries for asynchronous threaded install tasks

-we could try drush post command hook and run cohesion rebuild from there
**Alternatives considered**
look in to Symfony\Component\Process\Process 

 Find if f there is a way to run a block of code directly (no we cannot call a class directly for example check docroot/core/tests/Drupal/Tests/Core/Command/QuickStartTest.php)

Another simpler option could be to modify the acquia_cms_rebuild_cohesion() function so that it tests if the request is coming from cli, and if so, just print a big terminal message telling the user they need to run drush cohesion:rebuild


**Testing steps**
<!-- How can we replicate the issue and verify that this PR fixes it? -->

- Run site install and rebuild should get run automatically after site insatll.
 
