### PR TITLE
ACMS-763: Acquia CMS errors out in CloudIDE

### DIFF
--- a/patches/d9-acms-settings.patch
+++ b/patches/d9-acms-settings.patch
@@ -27,7 +27,10 @@ if (AcquiaDrupalEnvironmentDetector::isAhEnv()) {
       ],
     ];
     $databases = array_merge_recursive($databases, $default_settings);
-    acquia_hosting_db_choose_active();
+    // Only call this function on the cloud, not on a local environment.
+    if (function_exists(acquia_hosting_db_choose_active) {
+      acquia_hosting_db_choose_active();
+    }
   }
 }
 


### PR DESCRIPTION
https://backlog.acquia.com/browse/ACMS-763
**Motivation**
Acquia CMS errors out in CloudIDE
**Proposed changes**
Check that function exists in patches/d9-acms-settings.patch:

   // Only call this function on the cloud, not on a local environment.
    if (function_exists(acquia_hosting_db_choose_active) {
      acquia_hosting_db_choose_active();
    } 
 

**Testing steps**
 Following the installation steps for Acquia CMS from: https://docs.acquia.com/acquia-cms/install-acquia-cms/ -> https://github.com/acquia/acquia-cms-project should work in the Cloud IDE, and local. 

 
