### PR TITLE
ACMS-839: Changed the email ID to example no reply.

### DIFF
--- a/config/optional/reroute_email.settings.yml
+++ b/config/optional/reroute_email.settings.yml
@@ -2,5 +2,5 @@ enable: true
 description: true
 message: true
 mailkeys: ''
-address: no-reply@acquia.com
+address: no-reply@example.com
 whitelist: ''

--- a/drush/drush.yml
+++ b/drush/drush.yml
@@ -15,5 +15,5 @@ command:
       options:
         # Set a predetermined site-name when using site-install.
         site-name: 'Acquia CMS'
-        site-mail: 'no-reply@acquia.com'
-        account-mail: 'no-reply@acquia.com'
+        site-mail: 'no-reply@example.com'
+        account-mail: 'no-reply@example.com'

--- a/hooks/common/post-code-deploy/install_acms.sh
+++ b/hooks/common/post-code-deploy/install_acms.sh
@@ -22,7 +22,7 @@ if [ "$target_env" = "ode4" ]; then
     /usr/local/bin/drush9 @$site.$target_env updatedb --no-interaction
 # Install Acquia CMS.
 else
-    /usr/local/bin/drush9 @$site.$target_env site-install acquia_cms --account-pass=admin --yes --account-mail=no-reply@acquia.com --site-mail=no-reply@acquia.com
+    /usr/local/bin/drush9 @$site.$target_env site-install acquia_cms --account-pass=admin --yes --account-mail=no-reply@example.com --site-mail=no-reply@example.com
 fi
 
 # Toggle Modules based on the environment.

--- a/hooks/common/post-code-update/install_acms.sh
+++ b/hooks/common/post-code-update/install_acms.sh
@@ -22,7 +22,7 @@ if [ "$target_env" = "ode4" ]; then
     /usr/local/bin/drush9 @$site.$target_env updatedb --no-interaction
 # Install Acquia CMS.
 else
-    /usr/local/bin/drush9 @$site.$target_env site-install acquia_cms --account-pass=admin --yes --account-mail=no-reply@acquia.com --site-mail=no-reply@acquia.com
+    /usr/local/bin/drush9 @$site.$target_env site-install acquia_cms --account-pass=admin --yes --account-mail=no-reply@example.com --site-mail=no-reply@example.com
 fi
 
 /usr/local/bin/drush9 @$site.$target_env pm-enable acquia_cms_development --yes

--- a/modules/acquia_cms_common/acquia_cms_common.module
+++ b/modules/acquia_cms_common/acquia_cms_common.module
@@ -220,3 +220,14 @@ function _acquia_cms_common_update_view_display_options_style($view_name, $displ
     $view_storage->save($view);
   }
 }
+
+/**
+ * Implements hook_mail_alter().
+ */
+function acquia_cms_common_mail_alter(&$message) {
+  if (strpos($message['key'], 'template::') === 0) {
+    if ((!empty($message['from'])) && ($message['from'] === 'no-reply@example.com')) {
+      $message['send'] = 'false';
+    }
+  }
+}


### PR DESCRIPTION
**Motivation**
* The email id configured at various places is no reply acquia. It should be changed to no reply example.
Fixes #NNN

**Proposed changes**
* Change email ID to no reply example.

**Alternatives considered**
* None

**Testing steps**
* Check that all places have new email ID configured and the mail is only sent if the mail id is changed.

**Merge requirements**
- [ ] _Major change_, _Minor change_, _Bug_, _Enhancement_, and/or _Chore_ label applied
- [ ] Manual testing by a reviewer
