### PR TITLE
ACMS-918: Starter module create event content with title past event

### DIFF
--- a/modules/acquia_cms_starter/content/node/1761acce-1b37-4359-944f-abbeb34097d4.yml
+++ b/modules/acquia_cms_starter/content/node/1761acce-1b37-4359-944f-abbeb34097d4.yml
@@ -20,7 +20,7 @@ default:
       target_id: 0
   title:
     -
-      value: 'Past event one medium length placeholder heading.'
+      value: 'Event one medium length placeholder heading.'
   created:
     -
       value: 1612541528
@@ -38,7 +38,7 @@ default:
       value: published
   path:
     -
-      alias: /event/webinar/2020/01/past-event-one-medium-length-placeholder-heading
+      alias: /event/webinar/2020/01/event-one-medium-length-placeholder-heading
       langcode: en
       pathauto: 1
   publish_state:

--- a/modules/acquia_cms_starter/content/node/493e1456-3ec1-4696-903e-3d21e2612ea3.yml
+++ b/modules/acquia_cms_starter/content/node/493e1456-3ec1-4696-903e-3d21e2612ea3.yml
@@ -20,7 +20,7 @@ default:
       target_id: 0
   title:
     -
-      value: 'Past event five medium length placeholder heading.'
+      value: 'Event five medium length placeholder heading.'
   created:
     -
       value: 1612541528
@@ -38,7 +38,7 @@ default:
       value: published
   path:
     -
-      alias: /event/webinar/2020/05/past-event-five-medium-length-placeholder-heading
+      alias: /event/webinar/2020/05/event-five-medium-length-placeholder-heading
       langcode: en
       pathauto: 1
   publish_state:

--- a/modules/acquia_cms_starter/content/node/4e5945c9-3f3f-4785-b864-d24b6fad041a.yml
+++ b/modules/acquia_cms_starter/content/node/4e5945c9-3f3f-4785-b864-d24b6fad041a.yml
@@ -20,7 +20,7 @@ default:
       target_id: 0
   title:
     -
-      value: 'Past event three medium length placeholder heading.'
+      value: 'Event three medium length placeholder heading.'
   created:
     -
       value: 1612541528
@@ -38,7 +38,7 @@ default:
       value: published
   path:
     -
-      alias: /event/webinar/2020/03/past-event-three-medium-length-placeholder-heading
+      alias: /event/webinar/2020/03/event-three-medium-length-placeholder-heading
       langcode: en
       pathauto: 1
   publish_state:

--- a/modules/acquia_cms_starter/content/node/79f98237-e9e8-435a-b462-b240a59d0986.yml
+++ b/modules/acquia_cms_starter/content/node/79f98237-e9e8-435a-b462-b240a59d0986.yml
@@ -20,7 +20,7 @@ default:
       target_id: 0
   title:
     -
-      value: 'Past event two medium length placeholder heading.'
+      value: 'Event two medium length placeholder heading.'
   created:
     -
       value: 1612541528
@@ -38,7 +38,7 @@ default:
       value: published
   path:
     -
-      alias: /event/webinar/2020/02/past-event-two-medium-length-placeholder-heading
+      alias: /event/webinar/2020/02/event-two-medium-length-placeholder-heading
       langcode: en
       pathauto: 1
   publish_state:

--- a/modules/acquia_cms_starter/content/node/9ca2f5ef-2134-4999-acca-53ec55d7e926.yml
+++ b/modules/acquia_cms_starter/content/node/9ca2f5ef-2134-4999-acca-53ec55d7e926.yml
@@ -20,7 +20,7 @@ default:
       target_id: 0
   title:
     -
-      value: 'Past event four medium length placeholder heading.'
+      value: 'Event four medium length placeholder heading.'
   created:
     -
       value: 1612541528
@@ -38,7 +38,7 @@ default:
       value: published
   path:
     -
-      alias: /event/webinar/2020/04/past-event-four-medium-length-placeholder-heading
+      alias: /event/webinar/2020/04/event-four-medium-length-placeholder-heading
       langcode: en
       pathauto: 1
   publish_state:

--- a/modules/acquia_cms_starter/content/node/c99c8891-79ff-48db-abeb-87d477e944bc.yml
+++ b/modules/acquia_cms_starter/content/node/c99c8891-79ff-48db-abeb-87d477e944bc.yml
@@ -20,7 +20,7 @@ default:
       target_id: 0
   title:
     -
-      value: 'Past event six medium length placeholder heading.'
+      value: 'Event six medium length placeholder heading.'
   created:
     -
       value: 1612541528
@@ -38,7 +38,7 @@ default:
       value: published
   path:
     -
-      alias: /event/webinar/2020/06/past-event-six-medium-length-placeholder-heading
+      alias: /event/webinar/2020/06/event-six-medium-length-placeholder-heading
       langcode: en
       pathauto: 1
   publish_state:


### PR DESCRIPTION
**Motivation**
<!-- What problem does this solve? Why is it important? What's the context? If this fixes an issue, link to it above. -->
Fixes #[ACMS-918](https://backlog.acquia.com/browse/ACMS-918)

**Proposed changes**
<!-- What does this PR change? How does this impact end users? Are manual or automatic updates required? -->
Update events content title created by starter module.

**Alternatives considered**
<!-- How else could the original issue / use case be addressed? Why did you choose this solution over any others? -->
NA

**Testing steps**
<!-- How can we replicate the issue and verify that this PR fixes it? -->

- Install acquia cms with site studio key.
- Enable start module.
- Place event slider component on home page, which by default place upcoming block.
- Visit home page you will notice upcoming block has with title past event. 

**Merge requirements**
- [ ] _Major change_, _Minor change_, _Bug_, _Enhancement_, and/or _Chore_ label applied
- [ ] Manual testing by a reviewer
