### PR TITLE
ACMS-713: Added Css code for changing color to light grey for admin t…

### DIFF
--- a/modules/acquia_cms_toolbar/css/acquia_cms_toolbar.css
+++ b/modules/acquia_cms_toolbar/css/acquia_cms_toolbar.css
@@ -641,6 +641,10 @@
   margin: -39px 200px 0 0;
 }
 
+.toolbar .toolbar-tray-vertical .level-2 a {
+  color: #cccccc !important;
+}
+
 .toolbar .toolbar-tray-vertical .level-3 ul {
   margin-left: 0 !important;
 }

--- a/themes/acquia_claro/css/acquia_cms_toolbar.css
+++ b/themes/acquia_claro/css/acquia_cms_toolbar.css
@@ -641,6 +641,10 @@
   margin: -39px 200px 0 0;
 }
 
+.toolbar .toolbar-tray-vertical .level-2 a {
+  color: #cccccc !important;
+}
+
 .toolbar .toolbar-tray-vertical .level-3 ul {
   margin-left: 0 !important;
 }

--- a/themes/acquia_claro/scss/acquia_cms_toolbar.scss
+++ b/themes/acquia_claro/scss/acquia_cms_toolbar.scss
@@ -450,7 +450,7 @@
                 content: url(../images/0084d7/chevron-right.svg);
                 pointer-events: none;
               }
-              
+
               &:hover {
                 &:after {
                   transform: translate(6px, -8px);
@@ -865,6 +865,12 @@
 
 .toolbar {
   .toolbar-tray-vertical {
+    .level-2 {
+      a {
+        color: $df-light-grey !important;
+      }
+    }
+
     .level-3 {
       ul {
         margin-left: 0 !important;


### PR DESCRIPTION
**Motivation**
The menu items on admin toolbar looks inactive or disabled due to the link color. 
Fixes #713

**Proposed changes**
- Change the color of the link to light grey for vertical-toolbar tray.

**Testing steps**
Login to the dev environment with admin creds and head towards mobile view, click on content link on admin toolbar and notice the change in color.

**Merge requirements**
- [ *] _Bug_

**Screenshot** 
<img width="389" alt="Screenshot 2021-03-30 at 11 08 24 AM" src="https://user-images.githubusercontent.com/15887127/113101561-7e422080-921a-11eb-93a8-d0bee0662e90.png">
