### PR TITLE
ACMS-1044: Added a permission to content author role and removed workaround

### DIFF
--- a/modules/acquia_cms_common/config/install/user.role.content_author.yml
+++ b/modules/acquia_cms_common/config/install/user.role.content_author.yml
@@ -13,6 +13,7 @@ permissions:
   - 'access components'
   - 'access content elements group'
   - 'access content overview'
+  - 'access contextual links'
   - 'access cpt_cat_dynamic_components cohesion_component_category group'
   - 'access cpt_cat_general_components cohesion_component_category group'
   - 'access cpt_cat_hero_components cohesion_component_category group'

--- a/tests/src/ExistingSiteJavascript/DrupalBlockComponentTest.php
+++ b/tests/src/ExistingSiteJavascript/DrupalBlockComponentTest.php
@@ -71,19 +71,4 @@ class DrupalBlockComponentTest extends CohesionComponentTestBase {
     $this->editDefinition('Dynamic components', 'Drupal blocks');
   }
 
-  /**
-   * We are overriding this method due to JS issue.
-   *
-   * @return array[]
-   *   Sets of arguments to pass to the test method.
-   */
-  public function providerAddComponentToLayoutCanvas() {
-    // @todo Find a solution and remove this function from here.
-    return [
-      [
-        ['administrator', 'site_builder'],
-      ],
-    ];
-  }
-
 }


### PR DESCRIPTION
**Motivation**
* Workaround was added to DrupalComponentBlock test.
Fixes #NNN

**Proposed changes**
* Remove the workaround and fix the failing DrupalComponentBlock Test

**Alternatives considered**
* None

**Testing steps**
* Install site 
* Navigate to node/add/page content type creation page.
* add a component to Layout Canvas field.
* Edit the component added and notice there are no issues on editing the component.
* Run the tests and notice the said test is not failing.

**Merge requirements**
- [ ] _Major change_, _Minor change_, _Bug_, _Enhancement_, and/or _Chore_ label applied
- [ ] Manual testing by a reviewer
