### PR TITLE
ACMS-742: Updated created date for the content listing order to match the reference image.

### DIFF
--- a/modules/acquia_cms_starter/content/node/0098ef73-f5d3-4b91-b376-62e01d6892b3.yml
+++ b/modules/acquia_cms_starter/content/node/0098ef73-f5d3-4b91-b376-62e01d6892b3.yml
@@ -24,7 +24,7 @@ default:
       value: 'Article nine medium length placeholder heading.'
   created:
     -
-      value: 1612538036
+      value: 1612538040
   promote:
     -
       value: true

--- a/modules/acquia_cms_starter/content/node/0ff5fe80-f6d5-471e-a922-990b4037c9e7.yml
+++ b/modules/acquia_cms_starter/content/node/0ff5fe80-f6d5-471e-a922-990b4037c9e7.yml
@@ -23,7 +23,7 @@ default:
       value: 'Article four medium length placeholder heading.'
   created:
     -
-      value: 1612538036
+      value: 1612538039
   promote:
     -
       value: true

--- a/modules/acquia_cms_starter/content/node/167cb9be-e752-419e-a4cc-060abce792a0.yml
+++ b/modules/acquia_cms_starter/content/node/167cb9be-e752-419e-a4cc-060abce792a0.yml
@@ -23,7 +23,7 @@ default:
       value: 'Article two medium length placeholder heading.'
   created:
     -
-      value: 1612538036
+      value: 1612538045
   promote:
     -
       value: true

--- a/modules/acquia_cms_starter/content/node/1fc224b3-849d-43fc-b0c1-cd4d6e1e3fbb.yml
+++ b/modules/acquia_cms_starter/content/node/1fc224b3-849d-43fc-b0c1-cd4d6e1e3fbb.yml
@@ -24,7 +24,7 @@ default:
       value: 'Article eight medium length placeholder heading.'
   created:
     -
-      value: 1612538036
+      value: 1612538050
   promote:
     -
       value: true

--- a/modules/acquia_cms_starter/content/node/2de584f5-f689-400e-b137-4744f2a1f68f.yml
+++ b/modules/acquia_cms_starter/content/node/2de584f5-f689-400e-b137-4744f2a1f68f.yml
@@ -24,7 +24,7 @@ default:
       value: 'Article twelve medium length placeholder heading.'
   created:
     -
-      value: 1612538036
+      value: 1612538041
   promote:
     -
       value: true

--- a/modules/acquia_cms_starter/content/node/6543ad81-8fdb-4852-b842-e665aa1788b6.yml
+++ b/modules/acquia_cms_starter/content/node/6543ad81-8fdb-4852-b842-e665aa1788b6.yml
@@ -23,7 +23,7 @@ default:
       value: 'Article three medium length placeholder heading.'
   created:
     -
-      value: 1612538036
+      value: 1612538047
   promote:
     -
       value: true

--- a/modules/acquia_cms_starter/content/node/8aef96ff-8e68-4d88-b6bd-28ff8a227eb3.yml
+++ b/modules/acquia_cms_starter/content/node/8aef96ff-8e68-4d88-b6bd-28ff8a227eb3.yml
@@ -23,7 +23,7 @@ default:
       value: 'Article eight medium length placeholder heading.'
   created:
     -
-      value: 1612538036
+      value: 1612538046
   promote:
     -
       value: true

--- a/modules/acquia_cms_starter/content/node/8ca3c322-4b7f-43d0-a37d-d883ef9b7e5b.yml
+++ b/modules/acquia_cms_starter/content/node/8ca3c322-4b7f-43d0-a37d-d883ef9b7e5b.yml
@@ -23,7 +23,7 @@ default:
       value: 'Article seven medium length placeholder heading.'
   created:
     -
-      value: 1612538036
+      value: 1612538038
   promote:
     -
       value: true

--- a/modules/acquia_cms_starter/content/node/922a4cef-f334-4e0b-87f8-7b31da9393bc.yml
+++ b/modules/acquia_cms_starter/content/node/922a4cef-f334-4e0b-87f8-7b31da9393bc.yml
@@ -23,7 +23,7 @@ default:
       value: 'Article five medium length placeholder heading.'
   created:
     -
-      value: 1612538036
+      value: 1612538043
   promote:
     -
       value: true

--- a/modules/acquia_cms_starter/content/node/96b0a01f-6d06-46ef-959c-8d96343c88a8.yml
+++ b/modules/acquia_cms_starter/content/node/96b0a01f-6d06-46ef-959c-8d96343c88a8.yml
@@ -23,7 +23,7 @@ default:
       value: 'Article one long length wrapping placeholder heading.'
   created:
     -
-      value: 1612538036
+      value: 1612538037
   promote:
     -
       value: true

--- a/modules/acquia_cms_starter/content/node/a0fc7bd8-f7dd-4468-bc77-d154c374c686.yml
+++ b/modules/acquia_cms_starter/content/node/a0fc7bd8-f7dd-4468-bc77-d154c374c686.yml
@@ -24,7 +24,7 @@ default:
       value: 'Article eleven medium length placeholder heading.'
   created:
     -
-      value: 1612538036
+      value: 1612538051
   promote:
     -
       value: true

--- a/modules/acquia_cms_starter/content/node/a1eafd08-eaec-4f57-be82-e93c81be9d62.yml
+++ b/modules/acquia_cms_starter/content/node/a1eafd08-eaec-4f57-be82-e93c81be9d62.yml
@@ -23,7 +23,7 @@ default:
       value: 'Article six medium length placeholder heading.'
   created:
     -
-      value: 1612538036
+      value: 1612538049
   promote:
     -
       value: true

--- a/modules/acquia_cms_starter/content/node/af87f256-f648-48d5-be0d-7e0e0616331a.yml
+++ b/modules/acquia_cms_starter/content/node/af87f256-f648-48d5-be0d-7e0e0616331a.yml
@@ -24,7 +24,7 @@ default:
       value: 'Article thirteen medium length placeholder heading.'
   created:
     -
-      value: 1612538036
+      value: 1612538048
   promote:
     -
       value: true

--- a/modules/acquia_cms_starter/content/node/e213202d-56f1-4e72-862c-e55d9ca19afe.yml
+++ b/modules/acquia_cms_starter/content/node/e213202d-56f1-4e72-862c-e55d9ca19afe.yml
@@ -24,7 +24,7 @@ default:
       value: 'Article fourteen medium length placeholder heading.'
   created:
     -
-      value: 1612538036
+      value: 1612538044
   promote:
     -
       value: true

--- a/modules/acquia_cms_starter/content/node/f01ed833-ec04-41d9-967c-45b04c6e3b12.yml
+++ b/modules/acquia_cms_starter/content/node/f01ed833-ec04-41d9-967c-45b04c6e3b12.yml
@@ -24,7 +24,7 @@ default:
       value: 'Article ten medium length placeholder heading.'
   created:
     -
-      value: 1612538036
+      value: 1612538052
   promote:
     -
       value: true

--- a/modules/acquia_cms_starter/content/node/f4b3eb8e-234a-4788-9ba7-6e8838b362d2.yml
+++ b/modules/acquia_cms_starter/content/node/f4b3eb8e-234a-4788-9ba7-6e8838b362d2.yml
@@ -24,7 +24,7 @@ default:
       value: 'Article eight medium length placeholder heading.'
   created:
     -
-      value: 1612538036
+      value: 1612538042
   promote:
     -
       value: true


### PR DESCRIPTION
**Motivation**
Updated the created date to list the content in order that matches the reference image for backstop for artifacts to pass.
Fixes #742

**Proposed changes**
Updated the created date to list the content in order that matches the reference image for backstop for artifacts to pass.

**Alternatives considered**
We cannot update the reference image hence considered the change in creation date to duplicate the order as per the reference image.

**Testing steps**
To test, create artifacts from Cloud IDE following this document - https://github.com/acquia/acquia_cms/wiki/Test-Artifact-Creation, once artifacts are created and committed, notice that the travis job does not return any error related to the following file - backstop_default_ACMS_Articles_Starter_0_document_0_mobile.png (attaching screenshot below for ideal scenario)

Refer following link for better understanding - https://travis-ci.com/github/acquia/acquia_cms/jobs/502579853

**Merge requirements**
- [*] _Major change_
- [*] Manual testing by a reviewer

<img width="1230" alt="Screenshot 2021-05-03 at 6 34 54 PM 1" src="https://user-images.githubusercontent.com/15887127/116880814-124f3f80-ac40-11eb-8811-81838774cae7.png">
