### PR TITLE
ACMS-976: Fixed deprecated code warnings: Call to deprecated method getSession().

### DIFF
--- a/tests/src/ExistingSiteJavascript/CohesionElement.php
+++ b/tests/src/ExistingSiteJavascript/CohesionElement.php
@@ -4,6 +4,7 @@ namespace Drupal\Tests\acquia_cms\ExistingSiteJavascript;
 
 use Behat\Mink\Element\ElementInterface;
 use Behat\Mink\Element\NodeElement;
+use Behat\Mink\Session;
 use Drupal\Tests\acquia_cms\Traits\AwaitTrait;
 use PHPUnit\Framework\Assert;
 
@@ -11,6 +12,19 @@ use PHPUnit\Framework\Assert;
  * Base wrapper class for interacting with the Cohesion UI.
  */
 abstract class CohesionElement extends NodeElement {
+
+  /**
+   * @var \Behat\Mink\Session
+   */
+  protected $session;
+
+  /**
+   * {@inheritdoc}
+   */
+  public function __construct($xpath, Session $session) {
+    $this->session = $session;
+    parent::__construct($xpath, $session);
+  }
 
   use AwaitTrait {
     waitForElementVisible as traitWaitForElementVisible;
@@ -20,7 +34,7 @@ abstract class CohesionElement extends NodeElement {
    * {@inheritdoc}
    */
   protected function waitForElementVisible(string $selector, $locator, ElementInterface $container = NULL) : ElementInterface {
-    return $this->traitWaitForElementVisible($selector, $locator, $container ?: $this->getSession()->getPage());
+    return $this->traitWaitForElementVisible($selector, $locator, $container ?: $this->session->getPage());
   }
 
   /**
@@ -31,7 +45,7 @@ abstract class CohesionElement extends NodeElement {
    */
   protected function waitForElementBrowser() : ElementBrowser {
     $element = $this->waitForElementVisible('css', '.coh-element-browser-modal');
-    return new ElementBrowser($element->getXpath(), $this->getSession());
+    return new ElementBrowser($element->getXpath(), $this->session);
   }
 
   /**
@@ -47,7 +61,7 @@ abstract class CohesionElement extends NodeElement {
     $selector = sprintf('.coh-layout-canvas-list-item[data-type="%s"]', $label);
     $element = $this->waitForElementVisible('css', $selector, $this);
 
-    return new Component($element->getXpath(), $element->getSession());
+    return new Component($element->getXpath(), $this->session);
   }
 
   /**

--- a/tests/src/ExistingSiteJavascript/CohesionTestBase.php
+++ b/tests/src/ExistingSiteJavascript/CohesionTestBase.php
@@ -25,7 +25,7 @@ abstract class CohesionTestBase extends ExistingSiteSelenium2DriverTestBase {
    */
   protected function getLayoutCanvas() : LayoutCanvas {
     $element = $this->waitForElementVisible('css', '.coh-layout-canvas', $this->getSession()->getPage());
-    return new LayoutCanvas($element->getXpath(), $element->getSession());
+    return new LayoutCanvas($element->getXpath(), $this->getSession());
   }
 
   /**
@@ -127,7 +127,7 @@ abstract class CohesionTestBase extends ExistingSiteSelenium2DriverTestBase {
    */
   protected function getSearch() : Search {
     $element = $this->waitForElementVisible('css', '.search-toggle-button', $this->getSession()->getPage());
-    return new Search($element->getXpath(), $element->getSession());
+    return new Search($element->getXpath(), $this->getSession());
   }
 
   /**

--- a/tests/src/ExistingSiteJavascript/SearchTest.php
+++ b/tests/src/ExistingSiteJavascript/SearchTest.php
@@ -293,7 +293,7 @@ class SearchTest extends ExistingSiteSelenium2DriverTestBase {
    */
   protected function getSearch() : Search {
     $element = $this->waitForElementVisible('css', '.search-toggle-button', $this->getSession()->getPage());
-    return new Search($element->getXpath(), $element->getSession());
+    return new Search($element->getXpath(), $this->getSession());
   }
 
 }

--- a/tests/travis/install.sh
+++ b/tests/travis/install.sh
@@ -37,7 +37,7 @@ printenv | grep ACMS_ | sort
 cd $ORCA_FIXTURE_DIR
 
 # Rebuild cohesion after install.
-if [[ "$ACMS_JOB" != "base" ]] && [[ "$ACMS_JOB" != "starter" ]] && [[ "$ORCA_JOB" != "LOOSE_DEPRECATED_CODE_SCAN" ]] && [[ "$ORCA_JOB" != "DEPRECATED_CODE_SCAN_W_CONTRIB" ]]; then
+if [[ "$ACMS_JOB" != "base" ]] && [[ "$ACMS_JOB" != "starter" ]] && [[ "$ORCA_JOB" != "LOOSE_DEPRECATED_CODE_SCAN" ]] && [[ "$ORCA_JOB" != "DEPRECATED_CODE_SCAN_W_CONTRIB" ]] && [[ "$ORCA_JOB" != "STRICT_DEPRECATED_CODE_SCAN" ]]; then
   drush cohesion:rebuild -y
 fi
 


### PR DESCRIPTION
**Motivation**
Fixes `STRICT_DEPRECATED_CODE_SCAN` travis job.

**Proposed changes**
The method `$element->getSession()` has been marked as deprecated from mink: 1.6. See [here](https://github.com/minkphp/Mink/blob/master/CHANGES.md#160--2014-09-26). 
In class CohesionElement.php (tests/src/ExistingSiteJavascript/CohesionElement.php) we've used `$element->getSession()` & `$this->getSession()` at multiple places. But since the method `getSession()` from element is marked as deprecated, so it's giving error. To fix this, we've added a protected variable `$session` in the class and use that instead everywhere (where session is required)

**Alternatives considered**
N/A

**Testing steps**
In order to test in local, we need drupal-check command. Use the following commands to download drupal-check command and test:
1. composer require mglaman/drupal-check --dev
2. ./vendor/bin/drupal-check tests/src --memory-limit=-1

You shouldn't see any error & warnings when running above drupal-check command.
Also, run the complete site tests to make sure all tests are passing i.e `./acms-run-tests.sh `

**Merge requirements**
- [ ] _Major change_ applied
- [ ] Manual testing by a reviewer
