### PR TITLE
ACMS-812: Fixed issue: Acquia CMS icon not appearing when using Drupal profile.

### DIFF
--- a/acquia_cms.profile
+++ b/acquia_cms.profile
@@ -56,7 +56,7 @@ function acquia_cms_print_icon() {
   $profile_path = \Drupal::service('extension.path.resolver')->getPath('profile', 'acquia_cms');
   $icon_path = DRUPAL_ROOT . '/' . $profile_path . '/acquia_cms.icon.ascii';
   // For local development, we've created symlink. So, get symlink file path.
-  $icon_path = !is_link($icon_path) ?: readlink($icon_path);
+  $icon_path = !is_link($icon_path) ? $icon_path : readlink($icon_path);
   if (file_exists($icon_path)) {
     $output->writeln('<info>' . file_get_contents($icon_path) . '</info>');
   }


### PR DESCRIPTION
Fixed issue: Acquia CMS icon not appearing when using Drupal profile.

**Motivation**
Fixes issue for Acquia CMS icon not appearing on Acquia Cloud.

**Proposed changes**
N/A.

**Alternatives considered**
N/A

**Testing steps**
Install Acquia CMS profile on Acquia Cloud using drush and you should see Acquia CMS icon.

**Merge requirements**
- [ ] _Minor change_
- [ ] Manual testing by a reviewer
