### PR TITLE
ACMS-720: Overlong word waring fix by removing coh comp from index

### DIFF
--- a/modules/acquia_cms_page/config/install/core.entity_view_display.node.page.search_index.yml
+++ b/modules/acquia_cms_page/config/install/core.entity_view_display.node.page.search_index.yml
@@ -1,0 +1,36 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_view_mode.node.search_index
+    - field.field.node.page.body
+    - field.field.node.page.field_categories
+    - field.field.node.page.field_layout_canvas
+    - field.field.node.page.field_page_image
+    - field.field.node.page.field_tags
+    - node.type.page
+  module:
+    - user
+id: node.page.search_index
+targetEntityType: node
+bundle: page
+mode: search_index
+content:
+  content_moderation_control:
+    weight: 0
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  links:
+    weight: 1
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+hidden:
+  body: true
+  field_categories: true
+  field_layout_canvas: true
+  field_page_image: true
+  field_tags: true
+  langcode: true
+  search_api_excerpt: true


### PR DESCRIPTION
**Motivation**
`Overlong word` error coming from search API when enabling Starter

**Proposed changes**
 Enable search index view mode and remove layout canvas field from it, since we are using this view mode in index, but did not create it, hence the index was using default view mode for page, which has layout canvas field, that is the root cause that layout canvas field was getting indexed, as part of rendered html field.

**Alternatives considered**
Stop tokeniser to tokenise cohesion component, or remove cohesion component from index

**Testing steps**
install site, add a new page with a site studio component, and there should noit be a overlong word log, also this warning should not appear when we enable starter module.


