### PR TITLE
ACMS-834: Site install using UI gives 403 on finish, due to update co…

### DIFF
--- a/acquia_cms.profile
+++ b/acquia_cms.profile
@@ -38,7 +38,6 @@ function acquia_cms_install_tasks_alter(array &$tasks) {
   // This code helps capture time right when the drupal bootstrap happens.
   // The pre start function calls another method that performs the actual logic.
   $tasks['install_bootstrap_full']['function'] = 'acquia_cms_pre_start';
-  $tasks['install_finished']['function'] = 'acquia_cms_install_ui_kit_finished';
 }
 
 /**

--- a/src/Form/SiteConfigureForm.php
+++ b/src/Form/SiteConfigureForm.php
@@ -4,11 +4,11 @@ namespace Drupal\acquia_cms\Form;
 
 use Drupal\acquia_cms_tour\Form\AcquiaGoogleMapsAPIForm;
 use Drupal\Core\Config\ConfigFactoryInterface;
-use Drupal\Core\Extension\ModuleHandlerInterface;
 use Drupal\Core\Extension\ModuleInstallerInterface;
 use Drupal\Core\Form\ConfigFormBase;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Installer\Form\SiteConfigureForm as CoreSiteConfigureForm;
+use Drupal\Core\Messenger\MessengerInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
@@ -31,11 +31,11 @@ final class SiteConfigureForm extends ConfigFormBase {
   private $moduleInstaller;
 
   /**
-   * The module handler.
+   * The Messenger service.
    *
-   * @var \Drupal\Core\Extension\ModuleHandlerInterface
+   * @var \Drupal\Core\Messenger\MessengerInterface
    */
-  private $moduleHandler;
+  protected $messenger;
 
   /**
    * The decorated site configuration form object.
@@ -60,18 +60,18 @@ final class SiteConfigureForm extends ConfigFormBase {
    *   The Cohesion API URL.
    * @param \Drupal\Core\Extension\ModuleInstallerInterface $module_installer
    *   The module installer.
-   * @param \Drupal\Core\Extension\ModuleHandlerInterface $module_handler
-   *   The module handler.
+   * @param \Drupal\Core\Messenger\MessengerInterface $messenger
+   *   The messenger service.
    * @param \Drupal\Core\Installer\Form\SiteConfigureForm $site_form
    *   The decorated site configuration form object.
    * @param \Drupal\acquia_cms_tour\Form\AcquiaGoogleMapsAPIForm $maps_form
    *   The decorated Google Maps configuration form object.
    */
-  public function __construct(ConfigFactoryInterface $config_factory, string $api_url, ModuleInstallerInterface $module_installer, ModuleHandlerInterface $module_handler, CoreSiteConfigureForm $site_form, AcquiaGoogleMapsAPIForm $maps_form) {
+  public function __construct(ConfigFactoryInterface $config_factory, string $api_url, ModuleInstallerInterface $module_installer, MessengerInterface $messenger, CoreSiteConfigureForm $site_form, AcquiaGoogleMapsAPIForm $maps_form) {
     parent::__construct($config_factory);
     $this->apiUrl = $api_url;
     $this->moduleInstaller = $module_installer;
-    $this->moduleHandler = $module_handler;
+    $this->messenger = $messenger;
     $this->siteForm = $site_form;
     $this->mapsForm = $maps_form;
   }
@@ -84,7 +84,7 @@ final class SiteConfigureForm extends ConfigFormBase {
       $container->get('config.factory'),
       $container->get('cohesion.api.utils')->getAPIServerURL(),
       $container->get('module_installer'),
-      $container->get('module_handler'),
+      $container->get('messenger'),
       CoreSiteConfigureForm::create($container),
       AcquiaGoogleMapsAPIForm::create($container)
     );
@@ -108,6 +108,13 @@ final class SiteConfigureForm extends ConfigFormBase {
    * {@inheritdoc}
    */
   public function buildForm(array $form, FormStateInterface $form_state) {
+    // Upgrading to drupal core 9.2 causing a regression by cohesion module
+    // which deletes session id for user 1 if there are any messages on
+    // site-install screen, as a workaround we are deleting all messages
+    // available on install screen, we will remove below code once we have
+    // a fix for https://backlog.acquia.com/browse/ACO-1169
+    $this->messenger->deleteAll();
+
     $form = $this->siteForm->buildForm($form, $form_state);
     // Set default value for site name.
     $form['site_information']['site_name']['#default_value'] = $this->t('Acquia CMS');


### PR DESCRIPTION
…re 9.2

**Motivation**
<!-- What problem does this solve? Why is it important? What's the context? If this fixes an issue, link to it above. -->
Fixes #[ACMS-834](https://backlog.acquia.com/browse/ACMS-834)

**Proposed changes**
<!-- What does this PR change? How does this impact end users? Are manual or automatic updates required? -->
We have a separate ticket [ACO-1169](https://backlog.acquia.com/browse/ACO-1169) where issue will be fixed from Site studio team.

**Alternatives considered**
<!-- How else could the original issue / use case be addressed? Why did you choose this solution over any others? -->
Remove all messages from install screen as work around, along with one additional task which is also causing.

**Testing steps**
<!-- How can we replicate the issue and verify that this PR fixes it? -->

- Install site using UI, without site studio key
- Install site using UI, with site studio key 

**Merge requirements**
- [ ] _Major change_, _Minor change_, _Bug_, _Enhancement_, and/or _Chore_ label applied
- [ ] Manual testing by a reviewer
