### PR TITLE
ACMS-858: Move tests back to acquia_cms_search with fallback approach

### DIFF
--- a/modules/acquia_cms_article/config/optional/block.block.stark_articles_article_type.yml
+++ b/modules/acquia_cms_article/config/optional/block.block.stark_articles_article_type.yml
@@ -1,0 +1,26 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - facets.facet.articles_article_type
+  module:
+    - collapsiblock
+    - facets
+  theme:
+    - stark
+third_party_settings:
+  collapsiblock:
+    collapse_action: '2'
+id: stark_articles_article_type
+theme: stark
+region: sidebar_first
+weight: 0
+provider: null
+plugin: 'facet_block:articles_article_type'
+settings:
+  id: 'facet_block:articles_article_type'
+  label: 'Article Type'
+  provider: facets
+  label_display: visible
+  block_id: articles_article_type
+visibility: {  }

--- a/modules/acquia_cms_article/config/optional/block.block.stark_articles_category.yml
+++ b/modules/acquia_cms_article/config/optional/block.block.stark_articles_category.yml
@@ -1,0 +1,27 @@
+uuid: a2c7a6f9-e0e5-46d5-a415-f60ae2baf369
+langcode: en
+status: true
+dependencies:
+  config:
+    - facets.facet.articles_category
+  module:
+    - collapsiblock
+    - facets
+  theme:
+    - stark
+third_party_settings:
+  collapsiblock:
+    collapse_action: '2'
+id: stark_articles_category
+theme: stark
+region: sidebar_first
+weight: 0
+provider: null
+plugin: 'facet_block:articles_category'
+settings:
+  id: 'facet_block:articles_category'
+  label: Category
+  provider: facets
+  label_display: visible
+  block_id: articles_category
+visibility: {  }

--- a/modules/acquia_cms_article/config/optional/block.block.stark_search_article_type.yml
+++ b/modules/acquia_cms_article/config/optional/block.block.stark_search_article_type.yml
@@ -1,0 +1,26 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - facets.facet.search_article_type
+  module:
+    - collapsiblock
+    - facets
+  theme:
+    - stark
+third_party_settings:
+  collapsiblock:
+    collapse_action: '2'
+id: stark_search_article_type
+theme: stark
+region: sidebar_first
+weight: 0
+provider: null
+plugin: 'facet_block:search_article_type'
+settings:
+  id: 'facet_block:search_article_type'
+  label: 'Article Type'
+  provider: facets
+  label_display: visible
+  block_id: search_article_type
+visibility: {  }

--- a/modules/acquia_cms_common/tests/src/ExistingSite/ContentTypeListTestBase.php
+++ b/modules/acquia_cms_common/tests/src/ExistingSite/ContentTypeListTestBase.php
@@ -330,7 +330,7 @@ abstract class ContentTypeListTestBase extends ExistingSiteBase {
   protected function getLinks() : array {
     $links = $this->getSession()
       ->getPage()
-      ->findAll('css', 'article a.card-link');
+      ->findAll('css', 'article a');
 
     $map = function (ElementInterface $link) {
       return $link->getText();

--- a/modules/acquia_cms_event/config/optional/block.block.stark_events_category.yml
+++ b/modules/acquia_cms_event/config/optional/block.block.stark_events_category.yml
@@ -1,0 +1,27 @@
+uuid: f185a345-6076-481d-a5a7-5baeb2ffdcc5
+langcode: en
+status: true
+dependencies:
+  config:
+    - facets.facet.events_category
+  module:
+    - collapsiblock
+    - facets
+  theme:
+    - stark
+third_party_settings:
+  collapsiblock:
+    collapse_action: '2'
+id: stark_events_category
+theme: stark
+region: sidebar_first
+weight: 0
+provider: null
+plugin: 'facet_block:events_category'
+settings:
+  id: 'facet_block:events_category'
+  label: Category
+  provider: facets
+  label_display: visible
+  block_id: events_category
+visibility: {  }

--- a/modules/acquia_cms_event/config/optional/block.block.stark_events_event_type.yml
+++ b/modules/acquia_cms_event/config/optional/block.block.stark_events_event_type.yml
@@ -1,0 +1,26 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - facets.facet.events_event_type
+  module:
+    - collapsiblock
+    - facets
+  theme:
+    - stark
+third_party_settings:
+  collapsiblock:
+    collapse_action: '2'
+id: stark_events_event_type
+theme: stark
+region: sidebar_first
+weight: 0
+provider: null
+plugin: 'facet_block:events_event_type'
+settings:
+  id: 'facet_block:events_event_type'
+  label: 'Event Type'
+  provider: facets
+  label_display: visible
+  block_id: events_event_type
+visibility: {  }

--- a/modules/acquia_cms_event/config/optional/block.block.stark_search_event_type.yml
+++ b/modules/acquia_cms_event/config/optional/block.block.stark_search_event_type.yml
@@ -1,0 +1,26 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - facets.facet.search_event_type
+  module:
+    - collapsiblock
+    - facets
+  theme:
+    - stark
+third_party_settings:
+  collapsiblock:
+    collapse_action: '2'
+id: stark_search_event_type
+theme: stark
+region: sidebar_first
+weight: 0
+provider: null
+plugin: 'facet_block:search_event_type'
+settings:
+  id: 'facet_block:search_event_type'
+  label: 'Event Type'
+  provider: facets
+  label_display: visible
+  block_id: search_event_type
+visibility: {  }

--- a/modules/acquia_cms_person/config/optional/block.block.stark_people_category.yml
+++ b/modules/acquia_cms_person/config/optional/block.block.stark_people_category.yml
@@ -1,0 +1,26 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - facets.facet.people_category
+  module:
+    - collapsiblock
+    - facets
+  theme:
+    - stark
+third_party_settings:
+  collapsiblock:
+    collapse_action: '2'
+id: stark_people_category
+theme: stark
+region: sidebar_first
+weight: 0
+provider: null
+plugin: 'facet_block:people_category'
+settings:
+  id: 'facet_block:people_category'
+  label: Category
+  provider: facets
+  label_display: visible
+  block_id: people_category
+visibility: {  }

--- a/modules/acquia_cms_person/config/optional/block.block.stark_people_person_type.yml
+++ b/modules/acquia_cms_person/config/optional/block.block.stark_people_person_type.yml
@@ -1,0 +1,26 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - facets.facet.people_person_type
+  module:
+    - collapsiblock
+    - facets
+  theme:
+    - stark
+third_party_settings:
+  collapsiblock:
+    collapse_action: '2'
+id: stark_people_person_type
+theme: stark
+region: sidebar_first
+weight: 0
+provider: null
+plugin: 'facet_block:people_person_type'
+settings:
+  id: 'facet_block:people_person_type'
+  label: 'Person Type'
+  provider: facets
+  label_display: visible
+  block_id: people_person_type
+visibility: {  }

--- a/modules/acquia_cms_person/config/optional/block.block.stark_search_person_type.yml
+++ b/modules/acquia_cms_person/config/optional/block.block.stark_search_person_type.yml
@@ -1,0 +1,26 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - facets.facet.search_person_type
+  module:
+    - collapsiblock
+    - facets
+  theme:
+    - stark
+third_party_settings:
+  collapsiblock:
+    collapse_action: '2'
+id: stark_search_person_type
+theme: stark
+region: sidebar_first
+weight: 0
+provider: null
+plugin: 'facet_block:search_person_type'
+settings:
+  id: 'facet_block:search_person_type'
+  label: 'Person Type'
+  provider: facets
+  label_display: visible
+  block_id: search_person_type
+visibility: {  }

--- a/modules/acquia_cms_place/config/optional/block.block.stark_places_category.yml
+++ b/modules/acquia_cms_place/config/optional/block.block.stark_places_category.yml
@@ -1,0 +1,26 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - facets.facet.places_category
+  module:
+    - collapsiblock
+    - facets
+  theme:
+    - stark
+third_party_settings:
+  collapsiblock:
+    collapse_action: '2'
+id: stark_places_category
+theme: stark
+region: sidebar_first
+weight: 0
+provider: null
+plugin: 'facet_block:places_category'
+settings:
+  id: 'facet_block:places_category'
+  label: Category
+  provider: facets
+  label_display: visible
+  block_id: places_category
+visibility: {  }

--- a/modules/acquia_cms_place/config/optional/block.block.stark_places_place_type.yml
+++ b/modules/acquia_cms_place/config/optional/block.block.stark_places_place_type.yml
@@ -1,0 +1,26 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - facets.facet.places_place_type
+  module:
+    - collapsiblock
+    - facets
+  theme:
+    - stark
+third_party_settings:
+  collapsiblock:
+    collapse_action: '2'
+id: stark_places_place_type
+theme: stark
+region: sidebar_first
+weight: 0
+provider: null
+plugin: 'facet_block:places_place_type'
+settings:
+  id: 'facet_block:places_place_type'
+  label: 'Place Type'
+  provider: facets
+  label_display: visible
+  block_id: places_place_type
+visibility: {  }

--- a/modules/acquia_cms_place/config/optional/block.block.stark_search_place_type.yml
+++ b/modules/acquia_cms_place/config/optional/block.block.stark_search_place_type.yml
@@ -1,0 +1,26 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - facets.facet.search_place_type
+  module:
+    - collapsiblock
+    - facets
+  theme:
+    - stark
+third_party_settings:
+  collapsiblock:
+    collapse_action: '2'
+id: stark_search_place_type
+theme: stark
+region: sidebar_first
+weight: 0
+provider: null
+plugin: 'facet_block:search_place_type'
+settings:
+  id: 'facet_block:search_place_type'
+  label: 'Place Type'
+  provider: facets
+  label_display: visible
+  block_id: search_place_type
+visibility: {  }

--- a/modules/acquia_cms_search/acquia_cms_search.info.yml
+++ b/modules/acquia_cms_search/acquia_cms_search.info.yml
@@ -5,8 +5,12 @@ type: module
 core_version_requirement: ^9
 dependencies:
   - drupal:acquia_cms_article
+  - drupal:acquia_cms_event
   - drupal:node
+  - drupal:block
   - drupal:views
   - search_api:search_api_db
   - drupal:acquia_search
   - drupal:facets
+  - drupal:collapsiblock
+  - drupal:facets_pretty_paths

--- a/modules/acquia_cms_search/composer.json
+++ b/modules/acquia_cms_search/composer.json
@@ -4,8 +4,11 @@
     "description": "Provides powerful search capabilities to the site.",
     "require": {
         "drupal/acquia_cms_article": "^1.0",
+        "drupal/acquia_cms_event": "^1.0",
         "drupal/acquia_search": "^3.0",
+        "drupal/collapsiblock": "^3",
         "drupal/facets": "^1.8",
+        "drupal/facets_pretty_paths": "^1.1",
         "drupal/search_api": "1.18",
         "drupal/search_api_autocomplete": "^1.4"
     }

--- a/modules/acquia_cms_search/config/optional/block.block.stark_clear_facet_filters.yml
+++ b/modules/acquia_cms_search/config/optional/block.block.stark_clear_facet_filters.yml
@@ -1,0 +1,23 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - acquia_cms_search
+    - collapsiblock
+  theme:
+    - stark
+third_party_settings:
+  collapsiblock:
+    collapse_action: '0'
+id: stark_clear_facet_filters
+theme: stark
+region: sidebar_first
+weight: 0
+provider: null
+plugin: clear_facet_filters
+settings:
+  id: clear_facet_filters
+  label: 'Clear Facet Filters'
+  provider: acquia_cms_search
+  label_display: '0'
+visibility: {  }

--- a/modules/acquia_cms_search/config/optional/block.block.stark_exposed_form_search.yml
+++ b/modules/acquia_cms_search/config/optional/block.block.stark_exposed_form_search.yml
@@ -1,0 +1,22 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - views.view.search
+  module:
+    - views
+  theme:
+    - stark
+id: stark_exposed_form_search
+theme: stark
+region: sidebar_first
+weight: 0
+provider: null
+plugin: 'views_exposed_filter_block:search-search'
+settings:
+  id: 'views_exposed_filter_block:search-search'
+  label: ''
+  provider: views
+  label_display: '0'
+  views_label: ''
+visibility: {  }

--- a/modules/acquia_cms_search/config/optional/block.block.stark_search_category.yml
+++ b/modules/acquia_cms_search/config/optional/block.block.stark_search_category.yml
@@ -1,0 +1,26 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - facets.facet.search_category
+  module:
+    - collapsiblock
+    - facets
+  theme:
+    - stark
+third_party_settings:
+  collapsiblock:
+    collapse_action: '2'
+id: stark_search_category
+theme: stark
+region: sidebar_first
+weight: 0
+provider: null
+plugin: 'facet_block:search_category'
+settings:
+  id: 'facet_block:search_category'
+  label: Category
+  provider: facets
+  label_display: visible
+  block_id: search_category
+visibility: {  }

--- a/modules/acquia_cms_search/config/optional/block.block.stark_search_content_type.yml
+++ b/modules/acquia_cms_search/config/optional/block.block.stark_search_content_type.yml
@@ -1,0 +1,26 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - facets.facet.search_content_type
+  module:
+    - collapsiblock
+    - facets
+  theme:
+    - stark
+third_party_settings:
+  collapsiblock:
+    collapse_action: '2'
+id: stark_search_content_type
+theme: stark
+region: sidebar_first
+weight: 0
+provider: null
+plugin: 'facet_block:search_content_type'
+settings:
+  id: 'facet_block:search_content_type'
+  label: 'Content Type'
+  provider: facets
+  label_display: visible
+  block_id: search_content_type
+visibility: {  }

--- a/modules/acquia_cms_search/tests/src/ExistingSite/ArticleListTest.php
+++ b/modules/acquia_cms_search/tests/src/ExistingSite/ArticleListTest.php
@@ -1,47 +1,47 @@
 <?php
 
-namespace Drupal\Tests\acquia_cms_site_studio\ExistingSite;
+namespace Drupal\Tests\acquia_cms_search\ExistingSite;
 
 use Drupal\Core\Entity\Query\QueryInterface;
 use Drupal\Tests\acquia_cms_common\ExistingSite\ContentTypeListTestBase;
 use Drupal\views\Entity\View;
 
 /**
- * Tests the "all events" listing page.
+ * Tests the "all articles" listing page.
  *
- * @group acquia_cms
  * @group acquia_cms_site_studio
+ * @group acquia_cms
  * @group low_risk
  * @group pr
  * @group push
  */
-class EventListTest extends ContentTypeListTestBase {
+class ArticleListTest extends ContentTypeListTestBase {
 
   /**
    * {@inheritdoc}
    */
-  protected $nodeType = 'event';
+  protected $nodeType = 'article';
 
   /**
    * {@inheritdoc}
    */
   protected function getView() : View {
-    return View::load('events');
+    return View::load('articles');
   }
 
   /**
    * {@inheritdoc}
    */
   protected function visitListPage($langcode = NULL) : void {
-    $page = $langcode ? "/$langcode/events" : "/events";
+    $page = $langcode ? "/$langcode/articles" : "/articles";
     $this->drupalGet($page);
   }
 
   /**
    * {@inheritdoc}
    */
-  protected function getQuery() : QueryInterface {
-    return parent::getQuery()->sort('field_event_start')->sort('title');
+  protected function getQuery(): QueryInterface {
+    return parent::getQuery()->sort('created', 'DESC');
   }
 
 }

--- a/modules/acquia_cms_search/tests/src/ExistingSite/EventListTest.php
+++ b/modules/acquia_cms_search/tests/src/ExistingSite/EventListTest.php
@@ -1,13 +1,13 @@
 <?php
 
-namespace Drupal\Tests\acquia_cms_site_studio\ExistingSite;
+namespace Drupal\Tests\acquia_cms_search\ExistingSite;
 
 use Drupal\Core\Entity\Query\QueryInterface;
 use Drupal\Tests\acquia_cms_common\ExistingSite\ContentTypeListTestBase;
 use Drupal\views\Entity\View;
 
 /**
- * Tests the "all places" listing page.
+ * Tests the "all events" listing page.
  *
  * @group acquia_cms
  * @group acquia_cms_site_studio
@@ -15,25 +15,25 @@ use Drupal\views\Entity\View;
  * @group pr
  * @group push
  */
-class PlaceListTest extends ContentTypeListTestBase {
+class EventListTest extends ContentTypeListTestBase {
 
   /**
    * {@inheritdoc}
    */
-  protected $nodeType = 'place';
+  protected $nodeType = 'event';
 
   /**
    * {@inheritdoc}
    */
   protected function getView() : View {
-    return View::load('places');
+    return View::load('events');
   }
 
   /**
    * {@inheritdoc}
    */
   protected function visitListPage($langcode = NULL) : void {
-    $page = $langcode ? "/$langcode/places" : "/places";
+    $page = $langcode ? "/$langcode/events" : "/events";
     $this->drupalGet($page);
   }
 
@@ -41,7 +41,7 @@ class PlaceListTest extends ContentTypeListTestBase {
    * {@inheritdoc}
    */
   protected function getQuery() : QueryInterface {
-    return parent::getQuery()->sort('title');
+    return parent::getQuery()->sort('field_event_start')->sort('title');
   }
 
 }

--- a/modules/acquia_cms_search/tests/src/ExistingSite/PersonListTest.php
+++ b/modules/acquia_cms_search/tests/src/ExistingSite/PersonListTest.php
@@ -1,13 +1,13 @@
 <?php
 
-namespace Drupal\Tests\acquia_cms_site_studio\ExistingSite;
+namespace Drupal\Tests\acquia_cms_search\ExistingSite;
 
 use Drupal\Core\Entity\Query\QueryInterface;
 use Drupal\Tests\acquia_cms_common\ExistingSite\ContentTypeListTestBase;
 use Drupal\views\Entity\View;
 
 /**
- * Tests the "all articles" listing page.
+ * Tests the "all people" listing page.
  *
  * @group acquia_cms_site_studio
  * @group acquia_cms
@@ -15,33 +15,33 @@ use Drupal\views\Entity\View;
  * @group pr
  * @group push
  */
-class ArticleListTest extends ContentTypeListTestBase {
+class PersonListTest extends ContentTypeListTestBase {
 
   /**
    * {@inheritdoc}
    */
-  protected $nodeType = 'article';
+  protected $nodeType = 'person';
 
   /**
    * {@inheritdoc}
    */
   protected function getView() : View {
-    return View::load('articles');
+    return View::load('people');
   }
 
   /**
    * {@inheritdoc}
    */
   protected function visitListPage($langcode = NULL) : void {
-    $page = $langcode ? "/$langcode/articles" : "/articles";
+    $page = $langcode ? "/$langcode/people" : "/people";
     $this->drupalGet($page);
   }
 
   /**
    * {@inheritdoc}
    */
-  protected function getQuery(): QueryInterface {
-    return parent::getQuery()->sort('created', 'DESC');
+  protected function getQuery() : QueryInterface {
+    return parent::getQuery()->sort('title');
   }
 
 }

--- a/modules/acquia_cms_search/tests/src/ExistingSite/PlaceListTest.php
+++ b/modules/acquia_cms_search/tests/src/ExistingSite/PlaceListTest.php
@@ -1,39 +1,39 @@
 <?php
 
-namespace Drupal\Tests\acquia_cms_site_studio\ExistingSite;
+namespace Drupal\Tests\acquia_cms_search\ExistingSite;
 
 use Drupal\Core\Entity\Query\QueryInterface;
 use Drupal\Tests\acquia_cms_common\ExistingSite\ContentTypeListTestBase;
 use Drupal\views\Entity\View;
 
 /**
- * Tests the "all people" listing page.
+ * Tests the "all places" listing page.
  *
- * @group acquia_cms_site_studio
  * @group acquia_cms
+ * @group acquia_cms_site_studio
  * @group low_risk
  * @group pr
  * @group push
  */
-class PersonListTest extends ContentTypeListTestBase {
+class PlaceListTest extends ContentTypeListTestBase {
 
   /**
    * {@inheritdoc}
    */
-  protected $nodeType = 'person';
+  protected $nodeType = 'place';
 
   /**
    * {@inheritdoc}
    */
   protected function getView() : View {
-    return View::load('people');
+    return View::load('places');
   }
 
   /**
    * {@inheritdoc}
    */
   protected function visitListPage($langcode = NULL) : void {
-    $page = $langcode ? "/$langcode/people" : "/people";
+    $page = $langcode ? "/$langcode/places" : "/places";
     $this->drupalGet($page);
   }
 

--- a/modules/acquia_cms_site_studio/acquia_cms_site_studio.install
+++ b/modules/acquia_cms_site_studio/acquia_cms_site_studio.install
@@ -45,16 +45,6 @@ function acquia_cms_site_studio_install() {
   if ($module_handler->moduleExists('acquia_cms_search')) {
     _acquia_cms_common_update_view_display_options_style('search');
     _acquia_cms_common_update_view_display_options_style('search_fallback');
-
-    // Disable acquia_search view provided by Acquia Search Solrmodule,
-    // so that search view provided by acquia_cms_search module can be used
-    // which will allow content's related test to pass in isolation.
-    $view_storage = \Drupal::entityTypeManager()->getStorage('view');
-    if (!empty($view_storage->load('acquia_search'))) {
-      $view_storage->load('acquia_search')
-        ->setStatus(FALSE)
-        ->save();
-    }
   }
 }
 


### PR DESCRIPTION
**Motivation**
<!-- What problem does this solve? Why is it important? What's the context? If this fixes an issue, link to it above. -->
Fixes #[ACMS-858](https://backlog.acquia.com/browse/ACMS-858)

**Proposed changes**
<!-- What does this PR change? How does this impact end users? Are manual or automatic updates required? -->
Create fallback block configuration(using startk theme which is default theme for testing profile) for facet block which should allow test to pass without needing acquia_cms_site_studio or cohesion module/theme.

**Alternatives considered**
<!-- How else could the original issue / use case be addressed? Why did you choose this solution over any others? -->
N/A

**Testing steps**
<!-- How can we replicate the issue and verify that this PR fixes it? -->
Setup vanilla drupal site using testing profile and require acquia_cms_search module and then run test for this module, all test should pass. Refer [Test document](https://docs.google.com/document/d/1PqKu7EFkoqrw81x8rH1-R4psfdkeIYRqYM-WxbjAgt8/edit) for more details.

**Merge requirements**
- [_Enhancement_] _Major change_, _Minor change_, _Bug_, _Enhancement_, and/or _Chore_ label applied
- [x] Manual testing by a reviewer
