### PR TITLE
ACMS-883: Invalid module dependencies updated on acquia_cms_site_studio.info config.

### DIFF
--- a/modules/acquia_cms_site_studio/acquia_cms_site_studio.info.yml
+++ b/modules/acquia_cms_site_studio/acquia_cms_site_studio.info.yml
@@ -4,16 +4,16 @@ description: 'Module for Site Studio Installation Code.'
 core_version_requirement: ^9
 type: module
 dependencies:
-  - acquia:cohesion
-  - acquia:cohesion_base_styles
-  - acquia:cohesion_custom_styles
-  - acquia:cohesion_elements
-  - acquia:cohesion_style_guide
-  - acquia:cohesion_style_helpers
-  - acquia:cohesion_sync
-  - acquia:cohesion_templates
-  - acquia:cohesion_website_settings
-  - acquia:config_ignore
+  - drupal:cohesion
+  - drupal:cohesion_base_styles
+  - drupal:cohesion_custom_styles
+  - drupal:cohesion_elements
+  - drupal:cohesion_style_guide
+  - drupal:cohesion_style_helpers
+  - drupal:cohesion_sync
+  - drupal:cohesion_templates
+  - drupal:cohesion_website_settings
+  - drupal:config_ignore
   - drupal:collapsiblock
   - drupal:config
   - drupal:config_rewrite


### PR DESCRIPTION
**Motivation**
Fixes Invalid module dependencies updated on acquia_cms_site_studio.info config.

**Proposed changes**
Updated acquia_cms_site_studio.info.yml config with correct dependencies.

**Alternatives considered**
N/A

**Testing steps**
Run command: composer require drupal/acquia_cms_site_studio. It should download module without reporting any error.

**Merge requirements**
- [ ] _Minor change_  label applied
- [ ] Manual testing by a reviewer
