### PR TITLE
ACMS-882: Removed the update manager module from profile info file.

### DIFF
--- a/acquia_cms.info.yml
+++ b/acquia_cms.info.yml
@@ -64,7 +64,6 @@ install:
   - social_media_links
   - taxonomy
   - telephone
-  - update
   - username_enumeration_prevention
   - views_ui
   - workbench_email


### PR DESCRIPTION
**Motivation**
* The install new module link redirects to access denied page.
Fixes #NNN

**Proposed changes**
* Remove the update module from profile info file.

**Alternatives considered**
* None

**Testing steps**
* After merge, verify that install new module link is no longer available and also the update module is disabled.

**Merge requirements**
- [ ] _Major change_, _Minor change_, _Bug_, _Enhancement_, and/or _Chore_ label applied
- [ ] Manual testing by a reviewer
