### PR TITLE
ACMS-810: Fix Content Hub UI broken and blank in ACMS

### DIFF
--- a/modules/acquia_cms_toolbar/acquia_cms_toolbar.module
+++ b/modules/acquia_cms_toolbar/acquia_cms_toolbar.module
@@ -20,10 +20,13 @@ function acquia_cms_toolbar_preprocess_html(array &$variables) {
 /**
  * Implements hook_preprocess_HOOK() for page.
  */
-function acquia_cms_common_preprocess_page(&$variables) {
-  // Check if user has access to admin toolbar.
-  $toolbar_access = \Drupal::currentUser()->hasPermission('access toolbar') ? \Drupal::currentUser()->hasPermission('access toolbar') : FALSE;
-  if ($toolbar_access) {
+function acquia_cms_toolbar_preprocess_page(&$variables) {
+  $toolbar_access = \Drupal::currentUser()->hasPermission('access toolbar') ?? FALSE;
+  $route = \Drupal::routeMatch()->getRouteObject();
+  $is_admin_route = \Drupal::service('router.admin_context')->isAdminRoute($route);
+
+  // Check if user has access to admin toolbar and its not admin route.
+  if ($toolbar_access && !$is_admin_route) {
     // Attach toolbar styles library on all pages.
     $variables['#attached']['library'][] = 'acquia_cms_toolbar/toolbar_styles';
   }

--- a/modules/acquia_cms_toolbar/js/acms_toolbar.js
+++ b/modules/acquia_cms_toolbar/js/acms_toolbar.js
@@ -9,6 +9,7 @@
     // Avoid main menu's overlapping with admin toolbar.
     // Spacing from top should be equal to the height of admin toolbar.
     // JS code only gets applied when user is logged in and has access to admin toolbar.
+    // This was causing contentHub UI issue, hence added only for non-admin route.
     attach(context) {
       function adjustTopPadding() {
         // Since toolbar-icon-menu was adding its own js,
@@ -17,7 +18,7 @@
         var new_height = body_padding_top.replace('px', '') - 5;
         // Js should not be applied for desktop.
         if ($(window).width() < 768) {
-          $('body').css('margin-top', $('#toolbar-bar').height()- new_height);
+          $('body').css('margin-top', $('#toolbar-bar').height() - new_height);
         }
       }
       window.onload = adjustTopPadding;


### PR DESCRIPTION
**Motivation**
<!-- What problem does this solve? Why is it important? What's the context? If this fixes an issue, link to it above. -->
Fixes #[ACMS-810](https://backlog.acquia.com/browse/ACMS-810)

**Testing steps**
<!-- How can we replicate the issue and verify that this PR fixes it? -->

- Install acquia cms and configure content hub.
-  Visit admin/content/acquia-contenthub and make sure you can see content hub interface.

**Merge requirements**
- [x] _Major change_, _Minor change_, _Bug_, _Enhancement_, and/or _Chore_ label applied
- [x] Manual testing by a reviewer
