### PR TITLE
ACMS-645: Added patches for checlist and gdpr modules.

### DIFF
--- a/modules/acquia_cms_privacy/composer.json
+++ b/modules/acquia_cms_privacy/composer.json
@@ -4,8 +4,25 @@
     "description": "Module for configuring the gdpr and EU cookie compliance modules.",
     "license": "GPL-2.0-or-later",
     "require": {
+        "cweagans/composer-patches": "^1.7",
         "drupal/eu_cookie_compliance": "^1.19",
-        "drupal/gdpr": "^3.0@alpha"
+        "drupal/gdpr": "3.0.0-alpha4"
+    },
+    "extra": {
+        "drush": {
+            "services": {
+                "drush.services.yml": "^10"
+            }
+        },
+        "enable-patching": true,
+        "patches": {
+            "drupal/checklistapi": {
+                "Alter the prgress bar based upon the default value passed": "https://www.drupal.org/files/issues/2021-10-26/checklistapi-count-default-values-forprogress-2311855-2.patch"
+            },
+            "drupal/gdpr": {
+                "Altered the text for Polocies and other Measures tab": "https://gist.githubusercontent.com/panshulK/844666d662ffc2e12f55b66dbfa915bf/raw/f2ff809e9401b2a7fae7c5f1ace791b79968c972/gdpr-module-checklist-acms.patch"
+            }
+        }
     },
     "repositories": {
         "drupal": {


### PR DESCRIPTION
**Motivation**
* The improvements required for GDPR and related modules
Fixes #NNN

**Proposed changes**
* Alter the checklist text for indicating the module presence in ACMS using the acquia_cms_privacy module.

**Alternatives considered**
* None

**Testing steps**
* Download the module and notice that rlated modules are installed and patched without any errors.
* Test the functionality by visiting the checklist page provided by gdpr module.

**Merge requirements**
- [ ] _Major change_, _Minor change_, _Bug_, _Enhancement_, and/or _Chore_ label applied
- [ ] Manual testing by a reviewer
