### PR TITLE
ACMS-897: Allow custom profile to install & configure site studio fro…

### DIFF
--- a/CUSTOM_PROFILE/README.md
+++ b/CUSTOM_PROFILE/README.md
@@ -34,6 +34,18 @@ Note that if you include a .install file in your profile that implements hook_in
 
 Drupal.org provides excellent documentation for creating custom profiles at https://www.drupal.org/docs/distributions/creating-distributions/how-to-write-a-drupal-installation-profile
 
+### Additional information:
+
+Acquia CMS components module provides patches for its dependencies,
+in order to use them add following key in your root level composer.json file.
+```
+{
+  "extra": {
+      "enable-patching": true
+  }
+}
+```
+
 ### Including Acquia CMS Site Studio
 
 For custom profiles that include the Acquia CMS Site Studio module, include the contents of the [CUSTOM_PROFILE.profile.example](https://github.com/acquia/acquia_cms/blob/develop/CUSTOM_PROFILE/CUSTOM_PROFILE.profile.example) file to provide install tasks related to Site Studio.

--- a/modules/acquia_cms_common/composer.json
+++ b/modules/acquia_cms_common/composer.json
@@ -23,6 +23,12 @@
         },
         "enable-patching": true,
         "patches": {
+            "drupal/core": {
+                "Frontpage View Title for breadcrumb trail": "https://www.drupal.org/files/issues/2021-07-01/core_frontpage_views_title_patch.patch",
+                "It is possible to overflow the number of items allowed in Media Library": "https://www.drupal.org/files/issues/2019-12-28/3082690-80.patch",
+                "Media Library widget produces error this value should not be null when field is required": "https://www.drupal.org/files/issues/2020-10-08/3160238-25.patch",
+                "SQLite database locking errors cause fatal errors": "https://www.drupal.org/files/issues/1120020-59.patch"
+            },
             "drupal/entity_clone": {
                 "Allow fields implementing EntityReferenceFieldItemListInterface to clone their referenced entities": "https://www.drupal.org/files/issues/2019-02-22/3013286-8.patch"
             },

--- a/modules/acquia_cms_common/composer.json
+++ b/modules/acquia_cms_common/composer.json
@@ -5,6 +5,7 @@
     "license": "GPL-2.0-or-later",
     "require": {
         "acquia/drupal-environment-detector": "^1.4",
+        "cweagans/composer-patches": "^1.7",
         "drupal/entity_clone": "1.0-beta4",
         "drupal/focal_point": "^1.5",
         "drupal/pathauto": "^1",
@@ -18,6 +19,15 @@
         "drush": {
             "services": {
                 "drush.services.yml": "^10"
+            }
+        },
+        "enable-patching": true,
+        "patches": {
+            "drupal/entity_clone": {
+                "Allow fields implementing EntityReferenceFieldItemListInterface to clone their referenced entities": "https://www.drupal.org/files/issues/2019-02-22/3013286-8.patch"
+            },
+            "drupal/focal_point": {
+                "3162210 - Preview link accidentally closes the media library": "https://www.drupal.org/files/issues/2020-10-06/3162210-17.patch"
             }
         }
     },

--- a/modules/acquia_cms_place/composer.json
+++ b/modules/acquia_cms_place/composer.json
@@ -4,6 +4,7 @@
     "description": "Provides a Place content type and related configuration.",
     "license": "GPL-2.0-or-later",
     "require": {
+        "cweagans/composer-patches": "^1.7",
         "drupal/acquia_cms_image": "^1.0",
         "drupal/address": "^1",
         "drupal/field_group": "^3",
@@ -11,6 +12,14 @@
         "drupal/geofield": "^1",
         "drupal/scheduler": "^1.3",
         "geocoder-php/google-maps-provider": "^4.6"
+    },
+    "extra": {
+        "enable-patching": true,
+        "patches": {
+            "drupal/geocoder": {
+                "3224364 - Replace deprecated boolean return in uksort() for PHP 8 compatibility.": "https://www.drupal.org/files/issues/2021-07-19/3224364-2.patch"
+            }
+        }
     },
     "repositories": {
         "drupal": {

--- a/modules/acquia_cms_place/composer.json
+++ b/modules/acquia_cms_place/composer.json
@@ -4,7 +4,6 @@
     "description": "Provides a Place content type and related configuration.",
     "license": "GPL-2.0-or-later",
     "require": {
-        "cweagans/composer-patches": "^1.7",
         "drupal/acquia_cms_image": "^1.0",
         "drupal/address": "^1",
         "drupal/field_group": "^3",

--- a/modules/acquia_cms_site_studio/composer.json
+++ b/modules/acquia_cms_site_studio/composer.json
@@ -6,7 +6,6 @@
     "require": {
         "acquia/cohesion": "^6.5",
         "acquia/cohesion-theme": "^6.5",
-        "cweagans/composer-patches": "^1.7",
         "drupal/acquia_cms_common": "^1.3",
         "drupal/collapsiblock": "^3",
         "drupal/config_ignore": "^2.3",

--- a/modules/acquia_cms_site_studio/composer.json
+++ b/modules/acquia_cms_site_studio/composer.json
@@ -6,6 +6,7 @@
     "require": {
         "acquia/cohesion": "^6.5",
         "acquia/cohesion-theme": "^6.5",
+        "cweagans/composer-patches": "^1.7",
         "drupal/acquia_cms_common": "^1.3",
         "drupal/collapsiblock": "^3",
         "drupal/config_ignore": "^2.3",
@@ -15,6 +16,12 @@
         "drush": {
             "services": {
                 "drush.services.yml": "^10"
+            }
+        },
+        "enable-patching": true,
+        "patches": {
+            "acquia/cohesion": {
+                "Site install using UI gives 403 on finish, due to update core 9.2": "https://gist.githubusercontent.com/vishalkhode1/8762f8e2e5569f01a3fdcf3b8d8e2b50/raw/3f916d17b717fd5f3c215bde02e741a9ee7be4e5/site-studio-access-denied.patch"
             }
         }
     },

--- a/modules/acquia_cms_site_studio/composer.json
+++ b/modules/acquia_cms_site_studio/composer.json
@@ -21,6 +21,8 @@
         "enable-patching": true,
         "patches": {
             "acquia/cohesion": {
+                "Cannot use positional argument after named argument in _batch_process()": "https://raw.githubusercontent.com/acquia/acquia_cms/8d4d4d55fdaead4036cce2595dfacec1af804aec/patches/site-studio-batch-error-php8.patch",
+                "Error: Attempt to modify property 'styles' on array": "https://gist.githubusercontent.com/vishalkhode1/bd7b69d7353bd22b3d766cad726c02ac/raw/76a96fc38310ebdf8e7fc7e755c927a1587d7889/site-studio-styles-error.patch",
                 "Site install using UI gives 403 on finish, due to update core 9.2": "https://gist.githubusercontent.com/vishalkhode1/8762f8e2e5569f01a3fdcf3b8d8e2b50/raw/3f916d17b717fd5f3c215bde02e741a9ee7be4e5/site-studio-access-denied.patch"
             }
         }


### PR DESCRIPTION
…m site install form

**Motivation**
<!-- What problem does this solve? Why is it important? What's the context? If this fixes an issue, link to it above. -->
Fixes #[ACMS-897]

**Proposed changes**
<!-- What does this PR change? How does this impact end users? Are manual or automatic updates required? -->
Patch acquia/cohesion due to current issue [ACO-1169](https://backlog.acquia.com/browse/ACO-1169) to fix site install using UI

**Alternatives considered**
<!-- How else could the original issue / use case be addressed? Why did you choose this solution over any others? -->
N/A
**Testing steps**
<!-- How can we replicate the issue and verify that this PR fixes it? -->
- composer create-project drupal/recommended-project drupal9
- cd drupal9
- composer config minimum-stability dev
- composer config repositories.acquia_cms_profile_generator vcs 'git@github.com:acquia/acquia_cms_profile_generator.git'
- composer require acquia/acquia_cms_profile_generator
- ./vendor/bin/robo acquia:generate-profile
- Generate the profile and make sure to include acquia_cms_page module (This will automatically include acquia_cms_sit_studio module).
- Install the site using custom profile created above. After all modules are installed from the custom profile, you'll see user is redirected back to install page.
- 
**Merge requirements**
- [ ] _Major change_, _Minor change_, _Bug_, _Enhancement_, and/or _Chore_ label applied
- [ ] Manual testing by a reviewer
