### PR TITLE
ACMS-913: Add module media_entity_soundcloud in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -53,6 +53,7 @@
         "drupal/imagemagick": "^3",
         "drupal/imce": "2.x-dev",
         "drupal/jsonapi_extras": "^3",
+        "drupal/media_entity_soundcloud": "^3.0",
         "drupal/memcache": "^2.2",
         "drupal/moderation_dashboard": "1.0.0-beta3",
         "drupal/moderation_sidebar": "^1.4",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "56a35f88878c41a50a972a3c909ee4c1",
+    "content-hash": "881d726d54ee3a4ed5ec3118a4b35165",
     "packages": [
         {
             "name": "acquia/acsf-contenthub-console",
@@ -5351,6 +5351,68 @@
             "homepage": "https://www.drupal.org/project/jsonapi_extras",
             "support": {
                 "source": "https://git.drupalcode.org/project/jsonapi_extras"
+            }
+        },
+        {
+            "name": "drupal/media_entity_soundcloud",
+            "version": "3.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://git.drupalcode.org/project/media_entity_soundcloud.git",
+                "reference": "3.0.0"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://ftp.drupal.org/files/projects/media_entity_soundcloud-3.0.0.zip",
+                "reference": "3.0.0",
+                "shasum": "b1f3a1d12132d22eaa45f04eb6650b3a4974d1fc"
+            },
+            "require": {
+                "drupal/core": "^8 || ^9"
+            },
+            "type": "drupal-module",
+            "extra": {
+                "drupal": {
+                    "version": "3.0.0",
+                    "datestamp": "1603867629",
+                    "security-coverage": {
+                        "status": "covered",
+                        "message": "Covered by Drupal's security advisory policy"
+                    }
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Drupal\\media_entity_soundcloud\\": "src/"
+                }
+            },
+            "notification-url": "https://packages.drupal.org/8/downloads",
+            "license": [
+                "GPL-2.0+"
+            ],
+            "authors": [
+                {
+                    "name": "arshadcn",
+                    "homepage": "https://www.drupal.org/user/571032"
+                },
+                {
+                    "name": "dawehner",
+                    "homepage": "https://www.drupal.org/user/99340"
+                },
+                {
+                    "name": "jcisio",
+                    "homepage": "https://www.drupal.org/user/210762"
+                },
+                {
+                    "name": "jcisio",
+                    "homepage": "https://www.drupal.org/user/210762"
+                }
+            ],
+            "description": "Soundcloud integration for the Media Entity module",
+            "homepage": "https://drupal.org/project/media_entity_soundcloud",
+            "support": {
+                "source": "https://git.drupalcode.org/project/media_entity_soundcloud",
+                "issues": "https://drupal.org/project/issues/media_entity_soundcloud"
             }
         },
         {


### PR DESCRIPTION
**Motivation**
<!-- What problem does this solve? Why is it important? What's the context? If this fixes an issue, link to it above. -->
Fixes #[ACMS-913](https://backlog.acquia.com/browse/ACMS-913)

**Proposed changes**
<!-- What does this PR change? How does this impact end users? Are manual or automatic updates required? -->

- Require the Media Entity Soundcloud module in the acquia_cms_audio module to provide a simple hosted audio option.
- Add an Audio media type using soundcloud url as the source field with display using the embedded soundcloud option.
- Write PHPUnit tests.

**Alternatives considered**
<!-- How else could the original issue / use case be addressed? Why did you choose this solution over any others? -->
NA

**Testing steps**
<!-- How can we replicate the issue and verify that this PR fixes it? -->

- Install site using acquia_cms profile
- Check media type, you should see new media type called audio
- Try to add audio media type by providing sound cloud audio track URL
- It should create audio media

**Merge requirements**
- [_Enhancement_] _Major change_, _Minor change_, _Bug_, _Enhancement_, and/or _Chore_ label applied
- [ ] Manual testing by a reviewer
