### PR TITLE
ACMS-952: Update cohesion.setting config to set default sidebar view.

### DIFF
--- a/modules/acquia_cms_site_studio/acquia_cms_site_studio.module
+++ b/modules/acquia_cms_site_studio/acquia_cms_site_studio.module
@@ -83,6 +83,7 @@ function update_site_studio_settings() {
     ],
   ]);
   $config->set('use_dx8', 'enable');
+  $config->set('sidebar_view_style', 'titles');
   $config->save();
 }
 


### PR DESCRIPTION
Fixes the ExistingSiteJavascript test failure

**Motivation**
<!-- What problem does this solve? Why is it important? What's the context? If this fixes an issue, link to it above. -->
Fixes the issue for ExistingSiteJavascript test failure during CRON runs

**Proposed changes**
Updated the config `cohesion.settings` to set default sidebar view to: Show Title. This issue is most probably caused due to [ACMS-935](https://backlog.acquia.com/browse/ACMS-935) as we've removed the `cohesion.settings` config, which we've provided in config/install directory (earlier) and we've now programatically imported the config during site install.

**Testing steps**
- Install the site with Site Studio.
- Run the following tests: `docroot/profiles/contrib/acquia_cms/tests/src/ExistingSiteJavascript/AccordionComponentTest.php` and this should pass.

**Merge requirements**
- [ ] _Minor change_
- [ ] Manual testing by a reviewer
