### PR TITLE
ACMS-914: Drupal Image Styles in ACMS do not use 'Focal point scale a…

### DIFF
--- a/modules/acquia_cms_image/acquia_cms_image.install
+++ b/modules/acquia_cms_image/acquia_cms_image.install
@@ -5,6 +5,7 @@
  * Install, update and uninstall functions for the acquia_cms_image module.
  */
 
+use Drupal\Core\Config\FileStorage;
 use Drupal\Core\Installer\InstallerKernel;
 
 /**
@@ -33,5 +34,32 @@ function acquia_cms_image_module_implements_alter(array &$implementations, strin
     if (InstallerKernel::installationAttempted()) {
       unset($implementations['default_content']);
     }
+  }
+}
+
+/**
+ * Update image style to use 'Focal point scale and crop' effect.
+ */
+function acquia_cms_image_update_8001() {
+  $module_path = \Drupal::moduleHandler()->getModule('acquia_cms_image')->getPath();
+  $config_optional = $module_path . '/config/optional';
+
+  $source_optional_dir = new FileStorage($config_optional);
+  $config_storage = \Drupal::service('config.storage');
+  // Image styles name for updating Focal point scale and crop effect.
+  $image_styles = [
+    'image.style.coh_small_square',
+    'image.style.coh_large_landscape',
+    'image.style.coh_small_landscape',
+    'image.style.coh_medium_landscape',
+    'image.style.coh_x_large_landscape',
+    'image.style.coh_xx_small_landscape',
+    'image.style.coh_xx_large_landscape',
+    'image.style.coh_large_super_landscape',
+    'image.style.coh_medium_super_landscape',
+    'image.style.coh_x_large_super_landscape',
+  ];
+  foreach ($image_styles as $image_style) {
+    $config_storage->write($image_style, $source_optional_dir->read($image_style));
   }
 }

--- a/modules/acquia_cms_image/config/optional/image.style.coh_large_landscape.yml
+++ b/modules/acquia_cms_image/config/optional/image.style.coh_large_landscape.yml
@@ -1,17 +1,19 @@
 langcode: en
 status: true
 dependencies:
+  module:
+    - focal_point
   enforced:
     module:
       - acquia_cms_image
 name: coh_large_landscape
 label: 'Large landscape (1024x683)'
 effects:
-  e9089c93-176a-4841-8fcf-5b7e5e859ab0:
-    uuid: e9089c93-176a-4841-8fcf-5b7e5e859ab0
-    id: image_scale_and_crop
+  39fc4c54-ae2c-4de4-a02a-d06d882da247:
+    uuid: 39fc4c54-ae2c-4de4-a02a-d06d882da247
+    id: focal_point_scale_and_crop
     weight: 1
     data:
       width: 1024
       height: 683
-      anchor: center-center
+      crop_type: focal_point

--- a/modules/acquia_cms_image/config/optional/image.style.coh_large_super_landscape.yml
+++ b/modules/acquia_cms_image/config/optional/image.style.coh_large_super_landscape.yml
@@ -1,17 +1,19 @@
 langcode: en
 status: true
 dependencies:
+  module:
+    - focal_point
   enforced:
     module:
       - acquia_cms_image
 name: coh_large_super_landscape
 label: 'Large super landscape (1024x480)'
 effects:
-  e9089c93-176a-4841-8fcf-5b7e5e859ab0:
-    uuid: e9089c93-176a-4841-8fcf-5b7e5e859ab0
-    id: image_scale_and_crop
+  8bbe9d4d-cd43-44e9-a209-457a4caaeee4:
+    uuid: 8bbe9d4d-cd43-44e9-a209-457a4caaeee4
+    id: focal_point_scale_and_crop
     weight: 1
     data:
       width: 1024
       height: 480
-      anchor: center-center
+      crop_type: focal_point

--- a/modules/acquia_cms_image/config/optional/image.style.coh_medium_landscape.yml
+++ b/modules/acquia_cms_image/config/optional/image.style.coh_medium_landscape.yml
@@ -1,17 +1,19 @@
 langcode: en
 status: true
 dependencies:
+  module:
+    - focal_point
   enforced:
     module:
       - acquia_cms_image
 name: coh_medium_landscape
 label: 'Medium landscape (768x512)'
 effects:
-  823dd069-3fea-44d7-a594-104ad44a4fba:
-    uuid: 823dd069-3fea-44d7-a594-104ad44a4fba
-    id: image_scale_and_crop
+  87cf2dba-d703-4f1e-ab98-3f21eb92ecd2:
+    uuid: 87cf2dba-d703-4f1e-ab98-3f21eb92ecd2
+    id: focal_point_scale_and_crop
     weight: 1
     data:
       width: 768
       height: 512
-      anchor: center-center
+      crop_type: focal_point

--- a/modules/acquia_cms_image/config/optional/image.style.coh_medium_super_landscape.yml
+++ b/modules/acquia_cms_image/config/optional/image.style.coh_medium_super_landscape.yml
@@ -1,17 +1,19 @@
 langcode: en
 status: true
 dependencies:
+  module:
+    - focal_point
   enforced:
     module:
       - acquia_cms_image
 name: coh_medium_super_landscape
 label: 'Medium super landscape (768x360)'
 effects:
-  823dd069-3fea-44d7-a594-104ad44a4fba:
-    uuid: 823dd069-3fea-44d7-a594-104ad44a4fba
-    id: image_scale_and_crop
+  a7be10be-726c-4b2a-8025-9a9b7dd85a00:
+    uuid: a7be10be-726c-4b2a-8025-9a9b7dd85a00
+    id: focal_point_scale_and_crop
     weight: 1
     data:
       width: 768
       height: 360
-      anchor: center-center
+      crop_type: focal_point

--- a/modules/acquia_cms_image/config/optional/image.style.coh_small_landscape.yml
+++ b/modules/acquia_cms_image/config/optional/image.style.coh_small_landscape.yml
@@ -1,17 +1,19 @@
 langcode: en
 status: true
 dependencies:
+  module:
+    - focal_point
   enforced:
     module:
       - acquia_cms_image
 name: coh_small_landscape
 label: 'Small landscape (568x352)'
 effects:
-  8081d8c5-76e6-480e-8fea-1c3daaa64b23:
-    uuid: 8081d8c5-76e6-480e-8fea-1c3daaa64b23
-    id: image_scale_and_crop
+  d8e910fc-dc0e-4a7d-bc21-a3be9cb7a560:
+    uuid: d8e910fc-dc0e-4a7d-bc21-a3be9cb7a560
+    id: focal_point_scale_and_crop
     weight: 1
     data:
       width: 568
       height: 352
-      anchor: center-center
+      crop_type: focal_point

--- a/modules/acquia_cms_image/config/optional/image.style.coh_small_square.yml
+++ b/modules/acquia_cms_image/config/optional/image.style.coh_small_square.yml
@@ -1,17 +1,19 @@
 langcode: en
 status: true
 dependencies:
+  module:
+    - focal_point
   enforced:
     config:
       - core.entity_view_display.media.image.default
 name: coh_small_square
 label: 'Small square (568x568)'
 effects:
-  9b59a7b4-40a6-4a5c-b8ef-b6b46640465e:
-    uuid: 9b59a7b4-40a6-4a5c-b8ef-b6b46640465e
-    id: image_scale_and_crop
+  34322c52-b7f4-4755-bd49-62d4bb2b8e08:
+    uuid: 34322c52-b7f4-4755-bd49-62d4bb2b8e08
+    id: focal_point_scale_and_crop
     weight: 1
     data:
       width: 568
       height: 568
-      anchor: center-center
+      crop_type: focal_point

--- a/modules/acquia_cms_image/config/optional/image.style.coh_x_large_landscape.yml
+++ b/modules/acquia_cms_image/config/optional/image.style.coh_x_large_landscape.yml
@@ -1,17 +1,19 @@
 langcode: en
 status: true
 dependencies:
+  module:
+    - focal_point
   enforced:
     module:
       - acquia_cms_image
 name: coh_x_large_landscape
 label: 'X Large landscape (1360x908)'
 effects:
-  e9089c93-176a-4841-8fcf-5b7e5e859ab0:
-    uuid: e9089c93-176a-4841-8fcf-5b7e5e859ab0
-    id: image_scale_and_crop
+  ff9be98a-6552-4ae0-8687-8bf8e4dc61ef:
+    uuid: ff9be98a-6552-4ae0-8687-8bf8e4dc61ef
+    id: focal_point_scale_and_crop
     weight: 1
     data:
       width: 1360
       height: 908
-      anchor: center-center
+      crop_type: focal_point

--- a/modules/acquia_cms_image/config/optional/image.style.coh_x_large_super_landscape.yml
+++ b/modules/acquia_cms_image/config/optional/image.style.coh_x_large_super_landscape.yml
@@ -1,17 +1,19 @@
 langcode: en
 status: true
 dependencies:
+  module:
+    - focal_point
   enforced:
     module:
       - acquia_cms_image
 name: coh_x_large_super_landscape
 label: 'X Large super landscape (1360x640)'
 effects:
-  e9089c93-176a-4841-8fcf-5b7e5e859ab0:
-    uuid: e9089c93-176a-4841-8fcf-5b7e5e859ab0
-    id: image_scale_and_crop
+  b2c98208-726a-44f9-99de-2624f33ac6bd:
+    uuid: b2c98208-726a-44f9-99de-2624f33ac6bd
+    id: focal_point_scale_and_crop
     weight: 1
     data:
       width: 1360
       height: 640
-      anchor: center-center
+      crop_type: focal_point

--- a/modules/acquia_cms_image/config/optional/image.style.coh_xx_large_landscape.yml
+++ b/modules/acquia_cms_image/config/optional/image.style.coh_xx_large_landscape.yml
@@ -1,17 +1,19 @@
 langcode: en
 status: true
 dependencies:
+  module:
+    - focal_point
   enforced:
     module:
       - acquia_cms_image
 name: coh_xx_large_landscape
 label: 'XX Large landscape (1600x1067)'
 effects:
-  9af59107-7d25-4a0a-97e9-6e2c4c1855b7:
-    uuid: 9af59107-7d25-4a0a-97e9-6e2c4c1855b7
-    id: image_scale_and_crop
+  4fc6f472-7800-4b98-a94d-0e29a3996610:
+    uuid: 4fc6f472-7800-4b98-a94d-0e29a3996610
+    id: focal_point_scale_and_crop
     weight: 1
     data:
       width: 1600
       height: 1067
-      anchor: center-center
+      crop_type: focal_point

--- a/modules/acquia_cms_image/config/optional/image.style.coh_xx_small_landscape.yml
+++ b/modules/acquia_cms_image/config/optional/image.style.coh_xx_small_landscape.yml
@@ -1,17 +1,19 @@
 langcode: en
 status: true
 dependencies:
+  module:
+    - focal_point
   enforced:
     module:
       - acquia_cms_image
 name: coh_xx_small_landscape
 label: 'XX Small landscape (160x120)'
 effects:
-  0410655e-6d68-4687-b13e-b30b5d4093b1:
-    uuid: 0410655e-6d68-4687-b13e-b30b5d4093b1
-    id: image_scale_and_crop
+  9846c8a0-70c1-4f9b-ae0a-53411f2a6c52:
+    uuid: 9846c8a0-70c1-4f9b-ae0a-53411f2a6c52
+    id: focal_point_scale_and_crop
     weight: 1
     data:
       width: 160
       height: 120
-      anchor: center-center
+      crop_type: focal_point


### PR DESCRIPTION
…nd crop'

**Motivation**
<!-- What problem does this solve? Why is it important? What's the context? If this fixes an issue, link to it above. -->
Fixes #[ACMS-914](https://backlog.acquia.com/browse/ACMS-914)

**Proposed changes**
<!-- What does this PR change? How does this impact end users? Are manual or automatic updates required? -->
Update image style to use effect focal point and crop

**Alternatives considered**
<!-- How else could the original issue / use case be addressed? Why did you choose this solution over any others? -->
NA

**Testing steps**
<!-- How can we replicate the issue and verify that this PR fixes it? -->

- Install site using Acquia CMS
- Verify image style from (/admin/config/media/image-styles) edit any style, for example (/admin/config/media/image-styles/manage/coh_large_landscape)
- Check image effect, its showing "Scale and crop 1024×683" 

**Merge requirements**
- [ ] _Major change_, _Minor change_, _Bug_, _Enhancement_, and/or _Chore_ label applied
- [ ] Manual testing by a reviewer
