### PR TITLE
ACMS-819: Added condition to check for remote address.

### DIFF
--- a/acquia_cms.services.yml
+++ b/acquia_cms.services.yml
@@ -1,6 +1,6 @@
 services:
   acquia_cms_request_subscriber:
     class: '\Drupal\acquia_cms\EventSubscriber\HttpsRedirectSubscriber'
-    arguments: ['@config.factory', '@cache.config']
+    arguments: ['@config.factory', '@cache.config', '@request_stack']
     tags:
       - { name: 'event_subscriber' }

--- a/src/EventSubscriber/HttpsRedirectSubscriber.php
+++ b/src/EventSubscriber/HttpsRedirectSubscriber.php
@@ -8,6 +8,7 @@ use Drupal\Core\Routing\TrustedRedirectResponse;
 use Drupal\Core\Url;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpKernel\Event\RequestEvent;
 use Symfony\Component\HttpKernel\KernelEvents;
 
@@ -31,44 +32,67 @@ class HttpsRedirectSubscriber implements EventSubscriberInterface {
   private $cache;
 
   /**
+   * The Request URI Service.
+   *
+   * @var \Symfony\Component\HttpFoundation\RequestStack
+   */
+  protected $request;
+
+  /**
    * HttpsRedirectSubscriber constructor.
    *
    * @param \Drupal\Core\Config\ConfigFactoryInterface $config_factory
    *   The config factory service.
    * @param \Drupal\Core\Cache\CacheBackendInterface $cache
    *   A cache backend used to store configuration.
+   * @param Symfony\Component\HttpFoundation\RequestStack $request_stack
+   *   The request URI service to get request URL.
    */
-  public function __construct(ConfigFactoryInterface $config_factory, CacheBackendInterface $cache) {
+  public function __construct(ConfigFactoryInterface $config_factory, CacheBackendInterface $cache, RequestStack $request_stack) {
     $this->config = $config_factory;
     $this->cache = $cache;
+    $this->request = $request_stack->getCurrentRequest();
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container) {
+    return new static(
+      $container->get('request_stack')
+    );
   }
 
   /**
    * Code that should be triggered on event specified.
    */
   public function onRequest(RequestEvent $event) {
+    // Match the pattern to see if the address is that of a localhost.
+    // Avoids execution if host matches or relates to 127.0.0.1 and so on.
+    $hostPattern = "/^((https?|http?|ftp)\:\/\/)?(127\.0{0,3}\.0{0,3}.0{0,2}1|localhost)?(:\d+)?$/";
+    $host = $this->request->getSchemeAndHttpHost();
     // Get the config value from cache if available.
     $https_status = $this->config->get('acquia_cms.settings')->get('acquia_cms_https');
-    if ($https_status) {
-      $request = $event->getRequest();
-      // Do not redirect from HTTPS requests.
-      if ($request->isSecure()) {
-        return;
+    // Allow only if the host is not a localhost.
+    if (!preg_match($hostPattern, $host)) {
+      if ($https_status) {
+        $request = $event->getRequest();
+        // Do not redirect from HTTPS requests.
+        if ($request->isSecure()) {
+          return;
+        }
+        $url = Url::fromUri("internal:{$request->getPathInfo()}");
+        $url->setOption('absolute', TRUE)
+          ->setOption('external', FALSE)
+          ->setOption('https', TRUE)
+          ->setOption('query', $request->query->all());
+
+        $status = $this->getRedirectStatus($event);
+        $url = $this->secureUrl($url->toString());
+        $response = new TrustedRedirectResponse($url, $status);
+        $event->setResponse($response);
       }
-
-      $url = Url::fromUri("internal:{$request->getPathInfo()}");
-      $url->setOption('absolute', TRUE)
-        ->setOption('external', FALSE)
-        ->setOption('https', TRUE)
-        ->setOption('query', $request->query->all());
-
-      $status = $this->getRedirectStatus($event);
-      $url = $this->secureUrl($url->toString());
-      $response = new TrustedRedirectResponse($url, $status);
-
-      $event->setResponse($response);
     }
-
   }
 
   /**


### PR DESCRIPTION
**Motivation**
* The BLT tests fail because of the HTTPS enforced status code.
Fixes #[ACMS-819](https://backlog.acquia.com/browse/ACMS-819)

**Proposed changes**
* Add a remote address condition in code to check the URL is not a localhost URL.

**Alternatives considered**
* None

**Testing steps**
* Setup Acquia CMS using BLT
* Run a BLT related test and observe that the tests complete successfully.

**Merge requirements**
- [ ] _Major change_, _Minor change_, _Bug_, _Enhancement_, and/or _Chore_ label applied
- [ ] Manual testing by a reviewer
