### PR TITLE
ACMS-1031: ACMS version on ACMS site status report page

### DIFF
--- a/themes/acquia_claro/acquia_claro.theme
+++ b/themes/acquia_claro/acquia_claro.theme
@@ -34,3 +34,10 @@ function acquia_claro_preprocess_image_widget(array &$variables) {
     $variables['data']['preview']['#access'] = $variables['element']['preview']['#access'];
   }
 }
+
+/**
+ * Implements hook_preprocess_HOOK().
+ */
+function acquia_claro_preprocess_status_report_general_info(&$variables) {
+  $variables['acquia_cms']['value'] = drupal_install_profile_distribution_version();
+}

--- a/themes/acquia_claro/templates/status-report-general-info.html.twig
+++ b/themes/acquia_claro/templates/status-report-general-info.html.twig
@@ -1,0 +1,105 @@
+{#
+/**
+ * @file
+ * Theme override for status report general info.
+ *
+ * Available variables:
+ * - drupal: The status of Drupal installation:
+ *   - value: The current status of Drupal installation.
+ *   - description: The description for current status of Drupal installation.
+ * - cron: The status of cron:
+ *   - value: The current status of cron.
+ *   - description: The description for current status of cron.
+ *   - cron.run_cron: An array to render a button for running cron.
+ * - database_system: The status of database system:
+ *   - value: The current status of database system.
+ *   - description: The description for current status of cron.
+ * - database_system_version: The info about current database version:
+ *   - value: The current version of database.
+ *   - description: The description for current version of database.
+ * - php: The current version of PHP:
+ *   - value: The status of currently installed PHP version.
+ *   - description: The description for current installed PHP version.
+ * - php_memory_limit: The info about current PHP memory limit:
+ *   - value: The status of currently set PHP memory limit.
+ *   - description: The description for currently set PHP memory limit.
+ * - webserver: The info about currently installed web server:
+ *   - value: The status of currently installed web server.
+ *   - description: The description for the status of currently installed web
+ *     server.
+ */
+#}
+<div class="system-status-general-info">
+  <h2 class="system-status-general-info__header">{{ 'General System Information'|t }}</h2>
+  <div class="system-status-general-info__items">
+    <div class="system-status-general-info__item card">
+      <span class="system-status-general-info__item-icon system-status-general-info__item-icon--drupal"></span>
+      <div class="system-status-general-info__item-details">
+        <h3 class="system-status-general-info__item-title">{{ 'Acquia CMS'|t }}</h3>
+        <div class="drupal-banner">
+          <span class="powered-by">{{ 'Powered by'|t }}
+            <a href="https://www.drupal.org/project/drupal">{{ 'Drupal'|t }} {{ drupal.value }}</a>
+				  </span>
+        </div>
+        <h4 class="system-status-general-info__sub-item-title">{{ 'Version'|t }}</h4>{{ acquia_cms.value }}
+        {% if drupal.description %}
+          <div class="description">{{ drupal.description }}</div>
+        {% endif %}
+      </div>
+    </div>
+
+    <div class="system-status-general-info__item card">
+      <span class="system-status-general-info__item-icon system-status-general-info__item-icon--server"></span>
+      <div class="system-status-general-info__item-details">
+        <h3 class="system-status-general-info__item-title">{{ 'Web Server'|t }}</h3>
+        {{ webserver.value }}
+        {% if webserver.description %}
+          <div class="description">{{ webserver.description }}</div>
+        {% endif %}
+      </div>
+    </div>
+    <div class="system-status-general-info__item card">
+      <span class="system-status-general-info__item-icon system-status-general-info__item-icon--clock"></span>
+      <div class="system-status-general-info__item-details">
+        <h3 class="system-status-general-info__item-title">{{ 'Last Cron Run'|t }}</h3>
+        {{ cron.value }}
+        {% if cron.run_cron %}
+          <div class="system-status-general-info__run-cron">{{ cron.run_cron }}</div>
+        {% endif %}
+        {% if cron.description %}
+          <div class="system-status-general-info__description">{{ cron.description }}</div>
+        {% endif %}
+      </div>
+    </div>
+    <div class="system-status-general-info__item card">
+      <span class="system-status-general-info__item-icon system-status-general-info__item-icon--php"></span>
+      <div class="system-status-general-info__item-details">
+        <h3 class="system-status-general-info__item-title">{{ 'PHP'|t }}</h3>
+        <h4 class="system-status-general-info__sub-item-title">{{ 'Version'|t }}</h4>{{ php.value }}
+        {% if php.description %}
+          <div class="description">{{ php.description }}</div>
+        {% endif %}
+
+        <h4 class="system-status-general-info__sub-item-title">{{ 'Memory limit'|t }}</h4>{{ php_memory_limit.value }}
+        {% if php_memory_limit.description %}
+          <div class="description">{{ php_memory_limit.description }}</div>
+        {% endif %}
+      </div>
+    </div>
+    <div class="system-status-general-info__item card">
+      <span class="system-status-general-info__item-icon system-status-general-info__item-icon--database"></span>
+      <div class="system-status-general-info__item-details">
+        <h3 class="system-status-general-info__item-title">{{ 'Database'|t }}</h3>
+        <h4 class="system-status-general-info__sub-item-title">{{ 'Version'|t }}</h4>{{ database_system_version.value }}
+        {% if database_system_version.description %}
+          <div class="description">{{ database_system_version.description }}</div>
+        {% endif %}
+
+        <h4 class="system-status-general-info__sub-item-title">{{ 'System'|t }}</h4>{{ database_system.value }}
+        {% if database_system.description %}
+          <div class="description">{{ database_system.description }}</div>
+        {% endif %}
+      </div>
+    </div>
+  </div>
+</div>


### PR DESCRIPTION
**Motivation**
<!-- What problem does this solve? Why is it important? What's the context? If this fixes an issue, link to it above. -->
Fixes #[ACMS-1031](https://backlog.acquia.com/browse/ACMS-1031)

**Proposed changes**
<!-- What does this PR change? How does this impact end users? Are manual or automatic updates required? -->
We should have the ACMS version with the Drupal version displayed on the status report page after the ACMS site is installed under 'General System Information' as a card. Which will give the user/ consumer visibility after installation. 

**Alternatives considered**
<!-- How else could the original issue / use case be addressed? Why did you choose this solution over any others? -->
NA

**Testing steps**
<!-- How can we replicate the issue and verify that this PR fixes it? -->

- Install site with acquia_cms
- Navigate to status report page (admin/reports/status) and make sure you see card with acquia CMS information
<img width="1596" alt="acms-branding" src="https://user-images.githubusercontent.com/63041696/148539542-2ea5094c-ec7d-4a34-81f7-ad0eea899dfa.png">

**Merge requirements**
- [_Enhancement_] _Major change_, _Minor change_, _Bug_, _Enhancement_, and/or _Chore_ label applied
- [ ] Manual testing by a reviewer
