### PR TITLE
ACMS-696: Remove rebuild code from install-acms script

### DIFF
--- a/install-acms
+++ b/install-acms
@@ -41,4 +41,3 @@ if [ ${ADMIN_EMAIL} ]; then
   PARAMS+="--account-mail=${ADMIN_EMAIL} "
 fi
 ./vendor/bin/drush site-install -y acquia_cms --account-name=${ADMIN_NAME} ${PARAMS}
-./vendor/bin/drush cohesion:rebuild


### PR DESCRIPTION
**Motivation**
Since, we are now Rebuilding cohesion using drush post-command hook, so when we do site install using command: composer acms:install, cohesion rebuild runs twice.
Fixes #NNN

**Proposed changes**
Remove rebuild code from install-acms script
