### PR TITLE
ACMS-835: Remove Site Studio dependency from acquia_cms_search

### DIFF
--- a/modules/acquia_cms_search/acquia_cms_search.info.yml
+++ b/modules/acquia_cms_search/acquia_cms_search.info.yml
@@ -5,7 +5,6 @@ type: module
 core_version_requirement: ^9
 dependencies:
   - drupal:acquia_cms_article
-  - drupal:acquia_cms_site_studio
   - drupal:node
   - drupal:views
   - search_api:search_api_db

--- a/modules/acquia_cms_search/acquia_cms_search.install
+++ b/modules/acquia_cms_search/acquia_cms_search.install
@@ -5,6 +5,7 @@
  * Contains installation routines for Acquia CMS Search.
  */
 
+use Drupal\acquia_cms_search\Facade\SearchFacade;
 use Drupal\node\Entity\NodeType;
 
 /**
@@ -15,4 +16,12 @@ function acquia_cms_search_install() {
   // this module was installed.
   $node_types = NodeType::loadMultiple();
   array_walk($node_types, 'acquia_cms_search_node_type_insert');
+
+  // Update search & search_fallback views display_options's style
+  // type as cohesion_layout and option's views_template & master_template
+  // if acquia_cms_site_studio module is present else use default one.
+  if (\Drupal::moduleHandler()->moduleExists('acquia_cms_site_studio')) {
+    Drupal::classResolver(SearchFacade::class)->updateViewDisplayOptionsStyle('search');
+    Drupal::classResolver(SearchFacade::class)->updateViewDisplayOptionsStyle('search_fallback');
+  }
 }

--- a/modules/acquia_cms_search/composer.json
+++ b/modules/acquia_cms_search/composer.json
@@ -4,7 +4,6 @@
     "description": "Provides powerful search capabilities to the site.",
     "require": {
         "drupal/acquia_cms_article": "^1.0",
-        "drupal/acquia_cms_site_studio": "^1.0",
         "drupal/search_api": "1.18"
     }
 }

--- a/modules/acquia_cms_search/config/install/views.view.search.yml
+++ b/modules/acquia_cms_search/config/install/views.view.search.yml
@@ -6,7 +6,6 @@ dependencies:
     - views.view.search_fallback
   module:
     - acquia_cms_search
-    - cohesion
     - search_api
 id: search
 label: Search
@@ -67,10 +66,7 @@ display:
             offset_label: Offset
           quantity: 3
       style:
-        type: cohesion_layout
-        options:
-          views_template: view_tpl_search
-          master_template: master_template_boxed
+        type: default
       row:
         type: search_api
         options:

--- a/modules/acquia_cms_search/config/install/views.view.search_fallback.yml
+++ b/modules/acquia_cms_search/config/install/views.view.search_fallback.yml
@@ -4,7 +4,6 @@ dependencies:
   config:
     - core.entity_view_mode.node.teaser
   module:
-    - cohesion
     - node
     - user
   enforced:
@@ -71,10 +70,7 @@ display:
             offset_label: Offset
           quantity: 3
       style:
-        type: cohesion_layout
-        options:
-          views_template: view_tpl_search_fallback
-          master_template: master_template_boxed
+        type: default
       row:
         type: 'entity:node'
         options:

--- a/modules/acquia_cms_search/src/Facade/SearchFacade.php
+++ b/modules/acquia_cms_search/src/Facade/SearchFacade.php
@@ -284,4 +284,27 @@ final class SearchFacade implements ContainerInjectionInterface {
     return $index ? $this->indexStorage->load($index) : NULL;
   }
 
+  /**
+   * Update views display_options's style.
+   *
+   * @throws \Drupal\Core\Entity\EntityStorageException
+   */
+  public function updateViewDisplayOptionsStyle($view_name) {
+    /** @var \Drupal\views\ViewEntityInterface $view */
+    $view = $this->viewStorage->load($view_name);
+    if (empty($view)) {
+      return;
+    }
+    $display = &$view->getDisplay('default');
+    $style_type = $display['display_options']['style']['type'];
+    if ($style_type !== 'cohesion_layout') {
+      $display['display_options']['style']['type'] = 'cohesion_layout';
+      $display['display_options']['style']['options'] = [
+        'views_template' => 'view_tpl_' . $view_name,
+        'master_template' => 'master_template_boxed',
+      ];
+      $this->viewStorage->save($view);
+    }
+  }
+
 }

--- a/modules/acquia_cms_site_studio/acquia_cms_site_studio.install
+++ b/modules/acquia_cms_site_studio/acquia_cms_site_studio.install
@@ -5,6 +5,7 @@
  * Contains install-time code for the Acquia CMS profile.
  */
 
+use Drupal\acquia_cms_search\Facade\SearchFacade;
 use Drupal\Core\Installer\InstallerKernel;
 
 /**
@@ -36,6 +37,14 @@ function acquia_cms_site_studio_install() {
     if (PHP_SAPI !== 'cli') {
       acquia_cms_site_studio_rebuild_styles();
     }
+  }
+
+  // Update search & search_fallback views display_options's style
+  // type as cohesion_layout and option's views_template & master_template
+  // if acquia_cms_site_studio module is present else use default one.
+  if (\Drupal::moduleHandler()->moduleExists('acquia_cms_search')) {
+    Drupal::classResolver(SearchFacade::class)->updateViewDisplayOptionsStyle('search');
+    Drupal::classResolver(SearchFacade::class)->updateViewDisplayOptionsStyle('search_fallback');
   }
 }
 


### PR DESCRIPTION
**Motivation**
<!-- What problem does this solve? Why is it important? What's the context? If this fixes an issue, link to it above. -->
Fixes #[ACMS-835](https://backlog.acquia.com/browse/ACMS-835)

**Proposed changes**
<!-- What does this PR change? How does this impact end users? Are manual or automatic updates required? -->
Update search view display option programatically to use `cohesion_layout` if `acquia_cms_site_studio` module is present and enabled else leave to use default.

**Alternatives considered**
<!-- How else could the original issue / use case be addressed? Why did you choose this solution over any others? -->
Add `acquia_cms_site_studio` module dependency in `acquia_cms_search`

**Testing steps**
<!-- How can we replicate the issue and verify that this PR fixes it? -->
**Scenario 1:**
- Create vanilla drupal project along with custom profile refer : https://github.com/acquia/acquia_cms/blob/feature/profile-refactor/CUSTOM_PROFILE/README.md 
- Install site using custom profile created above.
- Creates some content like , article, person & place.
- Visit search page (/search) and verify that you can see result using default theme olivero template.
- Now set fallback search view  by running below command and check that result are coming:
```
drush cset views.view.search display.default.display_options.empty.view_fallback.simulate_unavailable TRUE
```

**Scenario 2:**

- Install acquia_cms on this PR branch and verify everything is working as expected.

- Now set fallback search view  by running below command and check that result are coming:
```
drush cset views.view.search display.default.display_options.empty.view_fallback.simulate_unavailable TRUE
```
Command to return to normal view from fallback:
```
drush cdel views.view.search display.default.display_options.empty.view_fallback.simulate_unavailable
```
**Merge requirements**
- [ ] _Major change_, _Minor change_, _Bug_, _Enhancement_, and/or _Chore_ label applied
- [ ] Manual testing by a reviewer
