### PR TITLE
ACMS-955: Display a warning message post UI install.

### DIFF
--- a/modules/acquia_cms_starter/acquia_cms_starter.install
+++ b/modules/acquia_cms_starter/acquia_cms_starter.install
@@ -34,17 +34,6 @@ function acquia_cms_starter_requirements(string $phase) : array {
               'severity' => REQUIREMENT_WARNING,
             ];
           }
-          else {
-            // Otherwise, the install is via the UI and we should direct them
-            // to the tour dashboard.
-            $requirements['acquia_cms_starter_google_maps_api_key'] = [
-              'title' => t('Google Maps API Key is missing!'),
-              'description' => t('Acquia CMS Starter requires a Google Maps API key to be set. <a href="@url">Go here to set it.</a>', [
-                '@url' => '/admin/tour/dashboard',
-              ]),
-              'severity' => REQUIREMENT_ERROR,
-            ];
-          }
         }
       }
     }
@@ -70,4 +59,35 @@ function acquia_cms_starter_requirements(string $phase) : array {
 function acquia_cms_starter_install() {
   \Drupal::service('module_installer')->install(['webform']);
   \Drupal::service('module_installer')->install(['webform_ui']);
+}
+
+/**
+ * Implements hook_modules_installed().
+ */
+function acquia_cms_starter_modules_installed(array $modules) {
+  // Moved the warning display for MAPS key from hook_requirements() above.
+  // The intention behind doing this was to display the warning message,
+  // on successful module installation.
+  // The warning message is ignored on UI installation in hook_requirements
+  // upon setting the severity level to REQUIRMENT_WARNING.
+  // Check issue here -  https://www.drupal.org/project/drupal/issues/2295051
+  $entity_type_manager = Drupal::entityTypeManager();
+  if ($entity_type_manager->hasDefinition('geocoder_provider')) {
+    /** @var \Drupal\geocoder\GeocoderProviderInterface $provider */
+    $provider = $entity_type_manager->getStorage('geocoder_provider')
+      ->load('googlemaps');
+
+    if ($provider) {
+      $configuration = $provider->get('configuration');
+      if (empty($configuration['apiKey'])) {
+        // Tweaked the message to be displayed on UI installation.
+        // The module will be installed with warning messages.
+        if (PHP_SAPI !== 'cli') {
+          \Drupal::messenger()->addWarning(t('The Google API key is not set, and you will see warnings below. They are technically harmless, but the maps will not work. You can set the key later <a href="@url">here</a> and resave your starter content to generate them.', [
+            '@url' => '/admin/tour/dashboard',
+          ]));
+        }
+      }
+    }
+  }
 }


### PR DESCRIPTION
**Motivation**
* The module acquia_cms_starter is not enabled when enabled using UI. The module should be enabled and a warning should be displayed as it is displayed when we enable the module using drush.
Fixes #[ACMS-955](https://backlog.acquia.com/browse/ACMS-955)

**Proposed changes**
* Added hook_modules_installed() to install the module and display the warning message for MAPS API key not set.

**Alternatives considered**
* The warning message could also be displayed by setting 'severity' => REQUIREMENT_WARNING in hook_requirements hook.
* But this doesn't work and the warning message is completely ignored in case of UI installation method.
* Check the issue link here - https://www.drupal.org/project/drupal/issues/2295051

**Testing steps**
* Enable the module using UI module enabling method and notice that module is enabled without any issues and just warning messages related to MAPS API key (See attached screenshot).

**Merge requirements**
- [ ] _Major change_, _Minor change_, _Bug_, _Enhancement_, and/or _Chore_ label applied
- [ ] Manual testing by a reviewer

**SCREENSHOT**
<img width="1430" alt="Screenshot 2021-11-08 at 6 54 10 PM" src="https://user-images.githubusercontent.com/15887127/140751878-e9bab5cf-0a22-4161-bb97-f99c00fef2d0.png">
