### PR TITLE
ACMS-917: Acquia CMS's Event Cards view block broken OOTB

### DIFF
--- a/modules/acquia_cms_common/src/EventSubscriber/ConfigEventsSubscriber.php
+++ b/modules/acquia_cms_common/src/EventSubscriber/ConfigEventsSubscriber.php
@@ -59,6 +59,7 @@ class ConfigEventsSubscriber implements EventSubscriberInterface {
     if ($this->moduleHandler->moduleExists('acquia_cms_site_studio')) {
       switch ($config->getName()) {
         case 'views.view.event_cards':
+          _acquia_cms_common_update_view_display_options_style('event_cards', 'past_events_block', 'view_tpl_event_cards_slider');
           _acquia_cms_common_update_view_display_options_style('event_cards', 'upcoming_events_block', 'view_tpl_event_cards_slider');
           break;
 

--- a/modules/acquia_cms_event/acquia_cms_event.install
+++ b/modules/acquia_cms_event/acquia_cms_event.install
@@ -5,6 +5,8 @@
  * Install, update and uninstall functions for the acquia_cms_event module.
  */
 
+use Drupal\Core\Config\FileStorage;
+
 /**
  * Implements hook_install().
  */
@@ -18,4 +20,16 @@ function acquia_cms_event_install() {
     'edit any event content',
     'delete any event content',
   ]);
+}
+
+/**
+ * Update past events views display & its title.
+ */
+function acquia_cms_event_update_8001() {
+  $module_path = \Drupal::moduleHandler()->getModule('acquia_cms_event')->getPath();
+  $config_optional = $module_path . '/config/optional';
+  $source_optional_dir = new FileStorage($config_optional);
+
+  $config_storage = \Drupal::service('config.storage');
+  $config_storage->write('views.view.event_cards', $source_optional_dir->read('views.view.event_cards'));
 }

--- a/modules/acquia_cms_event/config/optional/views.view.event_cards.yml
+++ b/modules/acquia_cms_event/config/optional/views.view.event_cards.yml
@@ -181,11 +181,11 @@ display:
   past_events_block:
     display_plugin: block
     id: past_events_block
-    display_title: ''
+    display_title: 'Past Events'
     position: 2
     display_options:
       display_extenders: {  }
-      title: 'Past Events'
+      title: ''
       defaults:
         title: false
         filters: false

--- a/modules/acquia_cms_event/tests/src/ExistingSite/PastEventsBlockTest.php
+++ b/modules/acquia_cms_event/tests/src/ExistingSite/PastEventsBlockTest.php
@@ -66,7 +66,6 @@ class PastEventsBlockTest extends ExistingSiteBase {
    */
   public function testPastEventsBlock() {
     $this->drupalGet('');
-    $this->assertSession()->pageTextContains('Past Events');
     $this->assertLinksExistInOrder();
   }
 


### PR DESCRIPTION
**Motivation**
<!-- What problem does this solve? Why is it important? What's the context? If this fixes an issue, link to it above. -->
Fixes #[ACMS-917](https://backlog.acquia.com/browse/ACMS-917)

**Proposed changes**
<!-- What does this PR change? How does this impact end users? Are manual or automatic updates required? -->
Update past event view display to use cohesion template with display title changes.

**Alternatives considered**
<!-- How else could the original issue / use case be addressed? Why did you choose this solution over any others? -->
NA

**Testing steps**
<!-- How can we replicate the issue and verify that this PR fixes it? -->

- Install Acquia CMS.
- Enable starter module.
- Create some events with past date.
- Add past event block on page.
- Verify its displaying correctly.
- Now visit past events views block `/admin/structure/views/view/event_cards/edit/upcoming_events_block` and make sure nothing is broken.

**Merge requirements**
- [ ] _Major change_, _Minor change_, _Bug_, _Enhancement_, and/or _Chore_ label applied
- [ ] Manual testing by a reviewer
