### PR TITLE
ACMS-997: Enable Site Studio Visual Page Builder

### DIFF
--- a/modules/acquia_cms_site_studio/acquia_cms_site_studio.info.yml
+++ b/modules/acquia_cms_site_studio/acquia_cms_site_studio.info.yml
@@ -18,3 +18,4 @@ dependencies:
   - drupal:collapsiblock
   - drupal:config
   - drupal:config_rewrite
+  - drupal:sitestudio_page_builder


### PR DESCRIPTION
**Motivation**
<!-- What problem does this solve? Why is it important? What's the context? If this fixes an issue, link to it above. -->
Fixes #[ACMS-997](https://backlog.acquia.com/browse/ACMS-997)

**Proposed changes**
<!-- What does this PR change? How does this impact end users? Are manual or automatic updates required? -->
Enable Site Studio Visual Page Builder module by default in acquia_cms profile

**Alternatives considered**
<!-- How else could the original issue / use case be addressed? Why did you choose this solution over any others? -->
NA

**Testing steps**
<!-- How can we replicate the issue and verify that this PR fixes it? -->

- Install site with acquia_cms profile
- Visite extend page (admin/modules)
- Make sure sitestudio_page_builder module enable by default

**Merge requirements**
- [_Enhancement_] _Major change_, _Minor change_, _Bug_, _Enhancement_, and/or _Chore_ label applied
- [ ] Manual testing by a reviewer
