### PR TITLE
ACMS-644: gdpr module updated to 3.0.0-alpha5 release.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,6 @@
         "drupal/address": "^1",
         "drupal/admin_toolbar": "^3.0",
         "drupal/autologout": "^1",
-        "drupal/checklistapi": "^2.0",
         "drupal/collapsiblock": "^3",
         "drupal/component": "1.0-rc3",
         "drupal/config_ignore": "2.3.0",
@@ -41,12 +40,12 @@
         "drupal/default_content": "2.0.0-alpha1",
         "drupal/diff": "^1",
         "drupal/entity_clone": "1.0-beta6",
+        "drupal/eu_cookie_compliance": "^1.19",
         "drupal/facets": "^2.0",
         "drupal/facets_pretty_paths": "^1.2",
-        "drupal/eu_cookie_compliance": "^1.19",
         "drupal/field_group": "^3",
         "drupal/focal_point": "1.5",
-        "drupal/gdpr": "3.0.0-alpha4",
+        "drupal/gdpr": "3.0.0-alpha5",
         "drupal/geocoder": "3.20",
         "drupal/geofield": "^1",
         "drupal/google_analytics": "^3.1",
@@ -162,14 +161,14 @@
             "drupal/acquia_telemetry-acquia_telemetry": {
                 "Add check for core index": "https://www.drupal.org/files/issues/2020-08-18/3165473-27.patch"
             },
+            "drupal/checklistapi": {
+                "Alter the prgress bar based upon the default value passed": "https://www.drupal.org/files/issues/2021-10-26/checklistapi-count-default-values-forprogress-2311855-2.patch"
+            },
             "drupal/component": {
                 "Missing Use statement creates fatal errors": "https://git.drupalcode.org/project/component/-/merge_requests/2.patch"
             },
             "drupal/config_ignore": {
                 "Support for export filtering via Drush": "https://www.drupal.org/files/issues/2021-08-18/config_ignore_2857247-75.patch"
-            },
-            "drupal/checklistapi": {
-                "Alter the prgress bar based upon the default value passed": "https://www.drupal.org/files/issues/2021-10-26/checklistapi-count-default-values-forprogress-2311855-2.patch"
             },
             "drupal/core": {
                 "It is possible to overflow the number of items allowed in Media Library": "https://www.drupal.org/files/issues/2019-12-28/3082690-80.patch",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "91199e4f3b65b534b86febc1844edf1b",
+    "content-hash": "360a2b421e995ce5d806f267f9de14b5",
     "packages": [
         {
             "name": "acquia/acsf-contenthub-console",
@@ -4736,17 +4736,17 @@
         },
         {
             "name": "drupal/gdpr",
-            "version": "3.0.0-alpha4",
+            "version": "3.0.0-alpha5",
             "source": {
                 "type": "git",
                 "url": "https://git.drupalcode.org/project/gdpr.git",
-                "reference": "3.0.0-alpha4"
+                "reference": "3.0.0-alpha5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://ftp.drupal.org/files/projects/gdpr-3.0.0-alpha4.zip",
-                "reference": "3.0.0-alpha4",
-                "shasum": "1a3eb2829fc06d7533b2fc30d8461ab40f9127c4"
+                "url": "https://ftp.drupal.org/files/projects/gdpr-3.0.0-alpha5.zip",
+                "reference": "3.0.0-alpha5",
+                "shasum": "770564ad2f864d3bda55ffcdcaa8f8d777f0b6ab"
             },
             "require": {
                 "drupal/checklistapi": "~2.0",
@@ -4772,8 +4772,8 @@
             "type": "drupal-module",
             "extra": {
                 "drupal": {
-                    "version": "3.0.0-alpha4",
-                    "datestamp": "1627687050",
+                    "version": "3.0.0-alpha5",
+                    "datestamp": "1640287403",
                     "security-coverage": {
                         "status": "not-covered",
                         "message": "Project has not opted into security advisory coverage!"

--- a/modules/acquia_cms_privacy/composer.json
+++ b/modules/acquia_cms_privacy/composer.json
@@ -6,7 +6,7 @@
     "require": {
         "cweagans/composer-patches": "^1.7",
         "drupal/eu_cookie_compliance": "^1.19",
-        "drupal/gdpr": "3.0.0-alpha4"
+        "drupal/gdpr": "3.0.0-alpha5"
     },
     "extra": {
         "drush": {


### PR DESCRIPTION
**Motivation**
gdpr module updated to 3.0.0-alpha5 release.

**Proposed changes**
Update composer dependencies to gdpr alpha5 version.

**Alternatives considered**
N/A

**Testing steps**
Install and enable acquia_cms_privacy module

**Merge requirements**
- [ ] _Minor change_
- [ ] Manual testing by a reviewer
