### PR TITLE
ACMS-750: Added check to bail out w/ error if user is running Compose…

### DIFF
--- a/install-acms
+++ b/install-acms
@@ -17,6 +17,13 @@ validate_email () {
 }
 
 printf "${CYAN}### Welcome to Acquia CMS! ###${NC}\n"
+COMPOSER=$(composer -V)
+VERSION="Composer version 1"
+printf "${CYAN}Composer version:${NC} $COMPOSER\n"
+if grep -q "$VERSION" <<< "$COMPOSER"; then
+    printf "${YELLOW}This script requires Composer version 2 or later. Go here for instructions to install: https://getcomposer.org${NC}\n";
+    exit 0;
+fi
 printf "Please enter the username for your administrator account [${GREEN}admin${NC}]: "
 DEFAULT_NAME="admin"
 read ADMIN_NAME


### PR DESCRIPTION
…r 1.

**Motivation**
Fixes ACMS-750.

**Proposed changes**
Forces user to have Composer 2 installed if using acms:install Composer script.

**Alternatives considered**
Composer 1 doesn't like the `read` command for inputs when running bash scripts, Composer 2 addresses this.

**Testing steps**
* Download the latest Composer 1 release from https://getcomposer.org
* Rename `composer.phar` to `composer1` and give it write permissions. Move it to the same folder where your current composer install lives (run `which composer` for folder location).
* Manually edit line 20 in install-acms to use your `composer1` executable.
* Validate the error message appears and the script exits.
* Manually edit line 20 to just use `composer` and validate the script proceeds as expected.

**Merge requirements**
- [ ] Manual testing by a reviewer
