### PR TITLE
ACMS-925: Reverted changes.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
         "drupal/acquia_connector": "^3",
         "drupal/acquia_contenthub": "^2.25",
         "drupal/acquia_lift": "^4.2",
-        "drupal/acquia_purge": "1.1",
+        "drupal/acquia_purge": "^1",
         "drupal/acquia_search": "^3.0.3",
         "drupal/acquia_telemetry-acquia_telemetry": "1.0-alpha5",
         "drupal/acsf": "^2",
@@ -178,10 +178,6 @@
             },
             "drupal/geocoder": {
                 "3224364 - Replace deprecated boolean return in uksort() for PHP 8 compatibility.": "https://www.drupal.org/files/issues/2021-07-19/3224364-2.patch"
-            },
-            "drupal/purge": {
-                "3.1 release added dependency to dynamic_page_cache module": "https://git.drupalcode.org/issue/purge-3240230/-/commit/adb745b784475432fdc8b6f07e335cf0aa18bd66.patch",
-                "Call to undefined method FilterResponseEvent::isMainRequest()": "https://git.drupalcode.org/project/purge/-/commit/b1ec9f4c7b7e03e7eccab22493e5f52aeb66c91e.patch"
             },
             "drupal/search_api": {
                 "Resolves call to member function preExecute() on null error on site install": "https://www.drupal.org/files/issues/2021-09-20/search_api_condition_cacheable_metadata.patch"

--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
         "drupal/acquia_connector": "^3",
         "drupal/acquia_contenthub": "^2.25",
         "drupal/acquia_lift": "^4.2",
-        "drupal/acquia_purge": "^1",
+        "drupal/acquia_purge": "1.1",
         "drupal/acquia_search": "^3.0.3",
         "drupal/acquia_telemetry-acquia_telemetry": "1.0-alpha5",
         "drupal/acsf": "^2",
@@ -178,6 +178,10 @@
             },
             "drupal/geocoder": {
                 "3224364 - Replace deprecated boolean return in uksort() for PHP 8 compatibility.": "https://www.drupal.org/files/issues/2021-07-19/3224364-2.patch"
+            },
+            "drupal/purge": {
+                "3.1 release added dependency to dynamic_page_cache module": "https://git.drupalcode.org/issue/purge-3240230/-/commit/adb745b784475432fdc8b6f07e335cf0aa18bd66.patch",
+                "Call to undefined method FilterResponseEvent::isMainRequest()": "https://git.drupalcode.org/project/purge/-/commit/b1ec9f4c7b7e03e7eccab22493e5f52aeb66c91e.patch"
             },
             "drupal/search_api": {
                 "Resolves call to member function preExecute() on null error on site install": "https://www.drupal.org/files/issues/2021-09-20/search_api_condition_cacheable_metadata.patch"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "367087664418c6d0d9e3df9906e44a18",
+    "content-hash": "59f07f1d95f911d6b4d98cbb78bf6917",
     "packages": [
         {
             "name": "acquia/acsf-contenthub-console",
@@ -2369,8 +2369,8 @@
                     "homepage": "http://www.acquia.com"
                 },
                 {
-                    "name": "japerry",
-                    "homepage": "https://www.drupal.org/user/45640"
+                    "name": "anavarre",
+                    "homepage": "https://www.drupal.org/user/796160"
                 },
                 {
                     "name": "nielsvm",
@@ -5561,9 +5561,6 @@
                 "reference": "8.x-1.2",
                 "shasum": "a4c4f6a7846971f494ee7850132bfbe220ff8687"
             },
-            "require": {
-                "drupal/core": "~9.0.0-beta3 || 9.1.* || 9.2.*"
-            },
             "type": "library",
             "extra": {
                 "drupal": {
@@ -5902,17 +5899,17 @@
         },
         {
             "name": "drupal/purge",
-            "version": "3.1.0",
+            "version": "3.0.0",
             "source": {
                 "type": "git",
                 "url": "https://git.drupalcode.org/project/purge.git",
-                "reference": "8.x-3.1"
+                "reference": "8.x-3.0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://ftp.drupal.org/files/projects/purge-8.x-3.1.zip",
-                "reference": "8.x-3.1",
-                "shasum": "cdf9c61f8e35dab0269e1389f0a9c493f26df1b8"
+                "url": "https://ftp.drupal.org/files/projects/purge-8.x-3.0.zip",
+                "reference": "8.x-3.0",
+                "shasum": "e7113e9927dbdbbd5c2f4edc2649a14676e14f34"
             },
             "require": {
                 "drupal/core": "^8.7.7 || ^9",
@@ -5921,8 +5918,8 @@
             "type": "drupal-module",
             "extra": {
                 "drupal": {
-                    "version": "8.x-3.1",
-                    "datestamp": "1633041576",
+                    "version": "8.x-3.0",
+                    "datestamp": "1590744318",
                     "security-coverage": {
                         "status": "covered",
                         "message": "Covered by Drupal's security advisory policy"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "59f07f1d95f911d6b4d98cbb78bf6917",
+    "content-hash": "367087664418c6d0d9e3df9906e44a18",
     "packages": [
         {
             "name": "acquia/acsf-contenthub-console",
@@ -5902,17 +5902,17 @@
         },
         {
             "name": "drupal/purge",
-            "version": "3.2.0",
+            "version": "3.1.0",
             "source": {
                 "type": "git",
                 "url": "https://git.drupalcode.org/project/purge.git",
-                "reference": "8.x-3.2"
+                "reference": "8.x-3.1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://ftp.drupal.org/files/projects/purge-8.x-3.2.zip",
-                "reference": "8.x-3.2",
-                "shasum": "eb025762097e5435d11f8b5bcb1b0ef32a6b72fe"
+                "url": "https://ftp.drupal.org/files/projects/purge-8.x-3.1.zip",
+                "reference": "8.x-3.1",
+                "shasum": "cdf9c61f8e35dab0269e1389f0a9c493f26df1b8"
             },
             "require": {
                 "drupal/core": "^8.7.7 || ^9",
@@ -5921,8 +5921,8 @@
             "type": "drupal-module",
             "extra": {
                 "drupal": {
-                    "version": "8.x-3.2",
-                    "datestamp": "1633428281",
+                    "version": "8.x-3.1",
+                    "datestamp": "1633041576",
                     "security-coverage": {
                         "status": "covered",
                         "message": "Covered by Drupal's security advisory policy"


### PR DESCRIPTION
**Motivation**
<!-- What problem does this solve? Why is it important? What's the context? If this fixes an issue, link to it above. -->
Revert changes for ACMS-925. We no longer need purge module patches as it's already incorporated in next release for purge module i.e v3.2 of purge module

**Proposed changes**
Reverted commits of ticket ACMS-925 contains in the following PR:
1. https://github.com/acquia/acquia_cms/pull/952
2. https://github.com/acquia/acquia_cms/pull/958

**Testing steps**
<!-- How can we replicate the issue and verify that this PR fixes it? -->

**Merge requirements**
- [ ] _Major change_ applied
- [ ] Manual testing by a reviewer
