### PR TITLE
ACMS-990: ACMS should not use Media library for inserting images into…

### DIFF
--- a/modules/acquia_cms_site_studio/acquia_cms_site_studio.install
+++ b/modules/acquia_cms_site_studio/acquia_cms_site_studio.install
@@ -85,7 +85,7 @@ function set_theme_site_studio_as_default() {
 }
 
 /**
- * Use IMCE for inserting images into Site Studio configuration.
+ * Update Site Studio configuration to use IMCE as Image Browser.
  */
 function acquia_cms_site_studio_update_8001() {
   // Using media browser, creates problem if you ever want to export
@@ -93,11 +93,13 @@ function acquia_cms_site_studio_update_8001() {
   // as the media entity won't be included as Site Studio
   // does not export content entities as part of packages.
   $config = \Drupal::service('config.factory')->getEditable('cohesion.settings');
-  $config->set('image_browser.config', [
-    'type' => 'imce_imagebrowser',
-    'dx8_entity_browser' => 'media_browser',
-    'cohesion_media_lib_types' => ['image'],
-    'dx8_imce_stream_wrapper' => 'public',
-  ]);
-  $config->save();
+  if (!empty($config)) {
+    $config->set('image_browser.config', [
+      'type' => 'imce_imagebrowser',
+      'dx8_entity_browser' => 'media_browser',
+      'cohesion_media_lib_types' => ['image'],
+      'dx8_imce_stream_wrapper' => 'public',
+    ]);
+    $config->save();
+  }
 }

--- a/modules/acquia_cms_site_studio/acquia_cms_site_studio.install
+++ b/modules/acquia_cms_site_studio/acquia_cms_site_studio.install
@@ -93,13 +93,11 @@ function acquia_cms_site_studio_update_8001() {
   // as the media entity won't be included as Site Studio
   // does not export content entities as part of packages.
   $config = \Drupal::service('config.factory')->getEditable('cohesion.settings');
-  $config->set('image_browser', [
-    'config' => [
-      'type' => 'imce_imagebrowser',
-      'dx8_entity_browser' => 'media_browser',
-      'cohesion_media_lib_types' => ['image'],
-      'dx8_imce_stream_wrapper' => 'public',
-    ],
+  $config->set('image_browser.config', [
+    'type' => 'imce_imagebrowser',
+    'dx8_entity_browser' => 'media_browser',
+    'cohesion_media_lib_types' => ['image'],
+    'dx8_imce_stream_wrapper' => 'public',
   ]);
   $config->save();
 }

--- a/modules/acquia_cms_site_studio/acquia_cms_site_studio.install
+++ b/modules/acquia_cms_site_studio/acquia_cms_site_studio.install
@@ -83,3 +83,23 @@ function set_theme_site_studio_as_default() {
     ->set('default', 'cohesion_theme')
     ->save();
 }
+
+/**
+ * Use IMCE for inserting images into Site Studio configuration.
+ */
+function acquia_cms_site_studio_update_8001() {
+  // Using media browser, creates problem if you ever want to export
+  // the configuration using the Site Studio package manager
+  // as the media entity won't be included as Site Studio
+  // does not export content entities as part of packages.
+  $config = \Drupal::service('config.factory')->getEditable('cohesion.settings');
+  $config->set('image_browser', [
+    'config' => [
+      'type' => 'imce_imagebrowser',
+      'dx8_entity_browser' => 'media_browser',
+      'cohesion_media_lib_types' => ['image'],
+      'dx8_imce_stream_wrapper' => 'public',
+    ],
+  ]);
+  $config->save();
+}

--- a/modules/acquia_cms_site_studio/acquia_cms_site_studio.module
+++ b/modules/acquia_cms_site_studio/acquia_cms_site_studio.module
@@ -72,9 +72,10 @@ function update_site_studio_settings() {
   $config = \Drupal::service('config.factory')->getEditable('cohesion.settings');
   $config->set('image_browser', [
     'config' => [
-      'type' => 'medialib_imagebrowser',
+      'type' => 'imce_imagebrowser',
       'dx8_entity_browser' => 'media_browser',
       'cohesion_media_lib_types' => ['image'],
+      'dx8_imce_stream_wrapper' => 'public',
     ],
     'content' => [
       'type' => 'medialib_imagebrowser',


### PR DESCRIPTION
… Site Studio configuration.

**Motivation**
<!-- What problem does this solve? Why is it important? What's the context? If this fixes an issue, link to it above. -->
Fixes #[ACMS-990](https://backlog.acquia.com/browse/ACMS-990)

**Proposed changes**
<!-- What does this PR change? How does this impact end users? Are manual or automatic updates required? -->
Use IMCE for site studio configuration.

**Alternatives considered**
<!-- How else could the original issue / use case be addressed? Why did you choose this solution over any others? -->
NA

**Testing steps**
<!-- How can we replicate the issue and verify that this PR fixes it? -->

- Install site
- Visit component creation page, click on add component button
- Create component with image uploader element, select default image and make sure IMCE browser in opening while selecting default image for comps
- Now create a page using above created component and try to replace the default image, here it should open media browser instead of IMCE.
- 

**Merge requirements**
- [_Enhancement_] _Major change_, _Minor change_, _Bug_, _Enhancement_, and/or _Chore_ label applied
- [ ] Manual testing by a reviewer
