### PR TITLE
ACMS-845: Updated the documentation to replace the --group option with actual module name.

### DIFF
--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -138,12 +138,17 @@ export DTT_MINK_DRIVER_ARGS=$MINK_DRIVER_ARGS_WEBDRIVER
 To run all Acquia CMS tests (which may take a while), use this command:
 ```
 cd docroot
-../vendor/bin/phpunit -c core --group acquia_cms --debug
+../vendor/bin/phpunit -c core profiles/contrib/acquia_cms/modules --debug
 ```
 To run all tests for a particular module:
 ```
 cd docroot
-../vendor/bin/phpunit -c core --group MODULE --debug
+../vendor/bin/phpunit -c core profiles/contrib/acquia_cms/modules/<MODULE>  --debug
+```
+Example:
+```
+cd docroot
+../vendor/bin/phpunit -c core profiles/contrib/acquia_cms/modules/acquia_cms_search --debug
 ```
 To run a particular test:
 ```


### PR DESCRIPTION
**Motivation**
* We need to update the steps to run the tests in documentation [here](https://github.com/acquia/acquia_cms/blob/develop/DEVELOPING.md) to be able to run the tests successfully without the --group option
Fixes #[ACMS-845](https://backlog.acquia.com/browse/ACMS-845)

**Proposed changes**
* Update the steps to run the tests in documentation [here](https://github.com/acquia/acquia_cms/blob/develop/DEVELOPING.md) to be able to run the tests successfully without the --group option

**Alternatives considered**
* None

**Testing steps**
* Follow the steps mentioned in ticket / developing documentation to run the tests succesfully.

**Merge requirements**
- [ ] _Major change_, _Minor change_, _Bug_, _Enhancement_, and/or _Chore_ label applied
- [ ] Manual testing by a reviewer
