### PR TITLE
ACMS-834: Created patch in Site Studio module to fix Access denied error.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -153,6 +153,9 @@
             "drupal/core": "-p2"
         },
         "patches": {
+            "acquia/cohesion": {
+                "Site install using UI gives 403 on finish, due to update core 9.2": "https://gist.githubusercontent.com/vishalkhode1/8762f8e2e5569f01a3fdcf3b8d8e2b50/raw/3f916d17b717fd5f3c215bde02e741a9ee7be4e5/site-studio-access-denied.patch"
+            },
             "drupal/acquia_telemetry-acquia_telemetry": {
                 "Add check for core index": "https://www.drupal.org/files/issues/2020-08-18/3165473-27.patch"
             },

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "4ec127f6ada5fd3ff4aee9b3a5a1bdb7",
+    "content-hash": "46afa027e3178247138f145144e3f9fe",
     "packages": [
         {
             "name": "acquia/acsf-contenthub-console",
@@ -5019,8 +5019,8 @@
                     "dev-2.x": "2.x-dev"
                 },
                 "drupal": {
-                    "version": "8.x-2.4+0-dev",
-                    "datestamp": "1618250676",
+                    "version": "8.x-2.4+2-dev",
+                    "datestamp": "1625891063",
                     "security-coverage": {
                         "status": "not-covered",
                         "message": "Dev releases are not covered by Drupal security advisories."
@@ -12529,6 +12529,7 @@
                     "type": "github"
                 }
             ],
+            "abandoned": true,
             "time": "2020-09-28T06:45:17+00:00"
         },
         {


### PR DESCRIPTION
**Motivation**
<!-- What problem does this solve? Why is it important? What's the context? If this fixes an issue, link to it above. -->
Fixes access denied issue when cohesion module is installed during site installation.

**Proposed changes**
Created a patch in Site Studio (cohesion) module which causing the access denied error.

**Alternatives considered**
Alternate patch is tried as provided by Site Studio team (i.e https://backlog.acquia.com/secure/attachment/323751/323751_ACO-1169.patch) but it didn't solve the actual issue.

**Testing steps**
- Install the Site using UI (without adding Site Studio keys in Site Configuration page). After site installation is completed, user shouldn't be redirected to Access Denied page.
- Install the Site using UI (adding Site Studio keys in Site Configuration page). After site installation is completed, user shouldn't be redirected to Access Denied page.

**Merge requirements**
- [ ] _Bug_, _Major_
- [ ] Manual testing by a reviewer
