### PR TITLE
ACMS-874: Can't edit user profile because password policy validates e…

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -56,7 +56,7 @@
         "drupal/moderation_dashboard": "1.0.0-beta3",
         "drupal/moderation_sidebar": "^1.4",
         "drupal/mysql56": "^1.0",
-        "drupal/password_policy": "3.0-beta1",
+        "drupal/password_policy": "^3.0",
         "drupal/pathauto": "^1",
         "drupal/recaptcha": "^3",
         "drupal/redirect": "^1",
@@ -175,10 +175,6 @@
             },
             "drupal/geocoder": {
                 "3224364 - Replace deprecated boolean return in uksort() for PHP 8 compatibility.": "https://www.drupal.org/files/issues/2021-07-19/3224364-2.patch"
-            },
-            "drupal/password_policy": {
-                "Field field_last_password_reset is unknown": "https://www.drupal.org/files/issues/2020-07-03/2771129-114.patch",
-                "Register account anonymously, does not validate constraint 'password_username'.": "https://www.drupal.org/files/issues/2020-09-24/password-username-validate--3161012-4.patch"
             },
             "drupal/reroute_email": {
                 "Core version needs removing from info file": "https://www.drupal.org/files/issues/2020-11-17/reroute_email-remove-core-version-3182079-5.patch"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "ceb71a197931ad92fbc280fd7b4a356a",
+    "content-hash": "625260646b7817ab5643b7f32b57dddc",
     "packages": [
         {
             "name": "acquia/acsf-contenthub-console",
@@ -3249,7 +3249,7 @@
             ],
             "authors": [
                 {
-                    "name": "Darvanen",
+                    "name": "darvanen",
                     "homepage": "https://www.drupal.org/user/1068770"
                 },
                 {
@@ -5762,17 +5762,17 @@
         },
         {
             "name": "drupal/password_policy",
-            "version": "3.0.0-beta1",
+            "version": "3.0.0",
             "source": {
                 "type": "git",
                 "url": "https://git.drupalcode.org/project/password_policy.git",
-                "reference": "8.x-3.0-beta1"
+                "reference": "8.x-3.0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://ftp.drupal.org/files/projects/password_policy-8.x-3.0-beta1.zip",
-                "reference": "8.x-3.0-beta1",
-                "shasum": "676f944750732168d4b39b50fedc67f03bbd43a6"
+                "url": "https://ftp.drupal.org/files/projects/password_policy-8.x-3.0.zip",
+                "reference": "8.x-3.0",
+                "shasum": "6fbc4fe40ab26ec19e5ca37aaaa676348dc7fddb"
             },
             "require": {
                 "drupal/core": "^8 || ^9",
@@ -5781,11 +5781,11 @@
             "type": "drupal-module",
             "extra": {
                 "drupal": {
-                    "version": "8.x-3.0-beta1",
-                    "datestamp": "1586446450",
+                    "version": "8.x-3.0",
+                    "datestamp": "1625082607",
                     "security-coverage": {
-                        "status": "not-covered",
-                        "message": "Beta releases are not covered by Drupal security advisories."
+                        "status": "covered",
+                        "message": "Covered by Drupal's security advisory policy"
                     }
                 }
             },
@@ -7137,7 +7137,7 @@
             "extra": {
                 "drupal": {
                     "version": "6.0.4",
-                    "datestamp": "1624461046",
+                    "datestamp": "1629907247",
                     "security-coverage": {
                         "status": "covered",
                         "message": "Covered by Drupal's security advisory policy"
@@ -19012,5 +19012,5 @@
     "prefer-lowest": false,
     "platform": [],
     "platform-dev": [],
-    "plugin-api-version": "2.1.0"
+    "plugin-api-version": "2.0.0"
 }


### PR DESCRIPTION
…ven when password unchanged

**Motivation**
<!-- What problem does this solve? Why is it important? What's the context? If this fixes an issue, link to it above. -->
Fixes #[ACMS-874](https://backlog.acquia.com/browse/ACMS-874)

**Proposed changes**
<!-- What does this PR change? How does this impact end users? Are manual or automatic updates required? -->
Update module version to fix all existing issue.

**Alternatives considered**
<!-- How else could the original issue / use case be addressed? Why did you choose this solution over any others? -->
Apply patch for all issue.

**Testing steps**
<!-- How can we replicate the issue and verify that this PR fixes it? -->

1.  Update profile issue.
     - Login using admin user, edit account and click on save. 
2. Register account anonymously, does not validate constraint 'password_username
     - Change user register setting and allow user to register account anonymously without email validation option
     - Register account from user/register page, and provide username as password issue
     - It should check for username can't set as password
3.  Field field_last_password_reset is unknown issue
     - Install site look for error `Field field_last_password_reset is unknown`

**Merge requirements**
- [x] _Major change_, _Minor change_, _Bug_, _Enhancement_, and/or _Chore_ label applied
- [x] Manual testing by a reviewer
