### PR TITLE
ACMS-783: version constraint updated to allow run tests on drupal core 9.2.x

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -36,7 +36,7 @@
         "drupal/collapsiblock": "^3",
         "drupal/config_ignore": "^2.3",
         "drupal/config_rewrite": "1.3",
-        "drupal/core": "~9.1.9",
+        "drupal/core": "^9.1.9",
         "drupal/default_content": "^2",
         "drupal/diff": "^1",
         "drupal/entity_clone": "1.0-beta4",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "a5231320249960e72f0d25e3bfdc41b4",
+    "content-hash": "c5256d276ef29ea580a06afb0c860df5",
     "packages": [
         {
             "name": "acquia/acsf-contenthub-console",


### PR DESCRIPTION
Drupal 9 core version constraints changed from `~9.1.9` to `^9.1.9`  so that our project runs on drupal core 9.2.x and our existing isolate tests gets executed and passed.