### PR TITLE
ACMS-878: Fix test failure in isolation with custom profile

### DIFF
--- a/modules/acquia_cms_common/acquia_cms_common.services.yml
+++ b/modules/acquia_cms_common/acquia_cms_common.services.yml
@@ -6,7 +6,7 @@ services:
 
   acquia_cms_common.event_subscriber:
     class: '\Drupal\acquia_cms_common\EventSubscriber\ConfigEventsSubscriber'
-    arguments: ['@module_handler', '@class_resolver']
+    arguments: ['@module_handler']
     tags:
       - { name: 'event_subscriber' }
 

--- a/modules/acquia_cms_search/acquia_cms_search.info.yml
+++ b/modules/acquia_cms_search/acquia_cms_search.info.yml
@@ -8,7 +8,6 @@ dependencies:
   - drupal:node
   - drupal:views
   - search_api:search_api_db
-  - drupal:acquia_search
   - drupal:facets
   - drupal:collapsiblock
   - drupal:facets_pretty_paths


### PR DESCRIPTION
**Motivation**
<!-- What problem does this solve? Why is it important? What's the context? If this fixes an issue, link to it above. -->
Fixes #[ACMS-878](https://backlog.acquia.com/browse/ACMS-878)

**Proposed changes**
<!-- What does this PR change? How does this impact end users? Are manual or automatic updates required? -->
Fix tests failure for combinations of module in isolation for example using (article, acquia_cms_search & acquia_cms_page) module.
**Alternatives considered**
<!-- How else could the original issue / use case be addressed? Why did you choose this solution over any others? -->
NA
**Testing steps**
<!-- How can we replicate the issue and verify that this PR fixes it? -->
Install site with custom profile and run test for acquia_cms_artile and make sure that following module is enabled as part of custom profile install - 

- acquia_cms_search
- acquia_cms_page
- acquia_cms_article

**Merge requirements**
- [ ] _Major change_, _Minor change_, _Bug_, _Enhancement_, and/or _Chore_ label applied
- [ ] Manual testing by a reviewer
