### PR TITLE
ACMS-979: Fixed the patch failing issue on Drupal 9.3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -36,7 +36,7 @@
         "drupal/collapsiblock": "^3",
         "drupal/config_ignore": "2.3.0",
         "drupal/config_rewrite": "^1.4",
-        "drupal/core": "~9.1.13 || ^9.2.6",
+        "drupal/core": "~9.2.6 || ^9.3",
         "drupal/default_content": "2.0.0-alpha1",
         "drupal/diff": "^1",
         "drupal/entity_clone": "1.0-beta6",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "abcf13cd2755c2eca8dbf04ccb4ae5a1",
+    "content-hash": "d8ca57b361e70b9b8d56168dc7150d9a",
     "packages": [
         {
             "name": "acquia/acsf-contenthub-console",
@@ -3467,16 +3467,16 @@
         },
         {
             "name": "drupal/core",
-            "version": "9.2.10",
+            "version": "9.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/drupal/core.git",
-                "reference": "61248f85f78c02e7e0afde2b8a5113d3914bb50f"
+                "reference": "1e1bf0e841e11029b21775dd125332d7ffd6fb47"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/drupal/core/zipball/61248f85f78c02e7e0afde2b8a5113d3914bb50f",
-                "reference": "61248f85f78c02e7e0afde2b8a5113d3914bb50f",
+                "url": "https://api.github.com/repos/drupal/core/zipball/1e1bf0e841e11029b21775dd125332d7ffd6fb47",
+                "reference": "1e1bf0e841e11029b21775dd125332d7ffd6fb47",
                 "shasum": ""
             },
             "require": {
@@ -3484,7 +3484,7 @@
                 "composer/semver": "^3.0",
                 "doctrine/annotations": "^1.12",
                 "doctrine/reflection": "^1.1",
-                "egulias/email-validator": "^2.0",
+                "egulias/email-validator": "^2.1.22|^3.0",
                 "ext-date": "*",
                 "ext-dom": "*",
                 "ext-filter": "*",
@@ -3512,8 +3512,9 @@
                 "symfony/event-dispatcher": "^4.4",
                 "symfony/http-foundation": "^4.4.7",
                 "symfony/http-kernel": "^4.4",
-                "symfony/mime": "^5.3.0",
+                "symfony/mime": "^5.4",
                 "symfony/polyfill-iconv": "^1.0",
+                "symfony/polyfill-php80": "^1.16",
                 "symfony/process": "^4.4",
                 "symfony/psr-http-message-bridge": "^2.0",
                 "symfony/routing": "^4.4",
@@ -3540,6 +3541,7 @@
                 "drupal/book": "self.version",
                 "drupal/breakpoint": "self.version",
                 "drupal/ckeditor": "self.version",
+                "drupal/ckeditor5": "self.version",
                 "drupal/claro": "self.version",
                 "drupal/classy": "self.version",
                 "drupal/color": "self.version",
@@ -3706,7 +3708,8 @@
                     "lib/Drupal/Core/Site/Settings.php"
                 ],
                 "files": [
-                    "includes/bootstrap.inc"
+                    "includes/bootstrap.inc",
+                    "includes/guzzle_php81_shim.php"
                 ]
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -3715,9 +3718,9 @@
             ],
             "description": "Drupal is an open source content management platform powering millions of websites and applications.",
             "support": {
-                "source": "https://github.com/drupal/core/tree/9.2.10"
+                "source": "https://github.com/drupal/core/tree/9.3.0"
             },
-            "time": "2021-11-24T14:27:27+00:00"
+            "time": "2021-12-08T22:09:38+00:00"
         },
         {
             "name": "drupal/crop",
@@ -5558,32 +5561,35 @@
         },
         {
             "name": "drupal/mysql56",
-            "version": "1.2.0",
+            "version": "1.3.0",
             "source": {
                 "type": "git",
                 "url": "https://git.drupalcode.org/project/mysql56.git",
-                "reference": "8.x-1.2"
+                "reference": "8.x-1.3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://ftp.drupal.org/files/projects/mysql56-8.x-1.2.zip",
-                "reference": "8.x-1.2",
-                "shasum": "a4c4f6a7846971f494ee7850132bfbe220ff8687"
+                "url": "https://ftp.drupal.org/files/projects/mysql56-8.x-1.3.zip",
+                "reference": "8.x-1.3",
+                "shasum": "9666b1c8df22509e2443ed98f8edd7c14f8a5234"
             },
             "require": {
-                "drupal/core": "~9.0.0-beta3 || 9.1.* || 9.2.*"
+                "drupal/core": "~9.0.0-beta3 || 9.1.* || 9.2.* || 9.3.*"
             },
             "type": "library",
             "extra": {
                 "drupal": {
-                    "version": "8.x-1.2",
-                    "datestamp": "1623858646",
+                    "version": "8.x-1.3",
+                    "datestamp": "1634249671",
                     "security-coverage": {
                         "status": "covered",
                         "message": "Covered by Drupal's security advisory policy"
                     }
                 },
-                "installer-name": "mysql"
+                "installer-name": "mysql",
+                "branch-alias": {
+                    "dev-8.x-1.x": "1.x-dev"
+                }
             },
             "autoload": {
                 "psr-4": {
@@ -7571,27 +7577,27 @@
         },
         {
             "name": "egulias/email-validator",
-            "version": "2.1.25",
+            "version": "3.1.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/egulias/EmailValidator.git",
-                "reference": "0dbf5d78455d4d6a41d186da50adc1122ec066f4"
+                "reference": "ee0db30118f661fb166bcffbf5d82032df484697"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/egulias/EmailValidator/zipball/0dbf5d78455d4d6a41d186da50adc1122ec066f4",
-                "reference": "0dbf5d78455d4d6a41d186da50adc1122ec066f4",
+                "url": "https://api.github.com/repos/egulias/EmailValidator/zipball/ee0db30118f661fb166bcffbf5d82032df484697",
+                "reference": "ee0db30118f661fb166bcffbf5d82032df484697",
                 "shasum": ""
             },
             "require": {
-                "doctrine/lexer": "^1.0.1",
-                "php": ">=5.5",
-                "symfony/polyfill-intl-idn": "^1.10"
+                "doctrine/lexer": "^1.2",
+                "php": ">=7.2",
+                "symfony/polyfill-intl-idn": "^1.15"
             },
             "require-dev": {
-                "dominicsayers/isemail": "^3.0.7",
-                "phpunit/phpunit": "^4.8.36|^7.5.15",
-                "satooshi/php-coveralls": "^1.0.1"
+                "php-coveralls/php-coveralls": "^2.2",
+                "phpunit/phpunit": "^8.5.8|^9.3.3",
+                "vimeo/psalm": "^4"
             },
             "suggest": {
                 "ext-intl": "PHP Internationalization Libraries are required to use the SpoofChecking validation"
@@ -7599,7 +7605,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.1.x-dev"
+                    "dev-master": "3.0.x-dev"
                 }
             },
             "autoload": {
@@ -7627,7 +7633,7 @@
             ],
             "support": {
                 "issues": "https://github.com/egulias/EmailValidator/issues",
-                "source": "https://github.com/egulias/EmailValidator/tree/2.1.25"
+                "source": "https://github.com/egulias/EmailValidator/tree/3.1.2"
             },
             "funding": [
                 {
@@ -7635,7 +7641,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2020-12-29T14:50:06+00:00"
+            "time": "2021-10-11T09:18:27+00:00"
         },
         {
             "name": "enlightn/security-checker",

--- a/modules/acquia_cms_common/acquia_cms_common.module
+++ b/modules/acquia_cms_common/acquia_cms_common.module
@@ -9,7 +9,9 @@ use Drupal\acquia_cms_common\Facade\MetatagFacade;
 use Drupal\acquia_cms_common\Facade\SitemapFacade;
 use Drupal\acquia_cms_common\Facade\WorkbenchEmailFacade;
 use Drupal\acquia_cms_common\Facade\WorkflowFacade;
+use Drupal\Core\Breadcrumb\Breadcrumb;
 use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\Routing\RouteMatchInterface;
 use Drupal\Core\Url;
 use Drupal\imce\Imce;
 use Drupal\node\NodeTypeInterface;
@@ -235,5 +237,25 @@ function acquia_cms_common_mail_alter(&$message) {
     if ((!empty($message['from'])) && ($message['from'] === 'no-reply@example.com')) {
       $message['send'] = 'false';
     }
+  }
+}
+
+/**
+ * Implements hook_system_breadcrumb_alter().
+ *
+ * This fixes the issue: https://www.drupal.org/project/drupal/issues/3220437.
+ *
+ * @todo Remove below & tests (NodeBreadcrumbTest) code once we have the stable working
+ * patch for this issue.
+ */
+function acquia_cms_common_system_breadcrumb_alter(Breadcrumb &$breadcrumb, RouteMatchInterface $route_match, array $context) {
+  if ($route_match->getRouteName() == "node.add" || $route_match->getRouteName() == "entity.node.edit_form") {
+    foreach ($breadcrumb->getLinks() as &$link) {
+      if (!$link->getText() && $link->getUrl()->getRouteName() == "view.frontpage.page_1") {
+        $link->setText(t("Node"));
+        break;
+      }
+    }
+    $breadcrumb->addCacheTags(['config:views.view.frontpage']);
   }
 }

--- a/modules/acquia_cms_common/composer.json
+++ b/modules/acquia_cms_common/composer.json
@@ -24,7 +24,6 @@
         "enable-patching": true,
         "patches": {
             "drupal/core": {
-                "Frontpage View Title for breadcrumb trail": "https://www.drupal.org/files/issues/2021-07-01/core_frontpage_views_title_patch.patch",
                 "It is possible to overflow the number of items allowed in Media Library": "https://www.drupal.org/files/issues/2019-12-28/3082690-80.patch",
                 "Media Library widget produces error this value should not be null when field is required": "https://www.drupal.org/files/issues/2020-10-08/3160238-25.patch",
                 "SQLite database locking errors cause fatal errors": "https://www.drupal.org/files/issues/1120020-59.patch"

--- a/modules/acquia_cms_common/tests/src/Functional/NodeBreadcrumbTest.php
+++ b/modules/acquia_cms_common/tests/src/Functional/NodeBreadcrumbTest.php
@@ -1,0 +1,111 @@
+<?php
+
+namespace Drupal\Tests\acquia_cms_common\Functional;
+
+use Drupal\Core\StringTranslation\StringTranslationTrait;
+use Drupal\Core\Url;
+use Drupal\Tests\BrowserTestBase;
+use Drupal\Tests\system\Functional\Menu\AssertBreadcrumbTrait;
+use Drupal\views\Views;
+
+/**
+ * Tests to verify breadcrumbs appearing on Node create/edit page.
+ *
+ * @group acquia_cms_common
+ * @group acquia_cms
+ * @group push
+ */
+class NodeBreadcrumbTest extends BrowserTestBase {
+
+  use AssertBreadcrumbTrait;
+  use StringTranslationTrait;
+
+  /**
+   * {@inheritdoc}
+   */
+  protected $defaultTheme = 'claro';
+
+  /**
+   * {@inheritdoc}
+   */
+  protected static $modules = [
+    'acquia_cms_common',
+    'views',
+  ];
+
+  /**
+   * The drupal user object.
+   *
+   * @var Drupal\user\Entity\User
+   */
+  protected $adminUser;
+
+  /**
+   * The path to frontpage of the site.
+   *
+   * @var string
+   */
+  protected $frontPagePath;
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp(): void {
+    parent::setUp();
+    $this->drupalCreateContentType([
+      'type' => 'page',
+      'name' => 'Basic page',
+    ]);
+    $this->adminUser = $this->drupalCreateUser([
+      'create page content',
+      'edit own page content',
+    ]);
+    $this->frontPagePath = Url::fromRoute('<front>')->toString();
+  }
+
+  /**
+   * Tests breadcrumb path on Node create page.
+   */
+  public function testNodeAddBreadcrumb() {
+    $this->drupalLogin($this->adminUser);
+    $this->assertBreadcrumb('node/add/page', [
+      $this->frontPagePath => 'Home',
+      'node' => 'Node',
+      'node/add' => 'Add content',
+    ]);
+  }
+
+  /**
+   * Tests breadcrumb path on Node edit page.
+   */
+  public function testNodeEditBreadcrumb() {
+    $this->drupalLogin($this->adminUser);
+    $node = $this->drupalCreateNode([
+      'type' => 'page',
+      'title' => $this->t('My Page Content'),
+      'uid' => $this->adminUser->id(),
+    ]);
+    $node->save();
+    $this->assertBreadcrumb("node/" . $node->id() . "/edit", [
+      $this->frontPagePath => 'Home',
+      'node' => 'Node',
+      $node->toUrl()->toString() => $this->t('My Page Content'),
+    ]);
+  }
+
+  /**
+   * Tests breadcrumb when title is updated on frontpage view.
+   */
+  public function testNodeBreadcrumbFromFrontpageView() {
+    $this->drupalLogin($this->adminUser);
+    $view = Views::getView('frontpage');
+    $view->getDisplay()->display['display_options']['title'] = "Another title";
+    $view->save();
+    $this->assertBreadcrumb('node/add/page', [
+      $this->frontPagePath => 'Home',
+      'node' => 'Another title',
+      'node/add' => 'Add content',
+    ]);
+  }
+
+}


### PR DESCRIPTION
**Motivation**
<!-- What problem does this solve? Why is it important? What's the context? If this fixes an issue, link to it above. -->
Fixes the patch failing issue on Drupal 9.3

**Proposed changes**
- Removed the patch and added hook_system_breadcrumb_alter() to set breadcrumb texts for node create/edit page (if it's empty)

**Alternatives considered**
Tried to use following composer plugin: https://github.com/netresearch/composer-patches-plugin but it's not working and giving error. It looks like it's conflicting with the composer plugin which we are using currently 
i.e `cweagans/composer-patches`

**Testing steps**
- Go to any content type create page and there you should see breadcrumb as: `Home -> Node -> Add content`.
- Go to any node edit page and there you should see breadcrumb as: `Home -> <Node Title>`.
- Navigate to Frontpage view (i.e /admin/structure/views/view/frontpage) & change to display title to anything like: 
`Some Title` and now navigate again to node create/edit page and you should see breadcrumb starting as: 
`Home -> Some Title`

**Merge requirements**
- [ ] _Major change_,
- [ ] Manual testing by a reviewer
- [ ] PHPUnit FunctionalTest added.
