### PR TITLE
ACMS-780: Rebuilds should be skipped during non-interactive install.

### DIFF
--- a/acquia_cms.profile
+++ b/acquia_cms.profile
@@ -168,8 +168,11 @@ function acquia_cms_install_ui_kit(array $install_state) {
   /** @var \Drupal\acquia_cms\Facade\CohesionFacade $facade */
   $facade = Drupal::classResolver(CohesionFacade::class);
 
-  // Interactive state means the site install is happening in the browser.
-  $operations = ($install_state['interactive']) ? $facade->getAllOperations() : $facade->getAllOperations(TRUE);
+  // Site studio will rebuild packages (fetch HTML/CSS via the API) by default
+  // on import. Passing this bool as TRUE will skip the rebuild, since we force
+  // a total rebuild at the end. This cuts install times approximately in half,
+  // especially via Drush.
+  $operations = $facade->getAllOperations(TRUE);
   $batch = ['operations' => $operations];
 
   // Set batch along with drush backend process if site is being

--- a/acquia_cms.profile
+++ b/acquia_cms.profile
@@ -168,7 +168,8 @@ function acquia_cms_install_ui_kit(array $install_state) {
   /** @var \Drupal\acquia_cms\Facade\CohesionFacade $facade */
   $facade = Drupal::classResolver(CohesionFacade::class);
 
-  $operations = ($install_state['interactive']) ? $facade->getAllOperations(TRUE) : $facade->getAllOperations();
+  // Interactive state means the site install is happening in the browser.
+  $operations = ($install_state['interactive']) ? $facade->getAllOperations() : $facade->getAllOperations(TRUE);
   $batch = ['operations' => $operations];
 
   // Set batch along with drush backend process if site is being


### PR DESCRIPTION
**Motivation**
Improves drush-based site install time significantly.

**Proposed changes**
We had this logic backwards. Rebuilds should be skipped on _non-interactive_ installs (e.g., drush).

**Testing steps**
Run a drush based site install of ACMS.

**Merge requirements**
- [ ] _Major change_, _Minor change_, _Bug_, _Enhancement_, and/or _Chore_ label applied
- [ ] Manual testing by a reviewer
