### PR TITLE
ACMS-912: Added patch for default content module for Acquia CMS Image.

### DIFF
--- a/modules/acquia_cms_image/composer.json
+++ b/modules/acquia_cms_image/composer.json
@@ -4,10 +4,19 @@
     "description": "Provides an Image media type and related configuration.",
     "license": "GPL-2.0-or-later",
     "require": {
+        "cweagans/composer-patches": "^1.7",
         "drupal/acquia_cms_common": "^1.0",
         "drupal/default_content": "^2",
         "drupal/field_group": "^3",
         "drupal/imce": "^2"
+    },
+    "extra": {
+        "enable-patching": true,
+        "patches": {
+            "drupal/default_content": {
+                "2698425 - Duplicate content issues in default content": "https://git.drupalcode.org/project/default_content/-/merge_requests/5.patch"
+            }
+        }
     },
     "repositories": {
         "drupal": {


### PR DESCRIPTION
**Motivation**
* Added patch for Acquia CMS Image dependency on default content
Fixes #NNN

**Proposed changes**
* * Added patch for Acquia CMS Image dependency on default content

**Alternatives considered**
* None

**Testing steps**
* none

**Merge requirements**
- [ ] _Major change_, _Minor change_, _Bug_, _Enhancement_, and/or _Chore_ label applied
- [ ] Manual testing by a reviewer
