### PR TITLE
ACMS-925: Update Purge module with patch

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
         "drupal/acquia_connector": "^3",
         "drupal/acquia_contenthub": "^2.25",
         "drupal/acquia_lift": "^4.2",
-        "drupal/acquia_purge": "^1",
+        "drupal/acquia_purge": "^1.1",
         "drupal/acquia_search": "^3.0.3",
         "drupal/acquia_telemetry-acquia_telemetry": "1.0-alpha5",
         "drupal/acsf": "^2",
@@ -178,6 +178,9 @@
             },
             "drupal/geocoder": {
                 "3224364 - Replace deprecated boolean return in uksort() for PHP 8 compatibility.": "https://www.drupal.org/files/issues/2021-07-19/3224364-2.patch"
+            },
+            "drupal/purge": {
+                "3.1 release added dependency to dynamic_page_cache module": "https://git.drupalcode.org/issue/purge-3240230/-/commit/adb745b784475432fdc8b6f07e335cf0aa18bd66.patch"
             },
             "drupal/search_api": {
                 "Resolves call to member function preExecute() on null error on site install": "https://www.drupal.org/files/issues/2021-09-20/search_api_condition_cacheable_metadata.patch"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "59f07f1d95f911d6b4d98cbb78bf6917",
+    "content-hash": "041c0a3fe131a6d04414ed55825d67dc",
     "packages": [
         {
             "name": "acquia/acsf-contenthub-console",
@@ -2369,8 +2369,8 @@
                     "homepage": "http://www.acquia.com"
                 },
                 {
-                    "name": "anavarre",
-                    "homepage": "https://www.drupal.org/user/796160"
+                    "name": "japerry",
+                    "homepage": "https://www.drupal.org/user/45640"
                 },
                 {
                     "name": "nielsvm",
@@ -5561,6 +5561,9 @@
                 "reference": "8.x-1.2",
                 "shasum": "a4c4f6a7846971f494ee7850132bfbe220ff8687"
             },
+            "require": {
+                "drupal/core": "~9.0.0-beta3 || 9.1.* || 9.2.*"
+            },
             "type": "library",
             "extra": {
                 "drupal": {
@@ -5899,17 +5902,17 @@
         },
         {
             "name": "drupal/purge",
-            "version": "3.0.0",
+            "version": "3.1.0",
             "source": {
                 "type": "git",
                 "url": "https://git.drupalcode.org/project/purge.git",
-                "reference": "8.x-3.0"
+                "reference": "8.x-3.1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://ftp.drupal.org/files/projects/purge-8.x-3.0.zip",
-                "reference": "8.x-3.0",
-                "shasum": "e7113e9927dbdbbd5c2f4edc2649a14676e14f34"
+                "url": "https://ftp.drupal.org/files/projects/purge-8.x-3.1.zip",
+                "reference": "8.x-3.1",
+                "shasum": "cdf9c61f8e35dab0269e1389f0a9c493f26df1b8"
             },
             "require": {
                 "drupal/core": "^8.7.7 || ^9",
@@ -5918,8 +5921,8 @@
             "type": "drupal-module",
             "extra": {
                 "drupal": {
-                    "version": "8.x-3.0",
-                    "datestamp": "1590744318",
+                    "version": "8.x-3.1",
+                    "datestamp": "1633041576",
                     "security-coverage": {
                         "status": "covered",
                         "message": "Covered by Drupal's security advisory policy"
@@ -19020,5 +19023,5 @@
     "prefer-lowest": false,
     "platform": [],
     "platform-dev": [],
-    "plugin-api-version": "2.1.0"
+    "plugin-api-version": "2.0.0"
 }


### PR DESCRIPTION
**Motivation**
<!-- What problem does this solve? Why is it important? What's the context? If this fixes an issue, link to it above. -->
Fixes #[ACMS-925](https://backlog.acquia.com/browse/ACMS-925)

**Proposed changes**
<!-- What does this PR change? How does this impact end users? Are manual or automatic updates required? -->
Update purge module to latest and patch it.

**Alternatives considered**
<!-- How else could the original issue / use case be addressed? Why did you choose this solution over any others? -->

**Testing steps**
<!-- How can we replicate the issue and verify that this PR fixes it? -->

- With a fresh install of ACMS on Cloud IDE (ACMS 1.3.2) I’m seeing a fatal on page load saying that Drupal\dynamic_page_cache\EventSubscriber\DynamicPageCacheSubscriber cannot be found.

**Merge requirements**
- [ ] _Major change_, _Minor change_, _Bug_, _Enhancement_, and/or _Chore_ label applied
- [ ] Manual testing by a reviewer
