### PR TITLE
ACMS-861: Add ORCA job to test with previous minor Drupal version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -68,7 +68,7 @@ matrix:
     # The following two jobs are not applicable because Acquia CMS does not support versions prior to Drupal 9.1.x.
     # - { env: ORCA_JOB=INTEGRATED_TEST_ON_OLDEST_SUPPORTED, name: "Integrated test on oldest supported Drupal core version" }
     # - { env: ORCA_JOB=INTEGRATED_TEST_ON_LATEST_LTS, name: "Integrated test on latest LTS Drupal core version" }
-    - { env: ORCA_JOB=INTEGRATED_TEST_ON_PREVIOUS_MINOR, name: "Integrated test on previous minor Drupal core version" }
+    - { env: ORCA_JOB=INTEGRATED_TEST_ON_PREVIOUS_MINOR, if: type = cron, name: "Integrated test on previous minor Drupal core version" }
     - { env: ORCA_JOB=INTEGRATED_UPGRADE_TEST_FROM_PREVIOUS_MINOR, if: type = cron, name: "Integrated upgrade test from previous minor" }
     - { env: ORCA_JOB=ISOLATED_TEST_ON_CURRENT ACMS_JOB=base_full, if: type = cron, name: "Isolated test on current Drupal core version" }
     # To send PHPUnit test coverage data to Coveralls (coveralls.io), configure

--- a/.travis.yml
+++ b/.travis.yml
@@ -65,7 +65,10 @@ matrix:
     # @see https://github.com/acquia/orca/blob/master/docs/understanding-orca.md#continuous-integration
     - { env: ORCA_JOB=STATIC_CODE_ANALYSIS, name: "Static code analysis" }
     - { env: ORCA_JOB=STRICT_DEPRECATED_CODE_SCAN, name: "Strict deprecated code scan" }
-    - { env: ORCA_JOB=INTEGRATED_TEST_ON_OLDEST_SUPPORTED, if: type = cron, name: "Integrated test on oldest supported Drupal core version" }
+    # The following two jobs are not applicable because Acquia CMS does not support versions prior to Drupal 9.1.x.
+    # - { env: ORCA_JOB=INTEGRATED_TEST_ON_OLDEST_SUPPORTED, name: "Integrated test on oldest supported Drupal core version" }
+    # - { env: ORCA_JOB=INTEGRATED_TEST_ON_LATEST_LTS, name: "Integrated test on latest LTS Drupal core version" }
+    - { env: ORCA_JOB=INTEGRATED_TEST_ON_PREVIOUS_MINOR, name: "Integrated test on previous minor Drupal core version" }
     - { env: ORCA_JOB=INTEGRATED_UPGRADE_TEST_FROM_PREVIOUS_MINOR, if: type = cron, name: "Integrated upgrade test from previous minor" }
     - { env: ORCA_JOB=ISOLATED_TEST_ON_CURRENT ACMS_JOB=base_full, if: type = cron, name: "Isolated test on current Drupal core version" }
     # To send PHPUnit test coverage data to Coveralls (coveralls.io), configure


### PR DESCRIPTION
**Motivation**
Fixes ACMS-861

**Proposed changes**
Add an ORCA job for the previous minor Drupal version, and only run it on cron builds.

**Alternatives considered**
N/A

**Testing steps**
Ensure test runs on cron build.

**Merge requirements**
- [ ] _Major change_, _Minor change_, _Bug_, _Enhancement_, and/or _Chore_ label applied
