### PR TITLE
ACMS-925: Patches removed as purge module updated.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
         "drupal/acquia_connector": "^3",
         "drupal/acquia_contenthub": "^2.25",
         "drupal/acquia_lift": "^4.2",
-        "drupal/acquia_purge": "1.1",
+        "drupal/acquia_purge": "^1",
         "drupal/acquia_search": "^3.0.3",
         "drupal/acquia_telemetry-acquia_telemetry": "1.0-alpha5",
         "drupal/acsf": "^2",
@@ -178,10 +178,6 @@
             },
             "drupal/geocoder": {
                 "3224364 - Replace deprecated boolean return in uksort() for PHP 8 compatibility.": "https://www.drupal.org/files/issues/2021-07-19/3224364-2.patch"
-            },
-            "drupal/purge": {
-                "3.1 release added dependency to dynamic_page_cache module": "https://git.drupalcode.org/issue/purge-3240230/-/commit/adb745b784475432fdc8b6f07e335cf0aa18bd66.patch",
-                "Call to undefined method FilterResponseEvent::isMainRequest()": "https://git.drupalcode.org/project/purge/-/commit/b1ec9f4c7b7e03e7eccab22493e5f52aeb66c91e.patch"
             },
             "drupal/search_api": {
                 "Resolves call to member function preExecute() on null error on site install": "https://www.drupal.org/files/issues/2021-09-20/search_api_condition_cacheable_metadata.patch"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "367087664418c6d0d9e3df9906e44a18",
+    "content-hash": "59f07f1d95f911d6b4d98cbb78bf6917",
     "packages": [
         {
             "name": "acquia/acsf-contenthub-console",
@@ -5902,17 +5902,17 @@
         },
         {
             "name": "drupal/purge",
-            "version": "3.1.0",
+            "version": "3.2.0",
             "source": {
                 "type": "git",
                 "url": "https://git.drupalcode.org/project/purge.git",
-                "reference": "8.x-3.1"
+                "reference": "8.x-3.2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://ftp.drupal.org/files/projects/purge-8.x-3.1.zip",
-                "reference": "8.x-3.1",
-                "shasum": "cdf9c61f8e35dab0269e1389f0a9c493f26df1b8"
+                "url": "https://ftp.drupal.org/files/projects/purge-8.x-3.2.zip",
+                "reference": "8.x-3.2",
+                "shasum": "eb025762097e5435d11f8b5bcb1b0ef32a6b72fe"
             },
             "require": {
                 "drupal/core": "^8.7.7 || ^9",
@@ -5921,8 +5921,8 @@
             "type": "drupal-module",
             "extra": {
                 "drupal": {
-                    "version": "8.x-3.1",
-                    "datestamp": "1633041576",
+                    "version": "8.x-3.2",
+                    "datestamp": "1633428281",
                     "security-coverage": {
                         "status": "covered",
                         "message": "Covered by Drupal's security advisory policy"


### PR DESCRIPTION
**Motivation**
<!-- What problem does this solve? Why is it important? What's the context? If this fixes an issue, link to it above. -->
Fix failing CI job. It's failing due to purge module next version released and we've patches included which is now included in the next release.

**Proposed changes**
Reverted acquia_purge pinned module change from PR: https://github.com/acquia/acquia_cms/pull/952

**Merge requirements**
- [ ] _Major change_ applied
- [ ] Manual testing by a reviewer
