### PR TITLE
ACMS-772: Update all Acquia CMS modules name to have prefix "Acquia CMS"

### DIFF
--- a/modules/acquia_cms_article/acquia_cms_article.info.yml
+++ b/modules/acquia_cms_article/acquia_cms_article.info.yml
@@ -1,4 +1,4 @@
-name: "Article"
+name: "Acquia CMS Article"
 package: "Acquia CMS"
 description: "Provides an Article content type and related configuration."
 type: module

--- a/modules/acquia_cms_audio/acquia_cms_audio.info.yml
+++ b/modules/acquia_cms_audio/acquia_cms_audio.info.yml
@@ -1,4 +1,4 @@
-name: "Audio"
+name: "Acquia CMS Audio"
 package: "Acquia CMS"
 description: "Provides an Audio media type and related configuration."
 type: module

--- a/modules/acquia_cms_common/acquia_cms_common.info.yml
+++ b/modules/acquia_cms_common/acquia_cms_common.info.yml
@@ -1,4 +1,4 @@
-name: "Common Functionality"
+name: "Acquia CMS Common"
 package: "Acquia CMS"
 description: "Handles shared functionality for Acquia CMS."
 type: module

--- a/modules/acquia_cms_document/acquia_cms_document.info.yml
+++ b/modules/acquia_cms_document/acquia_cms_document.info.yml
@@ -1,4 +1,4 @@
-name: "Document"
+name: "Acquia CMS Document"
 package: "Acquia CMS"
 description: "Provides a Document media type and related configuration."
 type: module

--- a/modules/acquia_cms_event/acquia_cms_event.info.yml
+++ b/modules/acquia_cms_event/acquia_cms_event.info.yml
@@ -1,4 +1,4 @@
-name: Event
+name: "Acquia CMS Event"
 package: 'Acquia CMS'
 description: 'Provides an Event content type and related configuration.'
 type: module

--- a/modules/acquia_cms_image/acquia_cms_image.info.yml
+++ b/modules/acquia_cms_image/acquia_cms_image.info.yml
@@ -1,4 +1,4 @@
-name: "Image"
+name: "Acquia CMS Image"
 package: "Acquia CMS"
 description: "Provides an Image media type and related configuration."
 type: module

--- a/modules/acquia_cms_page/acquia_cms_page.info.yml
+++ b/modules/acquia_cms_page/acquia_cms_page.info.yml
@@ -1,4 +1,4 @@
-name: "Page"
+name: "Acquia CMS Page"
 package: "Acquia CMS"
 description: "Provides an unstructured Page content type and related configuration."
 type: module

--- a/modules/acquia_cms_person/acquia_cms_person.info.yml
+++ b/modules/acquia_cms_person/acquia_cms_person.info.yml
@@ -1,4 +1,4 @@
-name: Person
+name: "Acquia CMS Person"
 package: 'Acquia CMS'
 description: 'Provides a Person content type, a structured data representation of people associated with a website or organization.'
 type: module

--- a/modules/acquia_cms_place/acquia_cms_place.info.yml
+++ b/modules/acquia_cms_place/acquia_cms_place.info.yml
@@ -1,4 +1,4 @@
-name: Place
+name: "Acquia CMS Place"
 package: 'Acquia CMS'
 description: 'Provides a Place content type and related configuration.'
 type: module

--- a/modules/acquia_cms_search/acquia_cms_search.info.yml
+++ b/modules/acquia_cms_search/acquia_cms_search.info.yml
@@ -1,4 +1,4 @@
-name: "Search"
+name: "Acquia CMS Search"
 package: "Acquia CMS"
 description: "Provides powerful search capabilities to the site"
 type: module

--- a/modules/acquia_cms_toolbar/acquia_cms_toolbar.info.yml
+++ b/modules/acquia_cms_toolbar/acquia_cms_toolbar.info.yml
@@ -1,4 +1,4 @@
-name: "Toolbar"
+name: "Acquia CMS Toolbar"
 core_version_requirement: ^9
 description: "Acquia CMS styling brought to admin toolbar."
 package: "Acquia CMS"

--- a/modules/acquia_cms_tour/acquia_cms_tour.info.yml
+++ b/modules/acquia_cms_tour/acquia_cms_tour.info.yml
@@ -1,4 +1,4 @@
-name: "Acquia Tour"
+name: "Acquia CMS Tour"
 package: "Acquia CMS"
 description: "Provides a tour page for Acquia CMS."
 type: module

--- a/modules/acquia_cms_video/acquia_cms_video.info.yml
+++ b/modules/acquia_cms_video/acquia_cms_video.info.yml
@@ -1,4 +1,4 @@
-name: "Video"
+name: "Acquia CMS Video"
 package: "Acquia CMS"
 description: "Provides a Video media type and related configuration."
 type: module


### PR DESCRIPTION
**Motivation**
<!-- What problem does this solve? Why is it important? What's the context? If this fixes an issue, link to it above. -->
Fixes #[ACMS-772](https://backlog.acquia.com/browse/ACMS-772)

**Proposed changes**
<!-- What does this PR change? How does this impact end users? Are manual or automatic updates required? -->
Update module's name in info file

**Testing steps**
<!-- How can we replicate the issue and verify that this PR fixes it? -->
Visit extend page and verify all acms module name should have prefix "Acquia CMS"

**Merge requirements**
- [ ] _Major change_, _Minor change_, _Bug_, _Enhancement_, and/or _Chore_ label applied
- [ ] Manual testing by a reviewer
