### PR TITLE
ACMS-768: Added code for logging time for install rebuild start & end.

### DIFF
--- a/src/Commands/SiteInstallCommands.php
+++ b/src/Commands/SiteInstallCommands.php
@@ -4,6 +4,7 @@ namespace Drush\Commands;
 
 use Consolidation\AnnotatedCommand\CommandData;
 use Consolidation\AnnotatedCommand\CommandResult;
+use Drupal\Core\Datetime\DrupalDateTime;
 
 /**
  * Rebuild site studio when site is installed via drush.
@@ -19,11 +20,28 @@ class SiteInstallCommands extends DrushCommands {
     $arguments = $commandData->arguments();
     $moduleHandler = \Drupal::service('module_handler');
     if (isset($arguments['profile'][0]) && $arguments['profile'][0] == 'acquia_cms' && $moduleHandler->moduleExists('cohesion')) {
+      $rebuild_start_time = new DrupalDateTime();
+      $formatted = \Drupal::service('date.formatter')->format(
+        $rebuild_start_time->getTimestamp(), 'custom', 'Y-m-d h:i:s'
+      );
+      \Drupal::state()->set('rebuild_start_time', $formatted);
       $this->say(dt('Rebuilding all entities.'));
       $result = \Drupal::service('acquia_cms_common.utility')->rebuildSiteStudio();
       $this->yell('Finished rebuilding.');
+      $this->setFinishedTime();
       return is_array($result) && isset(array_shift($result)['error']) ? CommandResult::exitCode(self::EXIT_FAILURE) : CommandResult::exitCode(self::EXIT_SUCCESS);
     }
+  }
+
+  /**
+   * Set site studio rebuild time once rebuild has completed.
+   */
+  public function setFinishedTime() {
+    $rebuild_end_time = new DrupalDateTime();
+    $formatted = \Drupal::service('date.formatter')->format(
+      $rebuild_end_time->getTimestamp(), 'custom', 'Y-m-d h:i:s'
+    );
+    \Drupal::state()->set('rebuild_end_time', $formatted);
   }
 
 }


### PR DESCRIPTION
**Motivation**
* We need to calculate and send the install & rebuild start and end time to acquia telemetry
Fixes #ACMS-768

**Proposed changes**
* Add the install start time and end time and rebuild start time and end time and calculate the difference between the two & send to acquia telemetry via heartbeat_event in acquia_cms.profile

**Alternatives considered**
* None

**Testing steps**
<Pending>

**Merge requirements**
- [ ] _Major change_, _Minor change_, _Bug_, _Enhancement_, and/or _Chore_ label applied
- [ ] Manual testing by a reviewer
