### PR TITLE
ACMS-1057: Enable sitestudio_page_builder module by default

### DIFF
--- a/modules/acquia_cms_site_studio/acquia_cms_site_studio.install
+++ b/modules/acquia_cms_site_studio/acquia_cms_site_studio.install
@@ -103,3 +103,10 @@ function acquia_cms_site_studio_update_8001() {
     $config->save();
   }
 }
+
+/**
+ * Install site studio page builder module.
+ */
+function acquia_cms_site_studio_update_8002() {
+  \Drupal::service('module_installer')->install(['sitestudio_page_builder']);
+}


### PR DESCRIPTION
**Motivation**
<!-- What problem does this solve? Why is it important? What's the context? If this fixes an issue, link to it above. -->
Fixes #[ACMS-1057](https://backlog.acquia.com/browse/ACMS-1057)

**Proposed changes**
<!-- What does this PR change? How does this impact end users? Are manual or automatic updates required? -->
After upgrading ACMS to version 1.4.1 from version 1.4.0 I can no longer install my site from configuration because of an error with site_studio_page_builder.

Steps to Reproduce

Install ACMS 1.4.0 and export the configuration. 

Upgrade to ACMS 1.4.1 and export the configuration.

Run blt setup again with blt having the following config:
```
cm: 
  strategy: config-split 
  core: 
    path: ../config 
    dirs: { sync: { path: '${cm.core.path}/default' } }
    install_from_config: false
```

**Alternatives considered**
<!-- How else could the original issue / use case be addressed? Why did you choose this solution over any others? -->

**Testing steps**
<!-- How can we replicate the issue and verify that this PR fixes it? -->

**Merge requirements**
- [ ] _Major change_, _Minor change_, _Bug_, _Enhancement_, and/or _Chore_ label applied
- [ ] Manual testing by a reviewer
