### PR TITLE
ACMS-893: Add acquia_cms_common dependency to acquia_cms_site_studio.

### DIFF
--- a/modules/acquia_cms_site_studio/acquia_cms_site_studio.info.yml
+++ b/modules/acquia_cms_site_studio/acquia_cms_site_studio.info.yml
@@ -4,6 +4,7 @@ description: 'Module for Site Studio Installation Code.'
 core_version_requirement: ^9
 type: module
 dependencies:
+  - drupal:acquia_cms_common
   - drupal:cohesion
   - drupal:cohesion_base_styles
   - drupal:cohesion_custom_styles

--- a/modules/acquia_cms_site_studio/composer.json
+++ b/modules/acquia_cms_site_studio/composer.json
@@ -6,6 +6,7 @@
     "require": {
         "acquia/cohesion": "^6.5",
         "acquia/cohesion-theme": "^6.5",
+        "drupal/acquia_cms_common": "^1.3",
         "drupal/collapsiblock": "^3",
         "drupal/config_ignore": "^2.3",
         "drupal/config_rewrite": "1.4"


### PR DESCRIPTION
**Motivation**
<!-- What problem does this solve? Why is it important? What's the context? If this fixes an issue, link to it above. -->
Fixes ACMS-893

**Proposed changes**
<!-- What does this PR change? How does this impact end users? Are manual or automatic updates required? -->
Adds ACMS Common module as a dependency for ACMS Site Studio module.

**Alternatives considered**
<!-- How else could the original issue / use case be addressed? Why did you choose this solution over any others? -->
N/A

**Testing steps**
<!-- How can we replicate the issue and verify that this PR fixes it? -->
ACMS Site Studio module should be installable in the absence of all other ACMS component modules.

**Merge requirements**
- [ ] _Major change_, _Minor change_, _Bug_, _Enhancement_, and/or _Chore_ label applied
- [ ] Manual testing by a reviewer
