### PR TITLE
ACMS-1012: JS Component : Place and page content are not visible

### DIFF
--- a/modules/acquia_cms_component/components/block/react_component_block/react_node_block.js
+++ b/modules/acquia_cms_component/components/block/react_component_block/react_node_block.js
@@ -30,8 +30,7 @@
       drupalApiOj.setEndpoint("node/" + attributes['data-type']);
       if (attributes.hasOwnProperty('data-display-item')) {
         params['page'] = {
-          "limit": attributes['data-display-item'],
-          "offset": "5"
+          "limit": attributes['data-display-item']
         };
       }
       drupalApiOj.setParams(params);


### PR DESCRIPTION
**Motivation**
<!-- What problem does this solve? Why is it important? What's the context? If this fixes an issue, link to it above. -->
Fixes #[ACMS-1012](https://backlog.acquia.com/browse/ACMS-1012)

**Proposed changes**
<!-- What does this PR change? How does this impact end users? Are manual or automatic updates required? -->
When React node component block is configured with page/ place node type, the contents of React Node Component Block on the site showing 'No Results' even if the page and place content is available in site

**Alternatives considered**
<!-- How else could the original issue / use case be addressed? Why did you choose this solution over any others? -->
NA

**Testing steps**
<!-- How can we replicate the issue and verify that this PR fixes it? -->

- Click on edit button, on js component block
- Select 'Choose the Node type' as page/ place
- Save
- Check for the React block on the main site 

**Merge requirements**
- [_Bug_] _Major change_, _Minor change_, _Bug_, _Enhancement_, and/or _Chore_ label applied
- [ ] Manual testing by a reviewer
