### PR TITLE
ACMS-891: Added dependency for search api autocomplete module.

### DIFF
--- a/modules/acquia_cms_search/acquia_cms_search.info.yml
+++ b/modules/acquia_cms_search/acquia_cms_search.info.yml
@@ -11,3 +11,4 @@ dependencies:
   - drupal:facets
   - drupal:collapsiblock
   - drupal:facets_pretty_paths
+  - drupal:search_api_autocomplete


### PR DESCRIPTION
**Motivation**
* The search bar on search result page is resulting in an incorrect styling of the search result bar.
Fixes #NNN

**Proposed changes**
* The module required for proper styling of the module was not getting enabled when search functionality is installed and enabled in isolated environment using custom profile.

**Alternatives considered**
* None

**Testing steps**
* Install the site in an isolated environment using a custom profile and install the following modules - 
* `composer require drupal/acquia_cms_article drupal/acquia_cms_audio drupal/acquia_cms_document drupal/acquia_cms_event drupal/acquia_cms_page drupal/acquia_cms_search drupal/acquia_cms_toolbar drupal/acquia_cms_video`
* You can use the following profile for testing - https://github.com/chandan-singh7929/starter
* See attached screenshots for better explanation
<img width="1518" alt="Screenshot 2021-08-30 at 5 27 57 PM" src="https://user-images.githubusercontent.com/15887127/131336824-967a8a9e-9f46-4529-8760-8c84a09b37cf.png">
<img width="1530" alt="Screenshot 2021-08-30 at 5 29 31 PM" src="https://user-images.githubusercontent.com/15887127/131336828-28686426-501d-4c63-8e6e-d311f182fefc.png">


**Merge requirements**
- [ ] _Major change_, _Minor change_, _Bug_, _Enhancement_, and/or _Chore_ label applied
- [ ] Manual testing by a reviewer
