### PR TITLE
ACMS-1042: Added patch for facet reset link failure.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -41,7 +41,7 @@
         "drupal/default_content": "2.0.0-alpha1",
         "drupal/diff": "^1",
         "drupal/entity_clone": "1.0-beta6",
-        "drupal/facets": "^2.0",
+        "drupal/facets": "2.0",
         "drupal/facets_pretty_paths": "^1.2",
         "drupal/field_group": "^3",
         "drupal/focal_point": "1.5",
@@ -178,6 +178,9 @@
             },
             "drupal/entity_clone": {
                 "Allow fields implementing EntityReferenceFieldItemListInterface to clone their referenced entities": "https://www.drupal.org/files/issues/2021-04-14/3013286-19.patch"
+            },
+            "drupal/facets": {
+                "Fix the select/deselect facet link issue": "https://www.drupal.org/files/issues/2022-01-18/3259123-search-facet-reset-link.patch"
             },
             "drupal/focal_point": {
                 "3162210 - Preview link accidentally closes the media library": "https://www.drupal.org/files/issues/2020-10-06/3162210-17.patch"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "881d726d54ee3a4ed5ec3118a4b35165",
+    "content-hash": "fa152e1c319db92026111bcf3d68b5c5",
     "packages": [
         {
             "name": "acquia/acsf-contenthub-console",
@@ -19283,5 +19283,5 @@
     "prefer-lowest": false,
     "platform": [],
     "platform-dev": [],
-    "plugin-api-version": "2.0.0"
+    "plugin-api-version": "2.1.0"
 }

--- a/modules/acquia_cms_search/composer.json
+++ b/modules/acquia_cms_search/composer.json
@@ -8,7 +8,7 @@
         "drupal/acquia_cms_article": "^1.0",
         "drupal/acquia_search": "^3.0.3",
         "drupal/collapsiblock": "^3",
-        "drupal/facets": "^2.0",
+        "drupal/facets": "2.0",
         "drupal/facets_pretty_paths": "^1.2",
         "drupal/search_api": "1.21",
         "drupal/search_api_autocomplete": "^1.4"
@@ -16,6 +16,9 @@
     "extra": {
         "enable-patching": true,
         "patches": {
+            "drupal/facets": {
+                "Fix the select/deselect facet link issue": "https://www.drupal.org/files/issues/2022-01-18/3259123-search-facet-reset-link.patch"
+            },
             "drupal/search_api": {
                 "Resolves call to member function preExecute() on null error on site install": "https://www.drupal.org/files/issues/2021-09-20/search_api_condition_cacheable_metadata.patch"
             }


### PR DESCRIPTION
**Motivation**
* unable to deselect selected facet.
Fixes #NNN

**Proposed changes**
* Revert code in the new version of the module.

**Alternatives considered**
* None

**Testing steps**
* Instal site and install facet and search module and filter result from facet.
* Notice that deselecting the facet doesn't work without the patch.

**Merge requirements**
- [ ] _Major change_, _Minor change_, _Bug_, _Enhancement_, and/or _Chore_ label applied
- [ ] Manual testing by a reviewer
