### PR TITLE
ACMS-760: Added code for displaying the tooltip beside Advance button.

### DIFF
--- a/modules/acquia_cms_tour/css/acquia_cms_tour_dashboard.css
+++ b/modules/acquia_cms_tour/css/acquia_cms_tour_dashboard.css
@@ -67,9 +67,36 @@
   flex-direction: column;
 }
 .dashboard-buttons-wrapper a {
-  padding-left: 10px;
+  margin-left: 2px;
 }
-
+.dashboard-buttons-wrapper .tooltip {
+  position: absolute;
+  visibility: hidden;
+  width: 200px;
+  background-color: black;
+  color: white;
+  text-align: center;
+  border-radius: 6px;
+  padding: 5px 0;
+  z-index: 1;
+}
+.tool-tip__icon:hover + .tooltip {
+  visibility: visible;
+  right: 4%;
+  margin-top: 25px;
+}
+.dashboard-buttons-wrapper .tool-tip__icon {
+  background: #27b1f0;
+  border-radius: 10px;
+  cursor: pointer;
+  display: inline-block;
+  height: 20px;
+  line-height: 1.3em;
+  text-align: center;
+  width: 20px;
+  margin-left: 5px;
+  color: white;
+}
 .acms-dashboard-form-wrapper .claro-details__summary[aria-expanded='true'] {
   border-bottom: 1px solid #808080;
 }

--- a/modules/acquia_cms_tour/src/Form/AcquiaConnectorForm.php
+++ b/modules/acquia_cms_tour/src/Form/AcquiaConnectorForm.php
@@ -77,11 +77,21 @@ final class AcquiaConnectorForm extends AcquiaCMSDashboardBase {
       ];
       if (isset($module_info['configure'])) {
         $form[$module]['actions']['advanced'] = [
+          '#prefix' => '<div class= "dashboard-tooltiptext">',
           '#markup' => $this->linkGenerator->generate(
             'Advanced',
             Url::fromRoute($module_info['configure'])
           ),
-          '#suffix' => "</div>",
+          '#suffix' => '</div>',
+        ];
+        $form[$module]['actions']['advanced']['information'] = [
+          '#prefix' => '<b class= "tool-tip__icon">i',
+          '#suffix' => "</b>",
+        ];
+        $form[$module]['actions']['advanced']['tooltip-text'] = [
+          '#prefix' => '<span class= "tooltip">',
+          '#markup' => $this->t("Opens Advance Configuration in new tab"),
+          '#suffix' => "</span></div>",
         ];
       }
 

--- a/modules/acquia_cms_tour/src/Form/AcquiaGoogleMapsApiDashboardForm.php
+++ b/modules/acquia_cms_tour/src/Form/AcquiaGoogleMapsApiDashboardForm.php
@@ -111,11 +111,21 @@ final class AcquiaGoogleMapsApiDashboardForm extends AcquiaCMSDashboardBase {
         '#submit' => ['::ignoreConfig'],
       ];
       $form[$module]['actions']['advanced'] = [
+        '#prefix' => '<div class= "dashboard-tooltiptext">',
         '#markup' => $this->linkGenerator->generate(
           'Advanced',
           Url::fromRoute('entity.geocoder_provider.collection')
         ),
         '#suffix' => "</div>",
+      ];
+      $form[$module]['actions']['advanced']['information'] = [
+        '#prefix' => '<b class= "tool-tip__icon">i',
+        '#suffix' => "</b>",
+      ];
+      $form[$module]['actions']['advanced']['tooltip-text'] = [
+        '#prefix' => '<span class= "tooltip">',
+        '#markup' => $this->t("Opens Advance Configuration in new tab"),
+        '#suffix' => "</span></div>",
       ];
 
       return $form;

--- a/modules/acquia_cms_tour/src/Form/AcquiaSearchForm.php
+++ b/modules/acquia_cms_tour/src/Form/AcquiaSearchForm.php
@@ -96,11 +96,21 @@ final class AcquiaSearchForm extends AcquiaCMSDashboardBase {
         '#submit' => ['::ignoreConfig'],
       ];
       $form[$module]['actions']['advanced'] = [
+        '#prefix' => '<div class= "dashboard-tooltiptext">',
         '#markup' => $this->linkGenerator->generate(
           'Advanced',
           Url::fromRoute('entity.search_api_server.edit_form', ['search_api_server' => 'acquia_search_server'])
         ),
         '#suffix' => "</div>",
+      ];
+      $form[$module]['actions']['advanced']['information'] = [
+        '#prefix' => '<b class= "tool-tip__icon">i',
+        '#suffix' => "</b>",
+      ];
+      $form[$module]['actions']['advanced']['tooltip-text'] = [
+        '#prefix' => '<span class= "tooltip">',
+        '#markup' => $this->t("Opens Advance Configuration in new tab"),
+        '#suffix' => "</span></div>",
       ];
       return $form;
     }

--- a/modules/acquia_cms_tour/src/Form/AcquiaTelemetryForm.php
+++ b/modules/acquia_cms_tour/src/Form/AcquiaTelemetryForm.php
@@ -94,11 +94,21 @@ final class AcquiaTelemetryForm extends AcquiaCMSDashboardBase {
     ];
     if (isset($module_info['configure'])) {
       $form[$module]['actions']['advanced'] = [
+        '#prefix' => '<div class= "dashboard-tooltiptext">',
         '#markup' => $this->linkGenerator->generate(
           'Advanced',
           Url::fromRoute($module_info['configure'])
         ),
         '#suffix' => "</div>",
+      ];
+      $form[$module]['actions']['advanced']['information'] = [
+        '#prefix' => '<b class= "tool-tip__icon">i',
+        '#suffix' => "</b>",
+      ];
+      $form[$module]['actions']['advanced']['tooltip-text'] = [
+        '#prefix' => '<span class= "tooltip">',
+        '#markup' => $this->t("Opens Advance Configuration in new tab"),
+        '#suffix' => "</span></div>",
       ];
     }
     return $form;

--- a/modules/acquia_cms_tour/src/Form/GoogleAnalyticsForm.php
+++ b/modules/acquia_cms_tour/src/Form/GoogleAnalyticsForm.php
@@ -79,11 +79,21 @@ final class GoogleAnalyticsForm extends AcquiaCMSDashboardBase {
       ];
       if (isset($module_info['configure'])) {
         $form[$module]['actions']['advanced'] = [
+          '#prefix' => '<div class= "dashboard-tooltiptext">',
           '#markup' => $this->linkGenerator->generate(
             'Advanced',
             Url::fromRoute($module_info['configure'])
           ),
           '#suffix' => "</div>",
+        ];
+        $form[$module]['actions']['advanced']['information'] = [
+          '#prefix' => '<b class= "tool-tip__icon">i',
+          '#suffix' => "</b>",
+        ];
+        $form[$module]['actions']['advanced']['tooltip-text'] = [
+          '#prefix' => '<span class= "tooltip">',
+          '#markup' => $this->t("Opens Advance Configuration in new tab"),
+          '#suffix' => "</span></div>",
         ];
       }
       return $form;

--- a/modules/acquia_cms_tour/src/Form/GoogleTagManagerForm.php
+++ b/modules/acquia_cms_tour/src/Form/GoogleTagManagerForm.php
@@ -77,11 +77,21 @@ final class GoogleTagManagerForm extends AcquiaCMSDashboardBase {
       ];
       if (isset($module_info['configure'])) {
         $form[$module]['actions']['advanced'] = [
+          '#prefix' => '<div class= "dashboard-tooltiptext">',
           '#markup' => $this->linkGenerator->generate(
             'Advanced',
             Url::fromRoute($module_info['configure'])
           ),
           '#suffix' => "</div>",
+        ];
+        $form[$module]['actions']['advanced']['information'] = [
+          '#prefix' => '<b class= "tool-tip__icon">i',
+          '#suffix' => "</b>",
+        ];
+        $form[$module]['actions']['advanced']['tooltip-text'] = [
+          '#prefix' => '<span class= "tooltip">',
+          '#markup' => $this->t("Opens Advance Configuration in new tab"),
+          '#suffix' => "</span></div>",
         ];
       }
     }

--- a/modules/acquia_cms_tour/src/Form/RecaptchaForm.php
+++ b/modules/acquia_cms_tour/src/Form/RecaptchaForm.php
@@ -85,11 +85,21 @@ final class RecaptchaForm extends AcquiaCMSDashboardBase {
       ];
       if (isset($module_info['configure'])) {
         $form[$module]['actions']['advanced'] = [
+          '#prefix' => '<div class= "dashboard-tooltiptext">',
           '#markup' => $this->linkGenerator->generate(
             'Advanced',
             Url::fromRoute($module_info['configure'])
           ),
           '#suffix' => "</div>",
+        ];
+        $form[$module]['actions']['advanced']['information'] = [
+          '#prefix' => '<b class= "tool-tip__icon">i',
+          '#suffix' => "</b>",
+        ];
+        $form[$module]['actions']['advanced']['tooltip-text'] = [
+          '#prefix' => '<span class= "tooltip">',
+          '#markup' => $this->t("Opens Advance Configuration in new tab"),
+          '#suffix' => "</span></div>",
         ];
       }
     }

--- a/modules/acquia_cms_tour/src/Form/SiteStudioCoreForm.php
+++ b/modules/acquia_cms_tour/src/Form/SiteStudioCoreForm.php
@@ -85,11 +85,21 @@ final class SiteStudioCoreForm extends AcquiaCMSDashboardBase {
         '#submit' => ['::ignoreConfig'],
       ];
       $form[$module]['actions']['advanced'] = [
+        '#prefix' => '<div class= "dashboard-tooltiptext">',
         '#markup' => $this->linkGenerator->generate(
             'Advanced',
             Url::fromRoute('cohesion.configuration.account_settings')
         ),
         '#suffix' => "</div>",
+      ];
+      $form[$module]['actions']['advanced']['information'] = [
+        '#prefix' => '<b class= "tool-tip__icon">i',
+        '#suffix' => "</b>",
+      ];
+      $form[$module]['actions']['advanced']['tooltip-text'] = [
+        '#prefix' => '<span class= "tooltip">',
+        '#markup' => $this->t("Opens Advance Configuration in new tab"),
+        '#suffix' => "</span></div>",
       ];
 
       return $form;


### PR DESCRIPTION
**Motivation**
* There should be a description beside the Advance button on Admin tour dashboard page.
Fixes #ACMS-760

**Proposed changes**
* Add an "i" button beside the Advance link to show the description of what Advance does.
* The button shows information on hover/click.

**Alternatives considered**
* NONE

**Testing steps**
* To test, head towards /admin/tour/dashboard and notice that there are different form tabs
* Open a form tab and notice the "i" button beside Advance link (check screenshot)
* Hover over the "i" button to see the tooltip getting displayed.

**Merge requirements**
- [ ] _Major change_, _Minor change_, _Bug_, _Enhancement_, and/or _Chore_ label applied
- [ ] Manual testing by a reviewer

**Screenshot Attached**
![Screenshot 2021-05-28 at 7 58 56 PM](https://user-images.githubusercontent.com/15887127/120001411-622be700-bff1-11eb-9ce7-95f46465fdf2.png)

