### PR TITLE
ACMS-749: Change view mode for image media, to hide timestamp from vi…

### DIFF
--- a/modules/acquia_cms_image/config/install/core.entity_view_display.media.image.default.yml
+++ b/modules/acquia_cms_image/config/install/core.entity_view_display.media.image.default.yml
@@ -1,3 +1,4 @@
+uuid: 7aae5706-2b63-487e-b74f-a00e04e1ad26
 langcode: en
 status: true
 dependencies:
@@ -14,16 +15,6 @@ targetEntityType: media
 bundle: image
 mode: default
 content:
-  created:
-    label: hidden
-    type: timestamp
-    weight: 1
-    region: content
-    settings:
-      date_format: medium
-      custom_date_format: ''
-      timezone: ''
-    third_party_settings: {  }
   thumbnail:
     type: image
     weight: 2
@@ -33,17 +24,12 @@ content:
       image_style: coh_small_square
       image_link: ''
     third_party_settings: {  }
-  uid:
-    label: hidden
-    type: author
-    weight: 0
-    region: content
-    settings: {  }
-    third_party_settings: {  }
 hidden:
+  created: true
   field_categories: true
   field_tags: true
   image: true
   langcode: true
   name: true
   search_api_excerpt: true
+  uid: true


### PR DESCRIPTION
…ew page
https://backlog.acquia.com/browse/ACMS-749

**Motivation**
For anonymous user, user who added image through image component is getting displayed on the top left corner of the image when image size small landscape(568*352) is being selected.

**Proposed changes**
Change view mode for image media, to hide timestamp from view page

 

**Testing steps**
Add a page to ACMS SS , content > page
Add image with image size small landscape(568*352) to layout canvas through image component
Save and Publish the page 
Logout as admin, and try to access the page as anonymous user
Check top left corner of the displayed image, User(admin) and timestamp should not get displayed
This should not get displayed for both anonymous and admin user.
 
