### PR TITLE
Update patch from #3220437 to apply to 9.3.x with no other changes

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -163,7 +163,7 @@
                 "Support for export filtering via Drush": "https://www.drupal.org/files/issues/2021-08-18/config_ignore_2857247-75.patch"
             },
             "drupal/core": {
-                "Frontpage View Title for breadcrumb trail": "https://www.drupal.org/files/issues/2021-07-01/core_frontpage_views_title_patch.patch",
+                "3220437 - Empty breadcrumb at node/add and node/add/{content_type} when frontpage view is enabled\nl": "https://www.drupal.org/files/issues/2021-12-09/3220437-69--do-not-test.txt",
                 "It is possible to overflow the number of items allowed in Media Library": "https://www.drupal.org/files/issues/2019-12-28/3082690-80.patch",
                 "Media Library widget produces error this value should not be null when field is required": "https://www.drupal.org/files/issues/2020-10-08/3160238-25.patch",
                 "SQLite database locking errors cause fatal errors": "https://www.drupal.org/files/issues/1120020-59.patch"


### PR DESCRIPTION
**Motivation**
ORCA builds are broken because the existing patch doesn't apply to 9.3.x.

**Proposed changes**
Same exact end user behavior and contents of the patch. The patched file had some keys reordered so the patch needed to be updated.

**Alternatives considered**
There is an alternative (better?) approach in https://github.com/acquia/acquia_cms/pull/1000. But that work wasn't completed prior to 9.3.0 being released. This is intended as a hotfix to unblock the rest of engineering.

**Merge requirements**
- [ ] _Major change_, _Minor change_, _Bug_, _Enhancement_, and/or _Chore_ label applied
- [ ] Manual testing by a reviewer
