### PR TITLE
ACMS-702: Further improvement needed for drush command 'acms:config-reset'

### DIFF
--- a/drush/Commands/SiteInstallCommands.php
+++ b/drush/Commands/SiteInstallCommands.php
@@ -4,7 +4,6 @@ namespace Drush\Commands;
 
 use Consolidation\AnnotatedCommand\CommandData;
 use Consolidation\AnnotatedCommand\CommandResult;
-use Drupal\cohesion\Drush\DX8CommandHelpers;
 
 /**
  * Rebuild site studio when site is installed via drush.
@@ -16,25 +15,13 @@ class SiteInstallCommands extends DrushCommands {
    *
    * @hook post-command site-install
    */
-  public function postCommand($result, CommandData $commandData) {
+  public function siteInstallPostCommand($result, CommandData $commandData) {
     $arguments = $commandData->arguments();
     $moduleHandler = \Drupal::service('module_handler');
     if (isset($arguments['profile'][0]) && $arguments['profile'][0] == 'acquia_cms' && $moduleHandler->moduleExists('cohesion')) {
-      // Forcefully clear the cache after site is installed otherwise site
-      // studio fails to rebuild.
-      drupal_flush_all_caches();
-      // Below code ensures that drush batch process doesn't hang. Unset all the
-      // earlier created batches so that drush_backend_batch_process() can run
-      // without being stuck.
-      // @see https://github.com/drush-ops/drush/issues/3773 for the issue.
-      $batch = &batch_get();
-      $batch = NULL;
-      unset($batch);
       $this->say(dt('Rebuilding all entities.'));
-      $result = DX8CommandHelpers::rebuild([]);
-      // Output results.
+      $result = \Drupal::service('acquia_cms_common.utility')->rebuildSiteStudio();
       $this->yell('Finished rebuilding.');
-      // Status code.
       return is_array($result) && isset(array_shift($result)['error']) ? CommandResult::exitCode(self::EXIT_FAILURE) : CommandResult::exitCode(self::EXIT_SUCCESS);
     }
   }

--- a/modules/acquia_cms_article/config/optional/block.block.articles_article_type.yml
+++ b/modules/acquia_cms_article/config/optional/block.block.articles_article_type.yml
@@ -5,9 +5,13 @@ dependencies:
     - facets.facet.articles_article_type
   module:
     - cohesion
+    - collapsiblock
     - facets
   theme:
     - cohesion_theme
+third_party_settings:
+  collapsiblock:
+    collapse_action: '2'
 id: articles_article_type
 theme: cohesion_theme
 region: dx8_hidden
@@ -18,7 +22,7 @@ settings:
   id: 'facet_block:articles_article_type'
   label: 'Article Type'
   provider: facets
-  label_display: '0'
+  label_display: visible
   block_id: articles_article_type
 visibility:
   cohesion_master_template:

--- a/modules/acquia_cms_article/config/optional/block.block.articles_category.yml
+++ b/modules/acquia_cms_article/config/optional/block.block.articles_category.yml
@@ -5,9 +5,13 @@ dependencies:
     - facets.facet.articles_category
   module:
     - cohesion
+    - collapsiblock
     - facets
   theme:
     - cohesion_theme
+third_party_settings:
+  collapsiblock:
+    collapse_action: '2'
 id: articles_category
 theme: cohesion_theme
 region: dx8_hidden
@@ -18,8 +22,8 @@ settings:
   id: 'facet_block:articles_category'
   label: Category
   provider: facets
-  label_display: '0'
-  block_id: articles_categories
+  label_display: visible
+  block_id: articles_category
 visibility:
   cohesion_master_template:
     id: cohesion_master_template

--- a/modules/acquia_cms_article/config/optional/block.block.search_article_type.yml
+++ b/modules/acquia_cms_article/config/optional/block.block.search_article_type.yml
@@ -4,9 +4,14 @@ dependencies:
   config:
     - facets.facet.search_article_type
   module:
+    - cohesion
+    - collapsiblock
     - facets
   theme:
     - cohesion_theme
+third_party_settings:
+  collapsiblock:
+    collapse_action: '2'
 id: search_article_type
 theme: cohesion_theme
 region: dx8_hidden
@@ -17,7 +22,7 @@ settings:
   id: 'facet_block:search_article_type'
   label: 'Article Type'
   provider: facets
-  label_display: '0'
+  label_display: visible
   block_id: search_article_type
 visibility:
   cohesion_master_template:

--- a/modules/acquia_cms_common/config/optional/block.block.search_category.yml
+++ b/modules/acquia_cms_common/config/optional/block.block.search_category.yml
@@ -5,9 +5,13 @@ dependencies:
     - facets.facet.search_category
   module:
     - cohesion
+    - collapsiblock
     - facets
   theme:
     - cohesion_theme
+third_party_settings:
+  collapsiblock:
+    collapse_action: '2'
 id: search_category
 theme: cohesion_theme
 region: dx8_hidden
@@ -18,7 +22,7 @@ settings:
   id: 'facet_block:search_category'
   label: Category
   provider: facets
-  label_display: '0'
+  label_display: visible
   block_id: search_category
 visibility:
   cohesion_master_template:

--- a/modules/acquia_cms_common/config/optional/block.block.search_content_type.yml
+++ b/modules/acquia_cms_common/config/optional/block.block.search_content_type.yml
@@ -4,9 +4,14 @@ dependencies:
   config:
     - facets.facet.search_content_type
   module:
+    - cohesion
+    - collapsiblock
     - facets
   theme:
     - cohesion_theme
+third_party_settings:
+  collapsiblock:
+    collapse_action: '2'
 id: search_content_type
 theme: cohesion_theme
 region: dx8_hidden
@@ -17,7 +22,7 @@ settings:
   id: 'facet_block:search_content_type'
   label: 'Content Type'
   provider: facets
-  label_display: '0'
+  label_display: visible
   block_id: search_content_type
 visibility:
   cohesion_master_template:

--- a/modules/acquia_cms_common/src/Commands/AcmsConfigImportCommands.php
+++ b/modules/acquia_cms_common/src/Commands/AcmsConfigImportCommands.php
@@ -185,7 +185,7 @@ final class AcmsConfigImportCommands extends DrushCommands {
    * @aliases acr
    * @usage acms:config-reset
    *   Reset the configuration to the default.
-   * @usage acms:config-reset acquia_cms_article acquia_cms_article acquia_cms_person --scope=all
+   * @usage acms:config-reset acquia_cms_article acquia_cms_person --scope=all
    * --delete-list=search_api.index.acquia_search_index
    *   Reset the configuration to the default.
    *

--- a/modules/acquia_cms_common/src/Commands/AcmsConfigImportCommands.php
+++ b/modules/acquia_cms_common/src/Commands/AcmsConfigImportCommands.php
@@ -163,7 +163,6 @@ final class AcmsConfigImportCommands extends DrushCommands {
     $this->stringTranslation = $stringTranslation;
     $this->moduleHandler = $moduleHandler;
     $this->cohesionFacade = $classResolver->getInstanceFromDefinition(CohesionFacade::class);
-    ;
     $this->acmsUtilityService = $acmsUtilityService;
   }
 
@@ -453,6 +452,12 @@ final class AcmsConfigImportCommands extends DrushCommands {
 
     $replacement_storage = new StorageReplaceDataWrapper($active_storage);
     foreach ($config_files as $name => $data) {
+      // We should not re-import cohesion settings at all,
+      // it will override the site studio credentials which
+      // will break the whole site.
+      if ($name === 'cohesion.settings') {
+        continue;
+      }
       $replacement_storage->replaceData($name, $data);
     }
     $source_storage = $replacement_storage;

--- a/modules/acquia_cms_common/src/Commands/AcmsConfigImportCommands.php
+++ b/modules/acquia_cms_common/src/Commands/AcmsConfigImportCommands.php
@@ -4,8 +4,10 @@ namespace Drupal\acquia_cms_common\Commands;
 
 use Consolidation\AnnotatedCommand\CommandData;
 use Consolidation\AnnotatedCommand\CommandError;
+use Consolidation\AnnotatedCommand\CommandResult;
 use Drupal\acquia_cms\Facade\CohesionFacade;
 use Drupal\acquia_cms_common\Services\AcmsUtilityService;
+use Drupal\cohesion\Drush\DX8CommandHelpers;
 use Drupal\Component\Serialization\Yaml;
 use Drupal\config\StorageReplaceDataWrapper;
 use Drupal\Core\Config\ConfigManagerInterface;
@@ -176,8 +178,6 @@ final class AcmsConfigImportCommands extends DrushCommands {
    * @param array $options
    *   The options array.
    *
-   * @throws \Drush\Exceptions\UserAbortException
-   *
    * @option scope
    *   The scope for particular package to be imported.
    * @option delete-list
@@ -186,9 +186,11 @@ final class AcmsConfigImportCommands extends DrushCommands {
    * @aliases acr
    * @usage acms:config-reset
    *   Reset the configuration to the default.
-   * @usage acms:config-reset acquia_cms_article acquia_cms_common --scope=all
+   * @usage acms:config-reset acquia_cms_article acquia_cms_article acquia_cms_person --scope=all
    * --delete-list=search_api.index.acquia_search_index
    *   Reset the configuration to the default.
+   *
+   * @throws \Drush\Exceptions\UserAbortException
    */
   public function resetConfigurations(array $package, array $options = [
     'scope' => NULL,
@@ -198,39 +200,39 @@ final class AcmsConfigImportCommands extends DrushCommands {
       "This should be used with extreme caution and can lead to unexpected behavior on your site if not well tested.",
       "Do not run this in production until you've tested it in a safe, non-public environment first.",
     ]);
-    // Lets get input from user if not provided package with command.
-    if (empty($package)) {
-      $acms_modules = $this->getAcmsModules();
-      $question_string = 'Choose a module that needs a configuration reset. Separate multiple choices with commas, e.g. "1,2,4".';
-      $question = $this->createMultipleChoiceOptions($question_string, $acms_modules);
-      $types = $this->io()->askQuestion($question);
-      if (in_array('Cancel', $types)) {
-        throw new UserAbortException();
-      }
-      elseif (in_array('All', $types)) {
-        $package = $acms_modules;
-      }
-      else {
-        $package = $types;
-      }
-      // Lets ask for scope if not already provided.
-      if (!$options['scope']) {
-        $scope = $this->io()->choice(dt('Choose a scope.'), self::ALLOWED_SCOPE, NULL);
-        $options['scope'] = self::ALLOWED_SCOPE[$scope];
-      }
-      elseif ($options['scope'] && !in_array($options['scope'], self::ALLOWED_SCOPE)) {
-        throw new \InvalidArgumentException('Invalid scope, allowed values are [config, site-studio, all]');
-      }
-      if (!$options['delete-list']) {
-        $options['delete-list'] = [];
-      }
-    }
-    // Lets import the configurations.
+    // Reset the configurations for given packages aka modules
+    // package, scope & delete-list are being added in validate command.
     $this->doImport($package, $options['scope'], $options['delete-list']);
   }
 
   /**
-   * Get lists of module only.
+   * Get package from user input if not provided already.
+   *
+   * @return array
+   *   The package from user input.
+   *
+   * @throws \Drush\Exceptions\UserAbortException
+   */
+  private function getPackagesFromUserInput(): array {
+    // Lets get input from user if not provided package with command.
+    $acms_modules = $this->getAcmsModules();
+    $question_string = 'Choose a module that needs a configuration reset. Separate multiple choices with commas, e.g. "1,2,4".';
+    $question = $this->createMultipleChoiceOptions($question_string, $acms_modules);
+    $types = $this->io()->askQuestion($question);
+    if (in_array('Cancel', $types)) {
+      throw new UserAbortException();
+    }
+    elseif (in_array('All', $types)) {
+      $package = $acms_modules;
+    }
+    else {
+      $package = $types;
+    }
+    return $package;
+  }
+
+  /**
+   * Get list of Acquia CMS modules.
    *
    * @return array
    *   Array of acms modules.
@@ -260,7 +262,7 @@ final class AcmsConfigImportCommands extends DrushCommands {
    * @return \Symfony\Component\Console\Question\ChoiceQuestion
    *   The ChoiceQuestion
    */
-  private function createMultipleChoiceOptions(string $question_string, array $choice_options, $default = NULL) {
+  private function createMultipleChoiceOptions(string $question_string, array $choice_options, $default = NULL): ChoiceQuestion {
     $choices = array_merge(['Cancel'], $choice_options);
     array_push($choices, 'All');
     $question = new ChoiceQuestion(dt($question_string), $choices, $default);
@@ -300,7 +302,7 @@ final class AcmsConfigImportCommands extends DrushCommands {
         $ss_config_files = array_merge($ss_config_files, $this->getSiteStudioPackage($module));
       }
       // Confirm the site studio changes before import.
-      if ($this->buildSiteStudioChanges($ss_config_files)) {
+      if ($this->buildSiteStudioChangeList($ss_config_files)) {
         if (!$this->io()->confirm(dt('Import these site studio configuration changes?'))) {
           throw new UserAbortException();
         }
@@ -308,13 +310,13 @@ final class AcmsConfigImportCommands extends DrushCommands {
         $this->importSiteStudioPackage($ss_config_files);
       }
       else {
-        $this->io()->success('No site studio package found to import.');
+        $this->io()->success('No site studio package to import.');
       }
     }
   }
 
   /**
-   * Show changes list for site studio packages.
+   * Show change list for site studio packages.
    *
    * @param array $ss_config_files
    *   Array of configurations file.
@@ -322,11 +324,10 @@ final class AcmsConfigImportCommands extends DrushCommands {
    * @return bool
    *   The package status.
    */
-  private function buildSiteStudioChanges(array $ss_config_files): bool {
+  private function buildSiteStudioChangeList(array $ss_config_files): bool {
     if (empty($ss_config_files)) {
       return FALSE;
     }
-
     $rows = [];
     foreach ($ss_config_files as $name) {
       $rows[] = [$name];
@@ -493,12 +494,14 @@ final class AcmsConfigImportCommands extends DrushCommands {
    * Hook validate for acms config reset command.
    *
    * @hook validate acms:config-reset
+   *
+   * @throws \Drush\Exceptions\UserAbortException
    */
   public function validateConfigResetCommand(CommandData $commandData) {
     // Since we are running config import with partial option
     // Lets check config module is enabled or not.
     if (!$this->moduleHandler->moduleExists('config')) {
-      $messages[] = 'Config module is not enabled, please enable it.';
+      return new CommandError('Config module is not enabled, please enable it.');
     }
 
     $messages = [];
@@ -506,11 +509,12 @@ final class AcmsConfigImportCommands extends DrushCommands {
     $scope = $commandData->input()->getOption('scope');
     $delete_list = $commandData->input()->getOption('delete-list');
     $package = $commandData->input()->getArgument('package');
+
     if (isset($scope) && !in_array($scope, self::ALLOWED_SCOPE)) {
       $messages[] = 'Invalid scope, allowed values are [config, site-studio, all]';
     }
     if ($package && !$this->hasValidPackage($package)) {
-      $messages[] = 'Given packages are not valid, try providing a list of ACMS modules ex: acquia_cms_article';
+      $messages[] = 'Given packages are not valid, try providing a list of ACMS modules separated by space ex: acquia_cms_article acquia_cms_place';
     }
     // In case of --delete-list option.
     if ($delete_list) {
@@ -522,10 +526,22 @@ final class AcmsConfigImportCommands extends DrushCommands {
         $commandData->input()->setOption('delete-list', $delete_list_array);
       }
     }
-
+    else {
+      $commandData->input()->setOption('delete-list', []);
+    }
     // In case of -y lets check user has provided all the required arguments.
     if (!$isInteractive && (!$package || !$scope)) {
       $messages[] = 'In order to use -y option, please provide a package and scope variable.';
+    }
+    // Get packages from user input.
+    if ($isInteractive && empty($messages) && !$package) {
+      $package = $this->getPackagesFromUserInput();
+      $commandData->input()->setArgument('package', $package);
+    }
+    // Get scope from user input.
+    if ($isInteractive && empty($messages) && !$scope) {
+      $scope = $this->io()->choice(dt('Choose a scope.'), self::ALLOWED_SCOPE, NULL);
+      $commandData->input()->setOption('scope', self::ALLOWED_SCOPE[$scope]);
     }
     if ($messages) {
       return new CommandError(implode(' ', $messages));
@@ -572,6 +588,33 @@ final class AcmsConfigImportCommands extends DrushCommands {
       }
     }
     return TRUE;
+  }
+
+  /**
+   * Execute site studio rebuild after Acquia CMS config reset.
+   *
+   * @hook post-command acms:config-reset
+   */
+  public function postCommand($result, CommandData $commandData) {
+    $scope = $commandData->input()->getOption('scope');
+    if (in_array($scope, ['site-studio', 'all'])) {
+      // Forcefully clear the cache after site is installed otherwise site
+      // studio fails to rebuild.
+      drupal_flush_all_caches();
+      // Below code ensures that drush batch process doesn't hang. Unset all the
+      // earlier created batches so that drush_backend_batch_process() can run
+      // without being stuck.
+      // @see https://github.com/drush-ops/drush/issues/3773 for the issue.
+      $batch = &batch_get();
+      $batch = NULL;
+      unset($batch);
+      $this->say(dt('Rebuilding all entities.'));
+      $result = DX8CommandHelpers::rebuild([]);
+      // Output results.
+      $this->yell('Finished rebuilding.');
+      // Status code.
+      return is_array($result) && isset(array_shift($result)['error']) ? CommandResult::exitCode(self::EXIT_FAILURE) : CommandResult::exitCode(self::EXIT_SUCCESS);
+    }
   }
 
 }

--- a/modules/acquia_cms_common/src/Services/AcmsUtilityService.php
+++ b/modules/acquia_cms_common/src/Services/AcmsUtilityService.php
@@ -2,6 +2,7 @@
 
 namespace Drupal\acquia_cms_common\Services;
 
+use Drupal\cohesion\Drush\DX8CommandHelpers;
 use Drupal\Core\Config\ConfigFactoryInterface;
 use Drupal\Core\Extension\ModuleHandlerInterface;
 
@@ -45,6 +46,23 @@ class AcmsUtilityService {
     return array_filter($profile_modules, function ($key) {
       return str_starts_with($key, 'acquia_cms');
     }, ARRAY_FILTER_USE_KEY);
+  }
+
+  /**
+   * Trigger site studio rebuild on demand.
+   */
+  public function rebuildSiteStudio() {
+    // Forcefully clear the cache after site is installed otherwise site
+    // studio fails to rebuild.
+    drupal_flush_all_caches();
+    // Below code ensures that drush batch process doesn't hang. Unset all the
+    // earlier created batches so that drush_backend_batch_process() can run
+    // without being stuck.
+    // @see https://github.com/drush-ops/drush/issues/3773 for the issue.
+    $batch = &batch_get();
+    $batch = NULL;
+    unset($batch);
+    return DX8CommandHelpers::rebuild([]);
   }
 
   /**

--- a/modules/acquia_cms_event/config/optional/block.block.events_category.yml
+++ b/modules/acquia_cms_event/config/optional/block.block.events_category.yml
@@ -5,9 +5,13 @@ dependencies:
     - facets.facet.events_category
   module:
     - cohesion
+    - collapsiblock
     - facets
   theme:
     - cohesion_theme
+third_party_settings:
+  collapsiblock:
+    collapse_action: '2'
 id: events_category
 theme: cohesion_theme
 region: dx8_hidden
@@ -18,7 +22,7 @@ settings:
   id: 'facet_block:events_category'
   label: Category
   provider: facets
-  label_display: '0'
+  label_display: visible
   block_id: events_category
 visibility:
   cohesion_master_template:

--- a/modules/acquia_cms_event/config/optional/block.block.events_event_type.yml
+++ b/modules/acquia_cms_event/config/optional/block.block.events_event_type.yml
@@ -5,9 +5,13 @@ dependencies:
     - facets.facet.events_event_type
   module:
     - cohesion
+    - collapsiblock
     - facets
   theme:
     - cohesion_theme
+third_party_settings:
+  collapsiblock:
+    collapse_action: '2'
 id: events_event_type
 theme: cohesion_theme
 region: dx8_hidden
@@ -18,7 +22,7 @@ settings:
   id: 'facet_block:events_event_type'
   label: 'Event Type'
   provider: facets
-  label_display: '0'
+  label_display: visible
   block_id: events_event_type
 visibility:
   cohesion_master_template:

--- a/modules/acquia_cms_event/config/optional/block.block.search_event_type.yml
+++ b/modules/acquia_cms_event/config/optional/block.block.search_event_type.yml
@@ -4,9 +4,14 @@ dependencies:
   config:
     - facets.facet.search_event_type
   module:
+    - cohesion
+    - collapsiblock
     - facets
   theme:
     - cohesion_theme
+third_party_settings:
+  collapsiblock:
+    collapse_action: '2'
 id: search_event_type
 theme: cohesion_theme
 region: dx8_hidden
@@ -17,7 +22,7 @@ settings:
   id: 'facet_block:search_event_type'
   label: 'Event Type'
   provider: facets
-  label_display: '0'
+  label_display: visible
   block_id: search_event_type
 visibility:
   cohesion_master_template:

--- a/modules/acquia_cms_person/config/optional/block.block.people_category.yml
+++ b/modules/acquia_cms_person/config/optional/block.block.people_category.yml
@@ -5,9 +5,13 @@ dependencies:
     - facets.facet.people_category
   module:
     - cohesion
+    - collapsiblock
     - facets
   theme:
     - cohesion_theme
+third_party_settings:
+  collapsiblock:
+    collapse_action: '2'
 id: people_category
 theme: cohesion_theme
 region: dx8_hidden
@@ -18,7 +22,7 @@ settings:
   id: 'facet_block:people_category'
   label: Category
   provider: facets
-  label_display: '0'
+  label_display: visible
   block_id: people_category
 visibility:
   cohesion_master_template:

--- a/modules/acquia_cms_person/config/optional/block.block.people_person_type.yml
+++ b/modules/acquia_cms_person/config/optional/block.block.people_person_type.yml
@@ -5,9 +5,13 @@ dependencies:
     - facets.facet.people_person_type
   module:
     - cohesion
+    - collapsiblock
     - facets
   theme:
     - cohesion_theme
+third_party_settings:
+  collapsiblock:
+    collapse_action: '2'
 id: people_person_type
 theme: cohesion_theme
 region: dx8_hidden
@@ -18,7 +22,7 @@ settings:
   id: 'facet_block:people_person_type'
   label: 'Person Type'
   provider: facets
-  label_display: '0'
+  label_display: visible
   block_id: people_person_type
 visibility:
   cohesion_master_template:

--- a/modules/acquia_cms_person/config/optional/block.block.search_person_type.yml
+++ b/modules/acquia_cms_person/config/optional/block.block.search_person_type.yml
@@ -4,9 +4,14 @@ dependencies:
   config:
     - facets.facet.search_person_type
   module:
+    - cohesion
+    - collapsiblock
     - facets
   theme:
     - cohesion_theme
+third_party_settings:
+  collapsiblock:
+    collapse_action: '2'
 id: search_person_type
 theme: cohesion_theme
 region: dx8_hidden
@@ -17,7 +22,7 @@ settings:
   id: 'facet_block:search_person_type'
   label: 'Person Type'
   provider: facets
-  label_display: '0'
+  label_display: visible
   block_id: search_person_type
 visibility:
   cohesion_master_template:

--- a/modules/acquia_cms_place/config/optional/block.block.places_category.yml
+++ b/modules/acquia_cms_place/config/optional/block.block.places_category.yml
@@ -5,9 +5,13 @@ dependencies:
     - facets.facet.places_category
   module:
     - cohesion
+    - collapsiblock
     - facets
   theme:
     - cohesion_theme
+third_party_settings:
+  collapsiblock:
+    collapse_action: '2'
 id: places_category
 theme: cohesion_theme
 region: dx8_hidden
@@ -18,8 +22,8 @@ settings:
   id: 'facet_block:places_category'
   label: Category
   provider: facets
-  label_display: '0'
-  block_id: places_categories
+  label_display: visible
+  block_id: places_category
 visibility:
   cohesion_master_template:
     id: cohesion_master_template

--- a/modules/acquia_cms_place/config/optional/block.block.places_place_type.yml
+++ b/modules/acquia_cms_place/config/optional/block.block.places_place_type.yml
@@ -5,9 +5,13 @@ dependencies:
     - facets.facet.places_place_type
   module:
     - cohesion
+    - collapsiblock
     - facets
   theme:
     - cohesion_theme
+third_party_settings:
+  collapsiblock:
+    collapse_action: '2'
 id: places_place_type
 theme: cohesion_theme
 region: dx8_hidden
@@ -18,7 +22,7 @@ settings:
   id: 'facet_block:places_place_type'
   label: 'Place Type'
   provider: facets
-  label_display: '0'
+  label_display: visible
   block_id: places_place_type
 visibility:
   cohesion_master_template:

--- a/modules/acquia_cms_place/config/optional/block.block.search_place_type.yml
+++ b/modules/acquia_cms_place/config/optional/block.block.search_place_type.yml
@@ -4,9 +4,14 @@ dependencies:
   config:
     - facets.facet.search_place_type
   module:
+    - cohesion
+    - collapsiblock
     - facets
   theme:
     - cohesion_theme
+third_party_settings:
+  collapsiblock:
+    collapse_action: '2'
 id: search_place_type
 theme: cohesion_theme
 region: dx8_hidden
@@ -17,7 +22,7 @@ settings:
   id: 'facet_block:search_place_type'
   label: 'Place Type'
   provider: facets
-  label_display: '0'
+  label_display: visible
   block_id: search_place_type
 visibility:
   cohesion_master_template:

--- a/modules/acquia_cms_video/config/optional/core.entity_view_display.media.video.default.yml
+++ b/modules/acquia_cms_video/config/optional/core.entity_view_display.media.video.default.yml
@@ -5,7 +5,7 @@ dependencies:
     - field.field.media.video.field_categories
     - field.field.media.video.field_media_oembed_video
     - field.field.media.video.field_tags
-    - image.style.card
+    - image.style.thumbnail
     - media.type.video
   module:
     - image
@@ -18,7 +18,7 @@ content:
   created:
     label: hidden
     type: timestamp
-    weight: 1
+    weight: 0
     region: content
     settings:
       date_format: medium
@@ -27,12 +27,12 @@ content:
     third_party_settings: {  }
   thumbnail:
     type: image
-    weight: 2
-    region: content
+    weight: 5
     label: hidden
     settings:
-      image_style: card
+      image_style: thumbnail
       image_link: ''
+    region: content
     third_party_settings: {  }
   uid:
     label: hidden


### PR DESCRIPTION
**Motivation**
ACMS-702
<!-- What problem does this solve? Why is it important? What's the context? If this fixes an issue, link to it above. -->
Fixes #NNN

**Proposed changes**
<!-- What does this PR change? How does this impact end users? Are manual or automatic updates required? -->
Improvement in drush command 
```
drush acms:config-reset
```

**Testing steps**
<!-- How can we replicate the issue and verify that this PR fixes it? -->
Run `acms:config-reset` drush command with variations and check all are working fine.
Interactive:
```
drush acms:config-reset
drush acms:config-reset acquia_cms_article,acquia_cms_person,acquia_cms_place
drush acms:config-reset acquia_cms_article acquia_cms_person acquia_cms_place --scope=all
```
Non-interactive:
```
drush acms:config-reset acquia_cms_article acquia_cms_person acquia_cms_place --scope=all -y
```
**Merge requirements**
- [ ] _Major change_, _Minor change_, _Bug_, _Enhancement_, and/or _Chore_ label applied
- [x] Manual testing by a reviewer
