### PR TITLE
ACMS-794: Add back the custom info file template.

### DIFF
--- a/CUSTOM_PROFILE/CUSTOM_PROFILE.info.yml
+++ b/CUSTOM_PROFILE/CUSTOM_PROFILE.info.yml
@@ -1,0 +1,86 @@
+# NOTE: Rename this file to replace CUSTOM_PROFILE with your profile name
+# and remove .example from the file name.
+name: Custom Profile Name
+type: profile
+description: 'Description of your custom profile.'
+core_version_requirement: '^9'
+
+# Optional: Declare your installation profile as a distribution
+# This will make the installer auto-select this installation profile.
+# The distribution_name property is used in the installer and other places as
+# a label for the software being installed.
+distribution:
+  name: Distribution Name
+
+# Your custom list of modules. You may remove Acquia CMS component modules and
+# add or remove other modules here as necessary for your custom profile.
+install:
+  - acquia_cms_common
+  - acquia_cms_search
+  - acquia_cms_article
+  - acquia_cms_image
+  - acquia_cms_document
+  - acquia_cms_person
+  - acquia_cms_place
+  - acquia_cms_toolbar
+  - acquia_cms_tour
+  - acquia_cms_video
+  - acquia_purge
+  - address
+  - admin_toolbar_tools
+  - captcha
+  - config_ignore
+  - collapsiblock
+  - config
+  - config_translation
+  - content_translation
+  - datetime
+  - datetime_range
+  - default_content
+  - diff
+  - entity_clone
+  - facets_pretty_paths
+  - field_ui
+  - focal_point
+  - google_analytics
+  - google_tag
+  - history
+  - honeypot
+  - menu_ui
+  - metatag_open_graph
+  - metatag_twitter_cards
+  - moderation_dashboard
+  - moderation_sidebar
+  - options
+  - page_cache
+  - password_policy_character_types
+  - password_policy_length
+  - password_policy_username
+  - pathauto
+  - purge_processor_cron
+  - purge_processor_lateruntime
+  - purge_queuer_coretags
+  - purge_ui
+  - recaptcha
+  - redirect
+  - responsive_preview
+  - scheduler_content_moderation_integration
+  - schema_article
+  - schema_person
+  - schema_place
+  - search_api_autocomplete
+  - search_api_db
+  - seckit
+  - simple_sitemap
+  - social_media_links
+  - taxonomy
+  - telephone
+  - update
+  - username_enumeration_prevention
+  - views_ui
+  - workbench_email
+
+# List any themes that should be installed as part of the profile installation.
+themes:
+  - olivero
+  - acquia_claro


### PR DESCRIPTION
**Motivation**
<!-- What problem does this solve? Why is it important? What's the context? If this fixes an issue, link to it above. -->
The custom profile template added in ACMS-794 is missing. This adds it again.

**Proposed changes**
<!-- What does this PR change? How does this impact end users? Are manual or automatic updates required? -->
Adds an info file temple for making custom profiles.

**Alternatives considered**
<!-- How else could the original issue / use case be addressed? Why did you choose this solution over any others? -->
N/A

**Merge requirements**
- [ ] _Major change_, _Minor change_, _Bug_, _Enhancement_, and/or _Chore_ label applied
- [ ] Manual testing by a reviewer
