### PR TITLE
ACMS-814: Changed the view title from none to node for frontpage view.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -160,6 +160,7 @@
                 "Make config_rewrite/tests/modules compatible with Drupal 9": "https://www.drupal.org/files/issues/2020-08-22/3166694-2.patch"
             },
             "drupal/core": {
+                "Frontpage View Title for breadcrumb trail": "https://www.drupal.org/files/issues/2021-06-28/core_views_frontview_view_title.patch",
                 "It is possible to overflow the number of items allowed in Media Library": "https://www.drupal.org/files/issues/2019-12-28/3082690-80.patch",
                 "Media Library widget produces error this value should not be null when field is required": "https://www.drupal.org/files/issues/2020-10-08/3160238-25.patch",
                 "SQLite database locking errors cause fatal errors": "https://www.drupal.org/files/issues/1120020-59.patch"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "62e9d8b0c78f7c901442295989c5459a",
+    "content-hash": "fed52e5cb470bf2de0d9850d3c56cdcd",
     "packages": [
         {
             "name": "acquia/acsf-contenthub-console",
@@ -3780,7 +3780,7 @@
             "extra": {
                 "drupal": {
                     "version": "8.x-3.6",
-                    "datestamp": "1620838181",
+                    "datestamp": "1623860918",
                     "security-coverage": {
                         "status": "covered",
                         "message": "Covered by Drupal's security advisory policy"
@@ -18930,5 +18930,5 @@
     "prefer-lowest": false,
     "platform": [],
     "platform-dev": [],
-    "plugin-api-version": "2.1.0"
+    "plugin-api-version": "2.0.0"
 }


### PR DESCRIPTION
**Motivation**
* The breadcrumb shows an empty space in between "Home" & "Add Content" on node add pages.
Fixes #ACMS-814

**Proposed changes**
* As per the latest release (9.2.0) following issue was created : https://www.drupal.org/node/2716019
* The changes made to the Drupal Core are in the patch : https://www.drupal.org/files/issues/2021-04-22/2716019-156.patch
* As per the comment here: https://www.drupal.org/project/drupal/issues/2716019#comment-14069261 the breadcrumb will now pick up the title from "View" itself. 
* Hence, in our case "None" was resulting in an empty space. After changing this to "Node" the issue is now fixed.
* Created the patch for core and added it in composer json file.

**Alternatives considered**
* None

**Testing steps**
* Head towards : node/add/article or any other node add page and notice that now the breadcrumb has the "Node" link added in between "Home" & "Add Content" (attaching screenshot below for reference)
<img width="561" alt="Screenshot 2021-06-21 at 8 01 49 AM" src="https://user-images.githubusercontent.com/15887127/122699394-f55de280-d266-11eb-942e-6fbe61afbd2f.png">

**Merge requirements**
- [ ] _Major change_, _Minor change_, _Bug_, _Enhancement_, and/or _Chore_ label applied
- [ ] Manual testing by a reviewer
