### PR TITLE
ACMS-1043: Include Node Revision Delete module in ACMS with default c…

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -58,6 +58,7 @@
         "drupal/moderation_dashboard": "1.0.0-beta3",
         "drupal/moderation_sidebar": "^1.4",
         "drupal/mysql56": "^1.0",
+        "drupal/node_revision_delete": "^1.0@RC",
         "drupal/password_policy": "^3.0",
         "drupal/pathauto": "^1",
         "drupal/recaptcha": "^3",

--- a/composer.json
+++ b/composer.json
@@ -58,7 +58,6 @@
         "drupal/moderation_dashboard": "1.0.0-beta3",
         "drupal/moderation_sidebar": "^1.4",
         "drupal/mysql56": "^1.0",
-        "drupal/node_revision_delete": "^1.0@RC",
         "drupal/password_policy": "^3.0",
         "drupal/pathauto": "^1",
         "drupal/recaptcha": "^3",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "cc3dc1bc2ea2bb35e847a838851ce7be",
+    "content-hash": "8d170e8dcad670d5f0a10540162f2628",
     "packages": [
         {
             "name": "acquia/acsf-contenthub-console",
@@ -19353,8 +19353,7 @@
     "aliases": [],
     "minimum-stability": "dev",
     "stability-flags": {
-        "drupal/imce": 20,
-        "drupal/node_revision_delete": 5
+        "drupal/imce": 20
     },
     "prefer-stable": true,
     "prefer-lowest": false,

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "8d170e8dcad670d5f0a10540162f2628",
+    "content-hash": "cc3dc1bc2ea2bb35e847a838851ce7be",
     "packages": [
         {
             "name": "acquia/acsf-contenthub-console",
@@ -19353,7 +19353,8 @@
     "aliases": [],
     "minimum-stability": "dev",
     "stability-flags": {
-        "drupal/imce": 20
+        "drupal/imce": 20,
+        "drupal/node_revision_delete": 5
     },
     "prefer-stable": true,
     "prefer-lowest": false,

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "8d170e8dcad670d5f0a10540162f2628",
+    "content-hash": "cc3dc1bc2ea2bb35e847a838851ce7be",
     "packages": [
         {
             "name": "acquia/acsf-contenthub-console",
@@ -2860,6 +2860,10 @@
             ],
             "authors": [
                 {
+                    "name": "Centarro",
+                    "homepage": "https://www.drupal.org/user/3661446"
+                },
+                {
                     "name": "bojanz",
                     "homepage": "https://www.drupal.org/user/86106"
                 },
@@ -5074,8 +5078,8 @@
                     "dev-2.x": "2.x-dev"
                 },
                 "drupal": {
-                    "version": "8.x-2.4+6-dev",
-                    "datestamp": "1632140426",
+                    "version": "8.x-2.4+7-dev",
+                    "datestamp": "1637281190",
                     "security-coverage": {
                         "status": "not-covered",
                         "message": "Dev releases are not covered by Drupal security advisories."
@@ -5722,6 +5726,79 @@
             "homepage": "https://www.drupal.org/project/mysql56",
             "support": {
                 "source": "https://git.drupalcode.org/project/mysql56"
+            }
+        },
+        {
+            "name": "drupal/node_revision_delete",
+            "version": "1.0.0-rc3",
+            "source": {
+                "type": "git",
+                "url": "https://git.drupalcode.org/project/node_revision_delete.git",
+                "reference": "8.x-1.0-rc3"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://ftp.drupal.org/files/projects/node_revision_delete-8.x-1.0-rc3.zip",
+                "reference": "8.x-1.0-rc3",
+                "shasum": "5c539e9ac8e4af276cc558a33f1da2a5ad57ac79"
+            },
+            "require": {
+                "drupal/core": "^8.7.7 || ^9.0"
+            },
+            "type": "drupal-module",
+            "extra": {
+                "drupal": {
+                    "version": "8.x-1.0-rc3",
+                    "datestamp": "1600878567",
+                    "security-coverage": {
+                        "status": "not-covered",
+                        "message": "RC releases are not covered by Drupal security advisories."
+                    }
+                },
+                "drush": {
+                    "services": {
+                        "drush.services.yml": "^9"
+                    }
+                }
+            },
+            "notification-url": "https://packages.drupal.org/8/downloads",
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "Adrian Cid Almaguer (adriancid)",
+                    "homepage": "https://www.drupal.org/u/adriancid",
+                    "email": "adriancid@gmail.com",
+                    "role": "Maintainer"
+                },
+                {
+                    "name": "Diosbel Mezquía (diosbelmezquia)",
+                    "homepage": "https://www.drupal.org/u/diosbelmezquia",
+                    "email": "dmezquiam@gmail.com",
+                    "role": "Maintainer"
+                },
+                {
+                    "name": "Robert Ngo (Robert Ngo)",
+                    "homepage": "https://www.drupal.org/u/robert-ngo",
+                    "email": "robertngo.18@gmail.com",
+                    "role": "Maintainer"
+                },
+                {
+                    "name": "kaushalkishorejaiswal",
+                    "homepage": "https://www.drupal.org/user/2228850"
+                }
+            ],
+            "description": "Track and prune node revisions.",
+            "homepage": "https://www.drupal.org/project/node_revision_delete",
+            "keywords": [
+                "Drupal",
+                "Nodes",
+                "Revisions"
+            ],
+            "support": {
+                "source": "http://cgit.drupalcode.org/node_revision_delete",
+                "issues": "https://www.drupal.org/project/issues/node_revision_delete"
             }
         },
         {
@@ -6597,7 +6674,7 @@
             "extra": {
                 "drupal": {
                     "version": "8.x-1.22",
-                    "datestamp": "1641999545",
+                    "datestamp": "1642935792",
                     "security-coverage": {
                         "status": "covered",
                         "message": "Covered by Drupal's security advisory policy"
@@ -9585,12 +9662,12 @@
             },
             "type": "library",
             "autoload": {
-                "psr-4": {
-                    "DeepCopy\\": "src/DeepCopy/"
-                },
                 "files": [
                     "src/DeepCopy/deep_copy.php"
-                ]
+                ],
+                "psr-4": {
+                    "DeepCopy\\": "src/DeepCopy/"
+                }
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
@@ -11350,11 +11427,11 @@
                 }
             },
             "autoload": {
-                "classmap": [
-                    "src/"
-                ],
                 "files": [
                     "src/Framework/Assert/Functions.php"
+                ],
+                "classmap": [
+                    "src/"
                 ]
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -18566,12 +18643,12 @@
             },
             "type": "library",
             "autoload": {
-                "psr-4": {
-                    "React\\Promise\\": "src/"
-                },
                 "files": [
                     "src/functions_include.php"
-                ]
+                ],
+                "psr-4": {
+                    "React\\Promise\\": "src/"
+                }
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
@@ -19276,7 +19353,8 @@
     "aliases": [],
     "minimum-stability": "dev",
     "stability-flags": {
-        "drupal/imce": 20
+        "drupal/imce": 20,
+        "drupal/node_revision_delete": 5
     },
     "prefer-stable": true,
     "prefer-lowest": false,

--- a/modules/acquia_cms_page/config/optional/node.type.page.yml
+++ b/modules/acquia_cms_page/config/optional/node.type.page.yml
@@ -37,6 +37,10 @@ third_party_settings:
     unpublish_enable: true
     unpublish_required: false
     unpublish_revision: false
+  node_revision_delete:
+    minimum_revisions_to_keep: 30
+    minimum_age_to_delete: 0
+    when_to_delete: 0
 name: Page
 type: page
 description: 'An unstructured content type that provides unique landing pages - e.g., a homepage, or marketing event landing page.'

--- a/modules/acquia_cms_site_studio/acquia_cms_site_studio.info.yml
+++ b/modules/acquia_cms_site_studio/acquia_cms_site_studio.info.yml
@@ -18,4 +18,5 @@ dependencies:
   - drupal:collapsiblock
   - drupal:config
   - drupal:config_rewrite
+  - drupal:node_revision_delete
   - drupal:sitestudio_page_builder

--- a/modules/acquia_cms_site_studio/acquia_cms_site_studio.install
+++ b/modules/acquia_cms_site_studio/acquia_cms_site_studio.install
@@ -6,6 +6,7 @@
  */
 
 use Drupal\Core\Installer\InstallerKernel;
+use Drupal\node\Entity\NodeType;
 
 /**
  * Implements hook_install().
@@ -109,4 +110,33 @@ function acquia_cms_site_studio_update_8001() {
  */
 function acquia_cms_site_studio_update_8002() {
   \Drupal::service('module_installer')->install(['sitestudio_page_builder']);
+}
+
+/**
+ * Install Node Revision Delete module with default configuration.
+ *
+ * Site Studio 6.8.x has a soft dependency on node_revision_delete module,
+ * Install module with default configuration.
+ */
+function acquia_cms_site_studio_update_8003() {
+  // Install node revision delete module and set default configurations.
+  \Drupal::service('module_installer')->install(['node_revision_delete']);
+  $config = \Drupal::service('config.factory')->getEditable('node_revision_delete.settings');
+  if (!empty($config)) {
+    $config->set('node_revision_delete_cron', '50')
+      ->set('node_revision_delete_time', '604800')
+      ->save();
+  }
+  // Set default node revision delete configuration for
+  // Article, Event, Page, Person, Place content type.
+  $moduleHandler = \Drupal::service('module_handler');
+  if ($moduleHandler->moduleExists('acquia_cms_page')) {
+    $type = NodeType::load('page');
+    if ($type) {
+      $type->setThirdPartySetting('node_revision_delete', 'minimum_revisions_to_keep', '30');
+      $type->setThirdPartySetting('node_revision_delete', 'minimum_age_to_delete', '0');
+      $type->setThirdPartySetting('node_revision_delete', 'when_to_delete', '0');
+      $type->save();
+    }
+  }
 }

--- a/modules/acquia_cms_site_studio/acquia_cms_site_studio.install
+++ b/modules/acquia_cms_site_studio/acquia_cms_site_studio.install
@@ -57,6 +57,13 @@ function acquia_cms_site_studio_install() {
         ->save();
     }
   }
+  // Set default configurations for node revision delete module.
+  $config = \Drupal::service('config.factory')->getEditable('node_revision_delete.settings');
+  if (!empty($config)) {
+    $config->set('node_revision_delete_cron', '50')
+      ->set('node_revision_delete_time', '604800')
+      ->save();
+  }
 }
 
 /**
@@ -127,8 +134,7 @@ function acquia_cms_site_studio_update_8003() {
       ->set('node_revision_delete_time', '604800')
       ->save();
   }
-  // Set default node revision delete configuration for
-  // Article, Event, Page, Person, Place content type.
+  // Set default node revision delete configuration for Place content type.
   $moduleHandler = \Drupal::service('module_handler');
   if ($moduleHandler->moduleExists('acquia_cms_page')) {
     $type = NodeType::load('page');

--- a/modules/acquia_cms_site_studio/composer.json
+++ b/modules/acquia_cms_site_studio/composer.json
@@ -9,7 +9,8 @@
         "drupal/acquia_cms_common": "^1.3",
         "drupal/collapsiblock": "^3",
         "drupal/config_ignore": "2.3.0",
-        "drupal/config_rewrite": "^1.4"
+        "drupal/config_rewrite": "^1.4",
+        "drupal/node_revision_delete": "^1.0@RC"
     },
     "extra": {
         "drush": {

--- a/modules/acquia_cms_site_studio/tests/src/ExistingSite/NodeRevisionDeleteConfigTest.php
+++ b/modules/acquia_cms_site_studio/tests/src/ExistingSite/NodeRevisionDeleteConfigTest.php
@@ -23,11 +23,7 @@ class NodeRevisionDeleteConfigTest extends ExistingSiteBase {
    * {@inheritdoc}
    */
   protected static $modules = [
-    'acquia_cms_article',
-    'acquia_cms_event',
     'acquia_cms_page',
-    'acquia_cms_person',
-    'acquia_cms_place',
     'acquia_cms_site_studio',
     'node',
     'node_revision_delete',

--- a/modules/acquia_cms_site_studio/tests/src/ExistingSite/NodeRevisionDeleteConfigTest.php
+++ b/modules/acquia_cms_site_studio/tests/src/ExistingSite/NodeRevisionDeleteConfigTest.php
@@ -1,0 +1,75 @@
+<?php
+
+namespace Drupal\Tests\acquia_cms_site_studio\ExistingSite;
+
+use Drupal\Core\Config\ImmutableConfig;
+use weitzman\DrupalTestTraits\ExistingSiteBase;
+
+/**
+ * Tests config values that are set at install.
+ *
+ * @group acquia_cms
+ * @group profile
+ * @group risky
+ */
+class NodeRevisionDeleteConfigTest extends ExistingSiteBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected $defaultTheme = 'stark';
+
+  /**
+   * {@inheritdoc}
+   */
+  protected static $modules = [
+    'acquia_cms_article',
+    'acquia_cms_event',
+    'acquia_cms_page',
+    'acquia_cms_person',
+    'acquia_cms_place',
+    'acquia_cms_site_studio',
+    'node',
+    'node_revision_delete',
+  ];
+
+  /**
+   * Returns a config object by name.
+   *
+   * @param string $name
+   *   The name of the config object to return.
+   *
+   * @return \Drupal\Core\Config\ImmutableConfig
+   *   The config object, read-only to discourage this test from making any
+   *   changes.
+   */
+  private function config(string $name) : ImmutableConfig {
+    return $this->container->get('config.factory')->get($name);
+  }
+
+  /**
+   * Assert that node revision delete default configs are available.
+   */
+  public function testNodeRevisionDeleteConfig() {
+    // Check that node revision delete default configs are in place.
+    $config = $this->config('node_revision_delete.settings');
+    if ($config) {
+      $this->assertEquals(50, $config->get('node_revision_delete_cron'));
+      $this->assertEquals(604800, $config->get('node_revision_delete_time'));
+    }
+  }
+
+  /**
+   * Assert that node revision delete configs available for Page content type.
+   */
+  public function testContentTypeConfig() {
+    // Check node revision delete configs for Page content type are in palce.
+    $config = $this->config('node.type.page');
+    if ($config) {
+      $this->assertSame(30, $config->get('third_party_settings.node_revision_delete.minimum_revisions_to_keep'));
+      $this->assertSame(0, $config->get('third_party_settings.node_revision_delete.minimum_age_to_delete'));
+      $this->assertSame(0, $config->get('third_party_settings.node_revision_delete.when_to_delete'));
+    }
+  }
+
+}


### PR DESCRIPTION
ACMS-1043: Include Node Revision Delete module in ACMS with default config

**Motivation**
Fixes #[1043](https://backlog.acquia.com/browse/ACMS-1043)

**Proposed changes**
Include Node Revision Delete module in ACMS with default config

**Alternatives considered**
NA

**Testing steps**
New Site:
- Install site with this branch
- Login into application as administrator
- Head towards - /admin/modules 
- Verify that the "Node Revision Delete" module is enabled
- Head towards - /admin/config/content/node_revision_delete
- Verify that default Node revision delete configs are in place
- Head towards - /admin/structure/types/manage/{content_type_machine_name}
- Click on "Publishing Options"
- Verify that default Node revision delete configs for page content type are in place

Existing Site:
- Pull code from this branch
- Execute `drush updb -y`
- Login into application as administrator
- Head towards - /admin/modules 
- Verify that the "Node Revision Delete" module is enabled
- Head towards - /admin/config/content/node_revision_delete
- Verify that default Node revision delete configs are in place
- Head towards - /admin/structure/types/manage/page
- Click on "Publishing Options"
- Verify that default Node revision delete configs for page content type are in place

**Merge requirements**
- [ ] _Major change_, _Minor change_, _Bug_, _Enhancement_, and/or _Chore_ label applied
- [ ] Manual testing by a reviewer
