### PR TITLE
ACMS-913: Enabling acquia_cms_audio does not add Audio media type

### DIFF
--- a/modules/acquia_cms_audio/acquia_cms_audio.info.yml
+++ b/modules/acquia_cms_audio/acquia_cms_audio.info.yml
@@ -4,5 +4,6 @@ description: "Provides an Audio media type and related configuration."
 type: module
 core_version_requirement: ^9
 dependencies:
-  - drupal:acquia_cms_common
-  - drupal:media
+  - 'drupal:acquia_cms_common'
+  - 'drupal:media'
+  - 'drupal:media_entity_soundcloud'

--- a/modules/acquia_cms_audio/acquia_cms_audio.info.yml
+++ b/modules/acquia_cms_audio/acquia_cms_audio.info.yml
@@ -7,3 +7,4 @@ dependencies:
   - 'drupal:acquia_cms_common'
   - 'drupal:media'
   - 'drupal:media_entity_soundcloud'
+  - 'field_group:field_group'

--- a/modules/acquia_cms_audio/acquia_cms_audio.install
+++ b/modules/acquia_cms_audio/acquia_cms_audio.install
@@ -1,0 +1,21 @@
+<?php
+
+/**
+ * @file
+ * Install, update and uninstall functions for the acquia_cms_audio module.
+ */
+
+/**
+ * Implements hook_install().
+ */
+function acquia_cms_audio_install() {
+  user_role_grant_permissions('content_author', [
+    'create audio media',
+    'edit own audio media',
+    'delete own audio media',
+  ]);
+  user_role_grant_permissions('content_editor', [
+    'edit any audio media',
+    'delete any audio media',
+  ]);
+}

--- a/modules/acquia_cms_audio/composer.json
+++ b/modules/acquia_cms_audio/composer.json
@@ -4,7 +4,8 @@
     "description": "Provides an Audio media type and related configuration.",
     "license": "GPL-2.0-or-later",
     "require": {
-        "drupal/acquia_cms_common": "^1.0"
+        "drupal/acquia_cms_common": "^1.0",
+        "drupal/media_entity_soundcloud": "^3.0"
     },
     "repositories": {
         "drupal": {

--- a/modules/acquia_cms_audio/config/optional/core.entity_form_display.media.audio.default.yml
+++ b/modules/acquia_cms_audio/config/optional/core.entity_form_display.media.audio.default.yml
@@ -1,0 +1,47 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.media.audio.field_media_soundcloud
+    - media.type.audio
+  enforced:
+    module:
+      - acquia_cms_audio
+id: media.audio.default
+targetEntityType: media
+bundle: audio
+mode: default
+content:
+  field_media_soundcloud:
+    type: string_textfield
+    weight: 1
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  langcode:
+    type: language_select
+    weight: 2
+    region: content
+    settings:
+      include_locked: true
+    third_party_settings: {  }
+  name:
+    type: string_textfield
+    weight: 0
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  translation:
+    weight: 3
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+hidden:
+  created: true
+  path: true
+  status: true
+  uid: true

--- a/modules/acquia_cms_audio/config/optional/core.entity_form_display.media.audio.default.yml
+++ b/modules/acquia_cms_audio/config/optional/core.entity_form_display.media.audio.default.yml
@@ -2,21 +2,64 @@ langcode: en
 status: true
 dependencies:
   config:
+    - field.field.media.audio.field_categories
     - field.field.media.audio.field_media_soundcloud
+    - field.field.media.audio.field_tags
     - media.type.audio
+  module:
+    - field_group
   enforced:
     module:
       - acquia_cms_audio
+third_party_settings:
+  field_group:
+    group_taxonomy:
+      children:
+        - field_categories
+        - field_tags
+      label: Taxonomy
+      region: content
+      parent_name: ''
+      weight: 4
+      format_type: fieldset
+      format_settings:
+        classes: ''
+        show_empty_fields: false
+        id: ''
+        description: ''
+        required_fields: true
 id: media.audio.default
 targetEntityType: media
 bundle: audio
 mode: default
 content:
+  created:
+    type: datetime_timestamp
+    weight: 6
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  field_categories:
+    type: options_select
+    weight: 5
+    region: content
+    settings: {  }
+    third_party_settings: {  }
   field_media_soundcloud:
     type: string_textfield
     weight: 1
     region: content
     settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  field_tags:
+    type: entity_reference_autocomplete_tags
+    weight: 6
+    region: content
+    settings:
+      match_operator: CONTAINS
+      match_limit: 10
       size: 60
       placeholder: ''
     third_party_settings: {  }
@@ -40,8 +83,16 @@ content:
     region: content
     settings: {  }
     third_party_settings: {  }
+  uid:
+    type: entity_reference_autocomplete
+    weight: 5
+    region: content
+    settings:
+      match_operator: CONTAINS
+      match_limit: 10
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
 hidden:
-  created: true
   path: true
   status: true
-  uid: true

--- a/modules/acquia_cms_audio/config/optional/core.entity_form_display.media.audio.media_library.yml
+++ b/modules/acquia_cms_audio/config/optional/core.entity_form_display.media.audio.media_library.yml
@@ -1,0 +1,48 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_form_mode.media.media_library
+    - field.field.media.audio.field_media_soundcloud
+    - media.type.audio
+  enforced:
+    module:
+      - acquia_cms_audio
+id: media.audio.media_library
+targetEntityType: media
+bundle: audio
+mode: media_library
+content:
+  field_media_soundcloud:
+    type: string_textfield
+    weight: 1
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  langcode:
+    type: language_select
+    weight: 2
+    region: content
+    settings:
+      include_locked: true
+    third_party_settings: {  }
+  name:
+    type: string_textfield
+    weight: 0
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  translation:
+    weight: 3
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+hidden:
+  created: true
+  path: true
+  status: true
+  uid: true

--- a/modules/acquia_cms_audio/config/optional/core.entity_form_display.media.audio.media_library.yml
+++ b/modules/acquia_cms_audio/config/optional/core.entity_form_display.media.audio.media_library.yml
@@ -3,21 +3,58 @@ status: true
 dependencies:
   config:
     - core.entity_form_mode.media.media_library
+    - field.field.media.audio.field_categories
     - field.field.media.audio.field_media_soundcloud
+    - field.field.media.audio.field_tags
     - media.type.audio
+  module:
+    - field_group
   enforced:
     module:
       - acquia_cms_audio
+third_party_settings:
+  field_group:
+    group_taxonomy:
+      children:
+        - field_categories
+        - field_tags
+      label: Taxonomy
+      region: content
+      parent_name: ''
+      weight: 4
+      format_type: fieldset
+      format_settings:
+        classes: ''
+        show_empty_fields: false
+        id: ''
+        description: ''
+        required_fields: true
 id: media.audio.media_library
 targetEntityType: media
 bundle: audio
 mode: media_library
 content:
+  field_categories:
+    type: options_select
+    weight: 5
+    region: content
+    settings: {  }
+    third_party_settings: {  }
   field_media_soundcloud:
     type: string_textfield
     weight: 1
     region: content
     settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  field_tags:
+    type: entity_reference_autocomplete_tags
+    weight: 6
+    region: content
+    settings:
+      match_operator: CONTAINS
+      match_limit: 10
       size: 60
       placeholder: ''
     third_party_settings: {  }

--- a/modules/acquia_cms_audio/config/optional/core.entity_form_mode.media.media_library.yml
+++ b/modules/acquia_cms_audio/config/optional/core.entity_form_mode.media.media_library.yml
@@ -6,7 +6,6 @@ dependencies:
   enforced:
     module:
       - media_library
-      - acquia_cms_audio
 id: media.media_library
 label: 'Media library'
 targetEntityType: media

--- a/modules/acquia_cms_audio/config/optional/core.entity_form_mode.media.media_library.yml
+++ b/modules/acquia_cms_audio/config/optional/core.entity_form_mode.media.media_library.yml
@@ -1,0 +1,13 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - media
+  enforced:
+    module:
+      - media_library
+      - acquia_cms_audio
+id: media.media_library
+label: 'Media library'
+targetEntityType: media
+cache: true

--- a/modules/acquia_cms_audio/config/optional/core.entity_view_display.media.audio.default.yml
+++ b/modules/acquia_cms_audio/config/optional/core.entity_view_display.media.audio.default.yml
@@ -1,0 +1,34 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.media.audio.field_media_soundcloud
+    - media.type.audio
+  enforced:
+    module:
+      - acquia_cms_audio
+  module:
+    - media_entity_soundcloud
+id: media.audio.default
+targetEntityType: media
+bundle: audio
+mode: default
+content:
+  field_media_soundcloud:
+    type: soundcloud_embed
+    label: visually_hidden
+    settings:
+      type: visual
+      width: 100%
+      height: '450'
+      options: {  }
+    third_party_settings: {  }
+    weight: 0
+    region: content
+hidden:
+  created: true
+  langcode: true
+  name: true
+  search_api_excerpt: true
+  thumbnail: true
+  uid: true

--- a/modules/acquia_cms_audio/config/optional/core.entity_view_display.media.audio.default.yml
+++ b/modules/acquia_cms_audio/config/optional/core.entity_view_display.media.audio.default.yml
@@ -2,13 +2,15 @@ langcode: en
 status: true
 dependencies:
   config:
+    - field.field.media.audio.field_categories
     - field.field.media.audio.field_media_soundcloud
+    - field.field.media.audio.field_tags
     - media.type.audio
+  module:
+    - media_entity_soundcloud
   enforced:
     module:
       - acquia_cms_audio
-  module:
-    - media_entity_soundcloud
 id: media.audio.default
 targetEntityType: media
 bundle: audio
@@ -27,6 +29,8 @@ content:
     region: content
 hidden:
   created: true
+  field_categories: true
+  field_tags: true
   langcode: true
   name: true
   search_api_excerpt: true

--- a/modules/acquia_cms_audio/config/optional/core.entity_view_display.media.audio.embedded.yml
+++ b/modules/acquia_cms_audio/config/optional/core.entity_view_display.media.audio.embedded.yml
@@ -3,13 +3,15 @@ status: true
 dependencies:
   config:
     - core.entity_view_mode.media.embedded
+    - field.field.media.audio.field_categories
     - field.field.media.audio.field_media_soundcloud
+    - field.field.media.audio.field_tags
     - media.type.audio
+  module:
+    - media_entity_soundcloud
   enforced:
     module:
       - acquia_cms_audio
-  module:
-    - media_entity_soundcloud
 id: media.audio.embedded
 targetEntityType: media
 bundle: audio
@@ -28,6 +30,8 @@ content:
     region: content
 hidden:
   created: true
+  field_categories: true
+  field_tags: true
   langcode: true
   name: true
   search_api_excerpt: true

--- a/modules/acquia_cms_audio/config/optional/core.entity_view_display.media.audio.embedded.yml
+++ b/modules/acquia_cms_audio/config/optional/core.entity_view_display.media.audio.embedded.yml
@@ -1,0 +1,35 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_view_mode.media.embedded
+    - field.field.media.audio.field_media_soundcloud
+    - media.type.audio
+  enforced:
+    module:
+      - acquia_cms_audio
+  module:
+    - media_entity_soundcloud
+id: media.audio.embedded
+targetEntityType: media
+bundle: audio
+mode: embedded
+content:
+  field_media_soundcloud:
+    type: soundcloud_embed
+    label: visually_hidden
+    settings:
+      type: visual
+      width: 100%
+      height: '450'
+      options: {  }
+    third_party_settings: {  }
+    weight: 0
+    region: content
+hidden:
+  created: true
+  langcode: true
+  name: true
+  search_api_excerpt: true
+  thumbnail: true
+  uid: true

--- a/modules/acquia_cms_audio/config/optional/core.entity_view_display.media.audio.media_library.yml
+++ b/modules/acquia_cms_audio/config/optional/core.entity_view_display.media.audio.media_library.yml
@@ -1,0 +1,34 @@
+langcode: en
+status: false
+dependencies:
+  config:
+    - core.entity_view_mode.media.media_library
+    - field.field.media.audio.field_media_soundcloud
+    - image.style.medium
+    - media.type.audio
+  enforced:
+    module:
+      - acquia_cms_audio
+  module:
+    - image
+id: media.audio.media_library
+targetEntityType: media
+bundle: audio
+mode: media_library
+content:
+  thumbnail:
+    type: image
+    label: hidden
+    settings:
+      image_link: ''
+      image_style: medium
+    third_party_settings: {  }
+    weight: 0
+    region: content
+hidden:
+  created: true
+  field_media_soundcloud: true
+  langcode: true
+  name: true
+  search_api_excerpt: true
+  uid: true

--- a/modules/acquia_cms_audio/config/optional/core.entity_view_display.media.audio.media_library.yml
+++ b/modules/acquia_cms_audio/config/optional/core.entity_view_display.media.audio.media_library.yml
@@ -3,14 +3,16 @@ status: false
 dependencies:
   config:
     - core.entity_view_mode.media.media_library
+    - field.field.media.audio.field_categories
     - field.field.media.audio.field_media_soundcloud
+    - field.field.media.audio.field_tags
     - image.style.medium
     - media.type.audio
+  module:
+    - image
   enforced:
     module:
       - acquia_cms_audio
-  module:
-    - image
 id: media.audio.media_library
 targetEntityType: media
 bundle: audio
@@ -27,7 +29,9 @@ content:
     region: content
 hidden:
   created: true
+  field_categories: true
   field_media_soundcloud: true
+  field_tags: true
   langcode: true
   name: true
   search_api_excerpt: true

--- a/modules/acquia_cms_audio/config/optional/core.entity_view_mode.media.embedded.yml
+++ b/modules/acquia_cms_audio/config/optional/core.entity_view_mode.media.embedded.yml
@@ -1,0 +1,12 @@
+langcode: en
+status: true
+dependencies:
+  enforced:
+    module:
+      - acquia_cms_audio
+  module:
+    - media
+id: media.embedded
+label: Embedded
+targetEntityType: media
+cache: true

--- a/modules/acquia_cms_audio/config/optional/core.entity_view_mode.media.embedded.yml
+++ b/modules/acquia_cms_audio/config/optional/core.entity_view_mode.media.embedded.yml
@@ -1,9 +1,6 @@
 langcode: en
 status: true
 dependencies:
-  enforced:
-    module:
-      - acquia_cms_audio
   module:
     - media
 id: media.embedded

--- a/modules/acquia_cms_audio/config/optional/core.entity_view_mode.media.media_library.yml
+++ b/modules/acquia_cms_audio/config/optional/core.entity_view_mode.media.media_library.yml
@@ -6,7 +6,6 @@ dependencies:
   enforced:
     module:
       - media_library
-      - acquia_cms_audio
 id: media.media_library
 label: 'Media library'
 targetEntityType: media

--- a/modules/acquia_cms_audio/config/optional/core.entity_view_mode.media.media_library.yml
+++ b/modules/acquia_cms_audio/config/optional/core.entity_view_mode.media.media_library.yml
@@ -1,0 +1,13 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - media
+  enforced:
+    module:
+      - media_library
+      - acquia_cms_audio
+id: media.media_library
+label: 'Media library'
+targetEntityType: media
+cache: true

--- a/modules/acquia_cms_audio/config/optional/field.field.media.audio.field_categories.yml
+++ b/modules/acquia_cms_audio/config/optional/field.field.media.audio.field_categories.yml
@@ -1,0 +1,31 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.media.field_categories
+    - media.type.audio
+    - taxonomy.vocabulary.categories
+  enforced:
+    module:
+      - acquia_cms_audio
+id: media.audio.field_categories
+field_name: field_categories
+entity_type: media
+bundle: audio
+label: Categories
+description: ''
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:taxonomy_term'
+  handler_settings:
+    target_bundles:
+      categories: categories
+    sort:
+      field: name
+      direction: asc
+    auto_create: false
+    auto_create_bundle: ''
+field_type: entity_reference

--- a/modules/acquia_cms_audio/config/optional/field.field.media.audio.field_media_soundcloud.yml
+++ b/modules/acquia_cms_audio/config/optional/field.field.media.audio.field_media_soundcloud.yml
@@ -1,0 +1,21 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.media.field_media_soundcloud
+    - media.type.audio
+  enforced:
+    module:
+      - acquia_cms_audio
+id: media.audio.field_media_soundcloud
+field_name: field_media_soundcloud
+entity_type: media
+bundle: audio
+label: 'Soundcloud audio URL'
+description: ''
+required: true
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/modules/acquia_cms_audio/config/optional/field.field.media.audio.field_tags.yml
+++ b/modules/acquia_cms_audio/config/optional/field.field.media.audio.field_tags.yml
@@ -1,0 +1,31 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.media.field_tags
+    - media.type.audio
+    - taxonomy.vocabulary.tags
+  enforced:
+    module:
+      - acquia_cms_audio
+id: media.audio.field_tags
+field_name: field_tags
+entity_type: media
+bundle: audio
+label: Tags
+description: ''
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:taxonomy_term'
+  handler_settings:
+    target_bundles:
+      tags: tags
+    sort:
+      field: name
+      direction: asc
+    auto_create: true
+    auto_create_bundle: ''
+field_type: entity_reference

--- a/modules/acquia_cms_audio/config/optional/field.storage.media.field_media_soundcloud.yml
+++ b/modules/acquia_cms_audio/config/optional/field.storage.media.field_media_soundcloud.yml
@@ -1,0 +1,23 @@
+langcode: en
+status: true
+dependencies:
+  enforced:
+    module:
+      - acquia_cms_audio
+  module:
+    - media
+id: media.field_media_soundcloud
+field_name: field_media_soundcloud
+entity_type: media
+type: string
+settings:
+  max_length: 255
+  case_sensitive: false
+  is_ascii: false
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/modules/acquia_cms_audio/config/optional/field.storage.media.field_media_soundcloud.yml
+++ b/modules/acquia_cms_audio/config/optional/field.storage.media.field_media_soundcloud.yml
@@ -1,11 +1,11 @@
 langcode: en
 status: true
 dependencies:
+  module:
+    - media
   enforced:
     module:
       - acquia_cms_audio
-  module:
-    - media
 id: media.field_media_soundcloud
 field_name: field_media_soundcloud
 entity_type: media

--- a/modules/acquia_cms_audio/config/optional/language.content_settings.media.audio.yml
+++ b/modules/acquia_cms_audio/config/optional/language.content_settings.media.audio.yml
@@ -1,0 +1,15 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - media.type.audio
+  module:
+    - content_translation
+third_party_settings:
+  content_translation:
+    enabled: true
+id: media.audio
+target_entity_type_id: media
+target_bundle: audio
+default_langcode: site_default
+language_alterable: true

--- a/modules/acquia_cms_audio/config/optional/media.type.audio.yml
+++ b/modules/acquia_cms_audio/config/optional/media.type.audio.yml
@@ -1,0 +1,21 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - crop
+    - media_entity_soundcloud
+  enforced:
+    module:
+      - acquia_cms_audio
+third_party_settings:
+  crop:
+    image_field: null
+id: audio
+label: Audio
+description: 'Remotely hosted audio from external sources soundcloud.'
+source: soundcloud
+queue_thumbnail_downloads: false
+new_revision: true
+source_configuration:
+  source_field: field_media_soundcloud
+field_map: {  }

--- a/modules/acquia_cms_audio/tests/src/Functional/AudioTest.php
+++ b/modules/acquia_cms_audio/tests/src/Functional/AudioTest.php
@@ -1,0 +1,85 @@
+<?php
+
+namespace Drupal\Tests\acquia_cms_audio\Functional;
+
+use Drupal\Tests\acquia_cms_common\Functional\MediaTypeTestBase;
+
+/**
+ * Tests the Audio media type that ships with Acquia CMS.
+ *
+ * @group acquia_cms_audio
+ * @group acquia_cms
+ * @group medium_risk
+ * @group push
+ * @group pr
+ */
+class AudioTest extends MediaTypeTestBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected static $modules = ['acquia_cms_audio'];
+
+  /**
+   * Disable strict config schema checks in this test.
+   *
+   * Cohesion has a lot of config schema errors, and until they are all fixed,
+   * this test cannot pass unless we disable strict config schema checking
+   * altogether. Since strict config schema isn't critically important in
+   * testing this functionality, it's okay to disable it for now, but it should
+   * be re-enabled (i.e., this property should be removed) as soon as possible.
+   *
+   * @var bool
+   */
+  // @codingStandardsIgnoreStart
+  protected $strictConfigSchema = FALSE;
+  // @codingStandardsIgnoreEnd
+
+  /**
+   * {@inheritdoc}
+   */
+  protected $mediaType = 'audio';
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function doTestEditForm() : void {
+    $page = $this->getSession()->getPage();
+    $assert_session = $this->assertSession();
+
+    $account = $this->drupalCreateUser();
+    $account->addRole('content_author');
+    $account->save();
+    $this->drupalLogin($account);
+
+    $this->drupalGet('media/add/' . $this->mediaType);
+    // Assert that the current user can access the form to create a video media.
+    // Note that status codes cannot be asserted in functional JavaScript tests.
+    $assert_session->statusCodeEquals(200);
+
+    // Assert that the expected fields show up.
+    $assert_session->fieldExists('Name');
+    $assert_session->fieldExists('Soundcloud audio URL');
+
+    // Assert that the fields are in the correct order.
+    $this->assertFieldsOrder([
+      'name',
+      'field_media_soundcloud',
+    ]);
+
+    // Submit the form and ensure that we see the expected error message(s).
+    $page->pressButton('Save');
+    $assert_session->pageTextContains('Name field is required.');
+
+    // Fill in the required fields and assert that things went as expected.
+    $page->fillField('Name', 'Decoupled Drupal Podcast with Third & Grove and Acquia');
+    $page->fillField('Soundcloud audio URL', 'https://soundcloud.com/user-64782202/decoupled-drupal-podcast-with-third-grove-and-acquia?utm_source=clipboard&utm_medium=text&utm_campaign=social_sharing');
+    $page->pressButton('Save');
+    $assert_session->pageTextContains('Audio Decoupled Drupal Podcast with Third & Grove and Acquia has been created.');
+
+    // Media items are not normally exposed at standalone URLs, so assert that
+    // the URL alias field does not show up.
+    $assert_session->fieldNotExists('path[0][alias]');
+  }
+
+}


### PR DESCRIPTION
**Motivation**
<!-- What problem does this solve? Why is it important? What's the context? If this fixes an issue, link to it above. -->
Fixes #[ACMS-913](https://backlog.acquia.com/browse/ACMS-913)

**Proposed changes**
<!-- What does this PR change? How does this impact end users? Are manual or automatic updates required? -->

- Require the Media Entity Soundcloud module in the acquia_cms_audio module to provide a simple hosted audio option.
- Add an Audio media type using soundcloud url as the source field with display using the embedded soundcloud option.
- Write PHPUnit tests.

**Alternatives considered**
<!-- How else could the original issue / use case be addressed? Why did you choose this solution over any others? -->
NA

**Testing steps**
<!-- How can we replicate the issue and verify that this PR fixes it? -->

- Install site using acquia_cms profile
- Check media type, you should see new media type called audio
- Try to add audio media type by providing sound cloud audio track URL
- It should create audio media

**Merge requirements**
- [_Enhancement_] _Major change_, _Minor change_, _Bug_, _Enhancement_, and/or _Chore_ label applied
- [ ] Manual testing by a reviewer
