### PR TITLE
ACMS-1060: Add allowed plugins in Composer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -94,6 +94,15 @@
         "weitzman/drupal-test-traits": "^1.5"
     },
     "config": {
+        "allow-plugins": {
+            "composer/installers": true,
+            "cweagans/composer-patches": true,
+            "dealerdirect/phpcodesniffer-composer-installer": true,
+            "drupal/core-composer-scaffold": true,
+            "ergebnis/composer-normalize": true,
+            "oomphinc/composer-installers-extender": true,
+            "phpro/grumphp-shim": true
+        },
         "preferred-install": {
             "drupal/core": "dist"
         },

--- a/composer.json
+++ b/composer.json
@@ -101,7 +101,8 @@
             "drupal/core-composer-scaffold": true,
             "ergebnis/composer-normalize": true,
             "oomphinc/composer-installers-extender": true,
-            "phpro/grumphp-shim": true
+            "phpro/grumphp-shim": true,
+            "webdriver-binary/binary-chromedriver": true
         },
         "preferred-install": {
             "drupal/core": "dist"

--- a/composer.lock
+++ b/composer.lock
@@ -10624,12 +10624,12 @@
                 }
             },
             "autoload": {
-                "psr-4": {
-                    "Http\\Message\\": "src/"
-                },
                 "files": [
                     "src/filters.php"
-                ]
+                ],
+                "psr-4": {
+                    "Http\\Message\\": "src/"
+                }
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [

--- a/composer.lock
+++ b/composer.lock
@@ -9652,9 +9652,6 @@
             "require": {
                 "php": "^7.1 || ^8.0"
             },
-            "replace": {
-                "myclabs/deep-copy": "self.version"
-            },
             "require-dev": {
                 "doctrine/collections": "^1.0",
                 "doctrine/common": "^2.6",
@@ -14113,16 +14110,16 @@
         },
         {
             "name": "symfony/filesystem",
-            "version": "v4.4.27",
+            "version": "v4.4.37",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/filesystem.git",
-                "reference": "517fb795794faf29086a77d99eb8f35e457837a7"
+                "reference": "c59f37705c3e513ae55b2735f128f4ce363c82ec"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/filesystem/zipball/517fb795794faf29086a77d99eb8f35e457837a7",
-                "reference": "517fb795794faf29086a77d99eb8f35e457837a7",
+                "url": "https://api.github.com/repos/symfony/filesystem/zipball/c59f37705c3e513ae55b2735f128f4ce363c82ec",
+                "reference": "c59f37705c3e513ae55b2735f128f4ce363c82ec",
                 "shasum": ""
             },
             "require": {
@@ -14156,7 +14153,7 @@
             "description": "Provides basic utilities for the filesystem",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/filesystem/tree/v4.4.27"
+                "source": "https://github.com/symfony/filesystem/tree/v4.4.37"
             },
             "funding": [
                 {
@@ -14172,20 +14169,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-07-21T12:19:41+00:00"
+            "time": "2022-01-02T09:41:36+00:00"
         },
         {
             "name": "symfony/finder",
-            "version": "v4.4.36",
+            "version": "v4.4.37",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/finder.git",
-                "reference": "1fef05633cd61b629e963e5d8200fb6b67ecf42c"
+                "reference": "b17d76d7ed179f017aad646e858c90a2771af15d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/finder/zipball/1fef05633cd61b629e963e5d8200fb6b67ecf42c",
-                "reference": "1fef05633cd61b629e963e5d8200fb6b67ecf42c",
+                "url": "https://api.github.com/repos/symfony/finder/zipball/b17d76d7ed179f017aad646e858c90a2771af15d",
+                "reference": "b17d76d7ed179f017aad646e858c90a2771af15d",
                 "shasum": ""
             },
             "require": {
@@ -14218,7 +14215,7 @@
             "description": "Finds files and directories via an intuitive fluent interface",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/finder/tree/v4.4.36"
+                "source": "https://github.com/symfony/finder/tree/v4.4.37"
             },
             "funding": [
                 {
@@ -14234,7 +14231,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-12-15T10:33:10+00:00"
+            "time": "2022-01-02T09:41:36+00:00"
         },
         {
             "name": "symfony/http-client-contracts",
@@ -17057,16 +17054,16 @@
         },
         {
             "name": "composer/ca-bundle",
-            "version": "1.2.11",
+            "version": "1.3.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/composer/ca-bundle.git",
-                "reference": "0b072d51c5a9c6f3412f7ea3ab043d6603cb2582"
+                "reference": "4c679186f2aca4ab6a0f1b0b9cf9252decb44d0b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/composer/ca-bundle/zipball/0b072d51c5a9c6f3412f7ea3ab043d6603cb2582",
-                "reference": "0b072d51c5a9c6f3412f7ea3ab043d6603cb2582",
+                "url": "https://api.github.com/repos/composer/ca-bundle/zipball/4c679186f2aca4ab6a0f1b0b9cf9252decb44d0b",
+                "reference": "4c679186f2aca4ab6a0f1b0b9cf9252decb44d0b",
                 "shasum": ""
             },
             "require": {
@@ -17113,7 +17110,7 @@
             "support": {
                 "irc": "irc://irc.freenode.org/composer",
                 "issues": "https://github.com/composer/ca-bundle/issues",
-                "source": "https://github.com/composer/ca-bundle/tree/1.2.11"
+                "source": "https://github.com/composer/ca-bundle/tree/1.3.1"
             },
             "funding": [
                 {
@@ -17129,35 +17126,36 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-09-25T20:32:43+00:00"
+            "time": "2021-10-28T20:44:15+00:00"
         },
         {
             "name": "composer/composer",
-            "version": "2.1.8",
+            "version": "2.2.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/composer/composer.git",
-                "reference": "24d38e9686092de05214cafa187dc282a5d89497"
+                "reference": "ce785a18c0fb472421e52d958bab339247cb0e82"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/composer/composer/zipball/24d38e9686092de05214cafa187dc282a5d89497",
-                "reference": "24d38e9686092de05214cafa187dc282a5d89497",
+                "url": "https://api.github.com/repos/composer/composer/zipball/ce785a18c0fb472421e52d958bab339247cb0e82",
+                "reference": "ce785a18c0fb472421e52d958bab339247cb0e82",
                 "shasum": ""
             },
             "require": {
                 "composer/ca-bundle": "^1.0",
                 "composer/metadata-minifier": "^1.0",
+                "composer/pcre": "^1.0",
                 "composer/semver": "^3.0",
                 "composer/spdx-licenses": "^1.2",
                 "composer/xdebug-handler": "^2.0",
                 "justinrainbow/json-schema": "^5.2.11",
                 "php": "^5.3.2 || ^7.0 || ^8.0",
-                "psr/log": "^1.0",
+                "psr/log": "^1.0 || ^2.0",
                 "react/promise": "^1.2 || ^2.7",
                 "seld/jsonlint": "^1.4",
                 "seld/phar-utils": "^1.0",
-                "symfony/console": "^2.8.52 || ^3.4.35 || ^4.4 || ^5.0 || ^6.0",
+                "symfony/console": "^2.8.52 || ^3.4.35 || ^4.4 || ^5.0",
                 "symfony/filesystem": "^2.8.52 || ^3.4.35 || ^4.4 || ^5.0 || ^6.0",
                 "symfony/finder": "^2.8.52 || ^3.4.35 || ^4.4 || ^5.0 || ^6.0",
                 "symfony/process": "^2.8.52 || ^3.4.35 || ^4.4 || ^5.0 || ^6.0"
@@ -17177,7 +17175,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.1-dev"
+                    "dev-main": "2.2-dev"
                 }
             },
             "autoload": {
@@ -17211,7 +17209,7 @@
             "support": {
                 "irc": "ircs://irc.libera.chat:6697/composer",
                 "issues": "https://github.com/composer/composer/issues",
-                "source": "https://github.com/composer/composer/tree/2.1.8"
+                "source": "https://github.com/composer/composer/tree/2.2.6"
             },
             "funding": [
                 {
@@ -17227,7 +17225,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-09-15T11:55:15+00:00"
+            "time": "2022-02-04T16:00:38+00:00"
         },
         {
             "name": "composer/installers",
@@ -17451,23 +17449,23 @@
         },
         {
             "name": "composer/pcre",
-            "version": "1.0.0",
+            "version": "1.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/composer/pcre.git",
-                "reference": "3d322d715c43a1ac36c7fe215fa59336265500f2"
+                "reference": "67a32d7d6f9f560b726ab25a061b38ff3a80c560"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/composer/pcre/zipball/3d322d715c43a1ac36c7fe215fa59336265500f2",
-                "reference": "3d322d715c43a1ac36c7fe215fa59336265500f2",
+                "url": "https://api.github.com/repos/composer/pcre/zipball/67a32d7d6f9f560b726ab25a061b38ff3a80c560",
+                "reference": "67a32d7d6f9f560b726ab25a061b38ff3a80c560",
                 "shasum": ""
             },
             "require": {
                 "php": "^5.3.2 || ^7.0 || ^8.0"
             },
             "require-dev": {
-                "phpstan/phpstan": "^1",
+                "phpstan/phpstan": "^1.3",
                 "phpstan/phpstan-strict-rules": "^1.1",
                 "symfony/phpunit-bridge": "^4.2 || ^5"
             },
@@ -17502,7 +17500,7 @@
             ],
             "support": {
                 "issues": "https://github.com/composer/pcre/issues",
-                "source": "https://github.com/composer/pcre/tree/1.0.0"
+                "source": "https://github.com/composer/pcre/tree/1.0.1"
             },
             "funding": [
                 {
@@ -17518,27 +17516,28 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-12-06T15:17:27+00:00"
+            "time": "2022-01-21T20:24:37+00:00"
         },
         {
             "name": "composer/spdx-licenses",
-            "version": "1.5.5",
+            "version": "1.5.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/composer/spdx-licenses.git",
-                "reference": "de30328a7af8680efdc03e396aad24befd513200"
+                "reference": "a30d487169d799745ca7280bc90fdfa693536901"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/composer/spdx-licenses/zipball/de30328a7af8680efdc03e396aad24befd513200",
-                "reference": "de30328a7af8680efdc03e396aad24befd513200",
+                "url": "https://api.github.com/repos/composer/spdx-licenses/zipball/a30d487169d799745ca7280bc90fdfa693536901",
+                "reference": "a30d487169d799745ca7280bc90fdfa693536901",
                 "shasum": ""
             },
             "require": {
                 "php": "^5.3.2 || ^7.0 || ^8.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "^4.8.35 || ^5.7 || 6.5 - 7"
+                "phpstan/phpstan": "^0.12.55",
+                "symfony/phpunit-bridge": "^4.2 || ^5"
             },
             "type": "library",
             "extra": {
@@ -17581,7 +17580,7 @@
             "support": {
                 "irc": "irc://irc.freenode.org/composer",
                 "issues": "https://github.com/composer/spdx-licenses/issues",
-                "source": "https://github.com/composer/spdx-licenses/tree/1.5.5"
+                "source": "https://github.com/composer/spdx-licenses/tree/1.5.6"
             },
             "funding": [
                 {
@@ -17597,7 +17596,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2020-12-03T16:04:16+00:00"
+            "time": "2021-11-18T10:14:14+00:00"
         },
         {
             "name": "composer/xdebug-handler",
@@ -18797,16 +18796,16 @@
         },
         {
             "name": "seld/phar-utils",
-            "version": "1.1.2",
+            "version": "1.2.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Seldaek/phar-utils.git",
-                "reference": "749042a2315705d2dfbbc59234dd9ceb22bf3ff0"
+                "reference": "9f3452c93ff423469c0d56450431562ca423dcee"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Seldaek/phar-utils/zipball/749042a2315705d2dfbbc59234dd9ceb22bf3ff0",
-                "reference": "749042a2315705d2dfbbc59234dd9ceb22bf3ff0",
+                "url": "https://api.github.com/repos/Seldaek/phar-utils/zipball/9f3452c93ff423469c0d56450431562ca423dcee",
+                "reference": "9f3452c93ff423469c0d56450431562ca423dcee",
                 "shasum": ""
             },
             "require": {
@@ -18839,9 +18838,9 @@
             ],
             "support": {
                 "issues": "https://github.com/Seldaek/phar-utils/issues",
-                "source": "https://github.com/Seldaek/phar-utils/tree/1.1.2"
+                "source": "https://github.com/Seldaek/phar-utils/tree/1.2.0"
             },
-            "time": "2021-08-19T21:01:38+00:00"
+            "time": "2021-12-10T11:20:11+00:00"
         },
         {
             "name": "slevomat/coding-standard",
@@ -19360,5 +19359,5 @@
     "prefer-lowest": false,
     "platform": [],
     "platform-dev": [],
-    "plugin-api-version": "2.1.0"
+    "plugin-api-version": "2.2.0"
 }

--- a/composer.lock
+++ b/composer.lock
@@ -704,12 +704,12 @@
             },
             "type": "library",
             "autoload": {
-                "psr-4": {
-                    "Clue\\StreamFilter\\": "src/"
-                },
                 "files": [
                     "src/functions_include.php"
-                ]
+                ],
+                "psr-4": {
+                    "Clue\\StreamFilter\\": "src/"
+                }
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [

--- a/modules/acquia_cms_article/composer.json
+++ b/modules/acquia_cms_article/composer.json
@@ -14,7 +14,8 @@
             "drupal/core-composer-scaffold": true,
             "ergebnis/composer-normalize": true,
             "oomphinc/composer-installers-extender": true,
-            "phpro/grumphp-shim": true
+            "phpro/grumphp-shim": true,
+            "webdriver-binary/binary-chromedriver": true
         }
     },
     "repositories": {

--- a/modules/acquia_cms_article/composer.json
+++ b/modules/acquia_cms_article/composer.json
@@ -15,5 +15,16 @@
             "type": "composer",
             "url": "https://asset-packagist.org"
         }
+    },
+    "config": {
+        "allow-plugins": {
+            "dealerdirect/phpcodesniffer-composer-installer": true,
+            "composer/installers": true,
+            "cweagans/composer-patches": true,
+            "ergebnis/composer-normalize": true,
+            "drupal/core-composer-scaffold": true,
+            "phpro/grumphp-shim": true,
+            "oomphinc/composer-installers-extender": true
+        }
     }
 }

--- a/modules/acquia_cms_article/composer.json
+++ b/modules/acquia_cms_article/composer.json
@@ -6,6 +6,17 @@
     "require": {
         "drupal/acquia_cms_person": "^1.0"
     },
+    "config": {
+        "allow-plugins": {
+            "composer/installers": true,
+            "cweagans/composer-patches": true,
+            "dealerdirect/phpcodesniffer-composer-installer": true,
+            "drupal/core-composer-scaffold": true,
+            "ergebnis/composer-normalize": true,
+            "oomphinc/composer-installers-extender": true,
+            "phpro/grumphp-shim": true
+        }
+    },
     "repositories": {
         "drupal": {
             "type": "composer",
@@ -14,17 +25,6 @@
         "assets": {
             "type": "composer",
             "url": "https://asset-packagist.org"
-        }
-    },
-    "config": {
-        "allow-plugins": {
-            "dealerdirect/phpcodesniffer-composer-installer": true,
-            "composer/installers": true,
-            "cweagans/composer-patches": true,
-            "ergebnis/composer-normalize": true,
-            "drupal/core-composer-scaffold": true,
-            "phpro/grumphp-shim": true,
-            "oomphinc/composer-installers-extender": true
         }
     }
 }

--- a/modules/acquia_cms_audio/composer.json
+++ b/modules/acquia_cms_audio/composer.json
@@ -15,7 +15,8 @@
             "drupal/core-composer-scaffold": true,
             "ergebnis/composer-normalize": true,
             "oomphinc/composer-installers-extender": true,
-            "phpro/grumphp-shim": true
+            "phpro/grumphp-shim": true,
+            "webdriver-binary/binary-chromedriver": true
         }
     },
     "repositories": {

--- a/modules/acquia_cms_audio/composer.json
+++ b/modules/acquia_cms_audio/composer.json
@@ -16,5 +16,16 @@
             "type": "composer",
             "url": "https://asset-packagist.org"
         }
+    },
+    "config": {
+        "allow-plugins": {
+            "dealerdirect/phpcodesniffer-composer-installer": true,
+            "composer/installers": true,
+            "cweagans/composer-patches": true,
+            "ergebnis/composer-normalize": true,
+            "drupal/core-composer-scaffold": true,
+            "phpro/grumphp-shim": true,
+            "oomphinc/composer-installers-extender": true
+        }
     }
 }

--- a/modules/acquia_cms_audio/composer.json
+++ b/modules/acquia_cms_audio/composer.json
@@ -7,6 +7,17 @@
         "drupal/acquia_cms_common": "^1.0",
         "drupal/media_entity_soundcloud": "^3.0"
     },
+    "config": {
+        "allow-plugins": {
+            "composer/installers": true,
+            "cweagans/composer-patches": true,
+            "dealerdirect/phpcodesniffer-composer-installer": true,
+            "drupal/core-composer-scaffold": true,
+            "ergebnis/composer-normalize": true,
+            "oomphinc/composer-installers-extender": true,
+            "phpro/grumphp-shim": true
+        }
+    },
     "repositories": {
         "drupal": {
             "type": "composer",
@@ -15,17 +26,6 @@
         "assets": {
             "type": "composer",
             "url": "https://asset-packagist.org"
-        }
-    },
-    "config": {
-        "allow-plugins": {
-            "dealerdirect/phpcodesniffer-composer-installer": true,
-            "composer/installers": true,
-            "cweagans/composer-patches": true,
-            "ergebnis/composer-normalize": true,
-            "drupal/core-composer-scaffold": true,
-            "phpro/grumphp-shim": true,
-            "oomphinc/composer-installers-extender": true
         }
     }
 }

--- a/modules/acquia_cms_common/composer.json
+++ b/modules/acquia_cms_common/composer.json
@@ -23,7 +23,8 @@
             "drupal/core-composer-scaffold": true,
             "ergebnis/composer-normalize": true,
             "oomphinc/composer-installers-extender": true,
-            "phpro/grumphp-shim": true
+            "phpro/grumphp-shim": true,
+            "webdriver-binary/binary-chromedriver": true
         }
     },
     "extra": {

--- a/modules/acquia_cms_common/composer.json
+++ b/modules/acquia_cms_common/composer.json
@@ -45,5 +45,16 @@
             "type": "composer",
             "url": "https://asset-packagist.org"
         }
+    },
+    "config": {
+        "allow-plugins": {
+            "dealerdirect/phpcodesniffer-composer-installer": true,
+            "composer/installers": true,
+            "cweagans/composer-patches": true,
+            "ergebnis/composer-normalize": true,
+            "drupal/core-composer-scaffold": true,
+            "phpro/grumphp-shim": true,
+            "oomphinc/composer-installers-extender": true
+        }
     }
 }

--- a/modules/acquia_cms_common/composer.json
+++ b/modules/acquia_cms_common/composer.json
@@ -15,6 +15,17 @@
         "drupal/smart_trim": "^1.3",
         "drupal/workbench_email": "^2.2"
     },
+    "config": {
+        "allow-plugins": {
+            "composer/installers": true,
+            "cweagans/composer-patches": true,
+            "dealerdirect/phpcodesniffer-composer-installer": true,
+            "drupal/core-composer-scaffold": true,
+            "ergebnis/composer-normalize": true,
+            "oomphinc/composer-installers-extender": true,
+            "phpro/grumphp-shim": true
+        }
+    },
     "extra": {
         "drush": {
             "services": {
@@ -44,17 +55,6 @@
         "assets": {
             "type": "composer",
             "url": "https://asset-packagist.org"
-        }
-    },
-    "config": {
-        "allow-plugins": {
-            "dealerdirect/phpcodesniffer-composer-installer": true,
-            "composer/installers": true,
-            "cweagans/composer-patches": true,
-            "ergebnis/composer-normalize": true,
-            "drupal/core-composer-scaffold": true,
-            "phpro/grumphp-shim": true,
-            "oomphinc/composer-installers-extender": true
         }
     }
 }

--- a/modules/acquia_cms_component/composer.json
+++ b/modules/acquia_cms_component/composer.json
@@ -24,5 +24,16 @@
             "type": "composer",
             "url": "https://asset-packagist.org"
         }
+    },
+    "config": {
+        "allow-plugins": {
+            "dealerdirect/phpcodesniffer-composer-installer": true,
+            "composer/installers": true,
+            "cweagans/composer-patches": true,
+            "ergebnis/composer-normalize": true,
+            "drupal/core-composer-scaffold": true,
+            "phpro/grumphp-shim": true,
+            "oomphinc/composer-installers-extender": true
+        }
     }
 }

--- a/modules/acquia_cms_component/composer.json
+++ b/modules/acquia_cms_component/composer.json
@@ -7,6 +7,17 @@
         "drupal/component": "1.0-rc3",
         "drupal/jsonapi_extras": "^3"
     },
+    "config": {
+        "allow-plugins": {
+            "composer/installers": true,
+            "cweagans/composer-patches": true,
+            "dealerdirect/phpcodesniffer-composer-installer": true,
+            "drupal/core-composer-scaffold": true,
+            "ergebnis/composer-normalize": true,
+            "oomphinc/composer-installers-extender": true,
+            "phpro/grumphp-shim": true
+        }
+    },
     "extra": {
         "enable-patching": true,
         "patches": {
@@ -23,17 +34,6 @@
         "assets": {
             "type": "composer",
             "url": "https://asset-packagist.org"
-        }
-    },
-    "config": {
-        "allow-plugins": {
-            "dealerdirect/phpcodesniffer-composer-installer": true,
-            "composer/installers": true,
-            "cweagans/composer-patches": true,
-            "ergebnis/composer-normalize": true,
-            "drupal/core-composer-scaffold": true,
-            "phpro/grumphp-shim": true,
-            "oomphinc/composer-installers-extender": true
         }
     }
 }

--- a/modules/acquia_cms_component/composer.json
+++ b/modules/acquia_cms_component/composer.json
@@ -15,7 +15,8 @@
             "drupal/core-composer-scaffold": true,
             "ergebnis/composer-normalize": true,
             "oomphinc/composer-installers-extender": true,
-            "phpro/grumphp-shim": true
+            "phpro/grumphp-shim": true,
+            "webdriver-binary/binary-chromedriver": true
         }
     },
     "extra": {

--- a/modules/acquia_cms_development/composer.json
+++ b/modules/acquia_cms_development/composer.json
@@ -16,7 +16,8 @@
             "drupal/core-composer-scaffold": true,
             "ergebnis/composer-normalize": true,
             "oomphinc/composer-installers-extender": true,
-            "phpro/grumphp-shim": true
+            "phpro/grumphp-shim": true,
+            "webdriver-binary/binary-chromedriver": true
         }
     }
 }

--- a/modules/acquia_cms_development/composer.json
+++ b/modules/acquia_cms_development/composer.json
@@ -7,5 +7,16 @@
         "drupal/acquia_connector": "^3",
         "drupal/acquia_search": "^3.0.3",
         "drupal/config_rewrite": "^1.4"
+    },
+    "config": {
+        "allow-plugins": {
+            "dealerdirect/phpcodesniffer-composer-installer": true,
+            "composer/installers": true,
+            "cweagans/composer-patches": true,
+            "ergebnis/composer-normalize": true,
+            "drupal/core-composer-scaffold": true,
+            "phpro/grumphp-shim": true,
+            "oomphinc/composer-installers-extender": true
+        }
     }
 }

--- a/modules/acquia_cms_development/composer.json
+++ b/modules/acquia_cms_development/composer.json
@@ -10,13 +10,13 @@
     },
     "config": {
         "allow-plugins": {
-            "dealerdirect/phpcodesniffer-composer-installer": true,
             "composer/installers": true,
             "cweagans/composer-patches": true,
-            "ergebnis/composer-normalize": true,
+            "dealerdirect/phpcodesniffer-composer-installer": true,
             "drupal/core-composer-scaffold": true,
-            "phpro/grumphp-shim": true,
-            "oomphinc/composer-installers-extender": true
+            "ergebnis/composer-normalize": true,
+            "oomphinc/composer-installers-extender": true,
+            "phpro/grumphp-shim": true
         }
     }
 }

--- a/modules/acquia_cms_document/composer.json
+++ b/modules/acquia_cms_document/composer.json
@@ -15,7 +15,8 @@
             "drupal/core-composer-scaffold": true,
             "ergebnis/composer-normalize": true,
             "oomphinc/composer-installers-extender": true,
-            "phpro/grumphp-shim": true
+            "phpro/grumphp-shim": true,
+            "webdriver-binary/binary-chromedriver": true
         }
     },
     "repositories": {

--- a/modules/acquia_cms_document/composer.json
+++ b/modules/acquia_cms_document/composer.json
@@ -7,6 +7,17 @@
         "drupal/acquia_cms_common": "^1.0",
         "drupal/field_group": "^3"
     },
+    "config": {
+        "allow-plugins": {
+            "composer/installers": true,
+            "cweagans/composer-patches": true,
+            "dealerdirect/phpcodesniffer-composer-installer": true,
+            "drupal/core-composer-scaffold": true,
+            "ergebnis/composer-normalize": true,
+            "oomphinc/composer-installers-extender": true,
+            "phpro/grumphp-shim": true
+        }
+    },
     "repositories": {
         "drupal": {
             "type": "composer",
@@ -15,17 +26,6 @@
         "assets": {
             "type": "composer",
             "url": "https://asset-packagist.org"
-        }
-    },
-    "config": {
-        "allow-plugins": {
-            "dealerdirect/phpcodesniffer-composer-installer": true,
-            "composer/installers": true,
-            "cweagans/composer-patches": true,
-            "ergebnis/composer-normalize": true,
-            "drupal/core-composer-scaffold": true,
-            "phpro/grumphp-shim": true,
-            "oomphinc/composer-installers-extender": true
         }
     }
 }

--- a/modules/acquia_cms_document/composer.json
+++ b/modules/acquia_cms_document/composer.json
@@ -16,5 +16,16 @@
             "type": "composer",
             "url": "https://asset-packagist.org"
         }
+    },
+    "config": {
+        "allow-plugins": {
+            "dealerdirect/phpcodesniffer-composer-installer": true,
+            "composer/installers": true,
+            "cweagans/composer-patches": true,
+            "ergebnis/composer-normalize": true,
+            "drupal/core-composer-scaffold": true,
+            "phpro/grumphp-shim": true,
+            "oomphinc/composer-installers-extender": true
+        }
     }
 }

--- a/modules/acquia_cms_event/composer.json
+++ b/modules/acquia_cms_event/composer.json
@@ -14,7 +14,8 @@
             "drupal/core-composer-scaffold": true,
             "ergebnis/composer-normalize": true,
             "oomphinc/composer-installers-extender": true,
-            "phpro/grumphp-shim": true
+            "phpro/grumphp-shim": true,
+            "webdriver-binary/binary-chromedriver": true
         }
     },
     "repositories": {

--- a/modules/acquia_cms_event/composer.json
+++ b/modules/acquia_cms_event/composer.json
@@ -6,6 +6,17 @@
     "require": {
         "drupal/acquia_cms_place": "^1.0"
     },
+    "config": {
+        "allow-plugins": {
+            "composer/installers": true,
+            "cweagans/composer-patches": true,
+            "dealerdirect/phpcodesniffer-composer-installer": true,
+            "drupal/core-composer-scaffold": true,
+            "ergebnis/composer-normalize": true,
+            "oomphinc/composer-installers-extender": true,
+            "phpro/grumphp-shim": true
+        }
+    },
     "repositories": {
         "drupal": {
             "type": "composer",
@@ -14,17 +25,6 @@
         "assets": {
             "type": "composer",
             "url": "https://asset-packagist.org"
-        }
-    },
-    "config": {
-        "allow-plugins": {
-            "dealerdirect/phpcodesniffer-composer-installer": true,
-            "composer/installers": true,
-            "cweagans/composer-patches": true,
-            "ergebnis/composer-normalize": true,
-            "drupal/core-composer-scaffold": true,
-            "phpro/grumphp-shim": true,
-            "oomphinc/composer-installers-extender": true
         }
     }
 }

--- a/modules/acquia_cms_event/composer.json
+++ b/modules/acquia_cms_event/composer.json
@@ -15,5 +15,16 @@
             "type": "composer",
             "url": "https://asset-packagist.org"
         }
+    },
+    "config": {
+        "allow-plugins": {
+            "dealerdirect/phpcodesniffer-composer-installer": true,
+            "composer/installers": true,
+            "cweagans/composer-patches": true,
+            "ergebnis/composer-normalize": true,
+            "drupal/core-composer-scaffold": true,
+            "phpro/grumphp-shim": true,
+            "oomphinc/composer-installers-extender": true
+        }
     }
 }

--- a/modules/acquia_cms_image/composer.json
+++ b/modules/acquia_cms_image/composer.json
@@ -27,5 +27,16 @@
             "type": "composer",
             "url": "https://asset-packagist.org"
         }
+    },
+    "config": {
+        "allow-plugins": {
+            "dealerdirect/phpcodesniffer-composer-installer": true,
+            "composer/installers": true,
+            "cweagans/composer-patches": true,
+            "ergebnis/composer-normalize": true,
+            "drupal/core-composer-scaffold": true,
+            "phpro/grumphp-shim": true,
+            "oomphinc/composer-installers-extender": true
+        }
     }
 }

--- a/modules/acquia_cms_image/composer.json
+++ b/modules/acquia_cms_image/composer.json
@@ -18,7 +18,8 @@
             "drupal/core-composer-scaffold": true,
             "ergebnis/composer-normalize": true,
             "oomphinc/composer-installers-extender": true,
-            "phpro/grumphp-shim": true
+            "phpro/grumphp-shim": true,
+            "webdriver-binary/binary-chromedriver": true
         }
     },
     "extra": {

--- a/modules/acquia_cms_image/composer.json
+++ b/modules/acquia_cms_image/composer.json
@@ -10,6 +10,17 @@
         "drupal/field_group": "^3",
         "drupal/imce": "2.x-dev"
     },
+    "config": {
+        "allow-plugins": {
+            "composer/installers": true,
+            "cweagans/composer-patches": true,
+            "dealerdirect/phpcodesniffer-composer-installer": true,
+            "drupal/core-composer-scaffold": true,
+            "ergebnis/composer-normalize": true,
+            "oomphinc/composer-installers-extender": true,
+            "phpro/grumphp-shim": true
+        }
+    },
     "extra": {
         "enable-patching": true,
         "patches": {
@@ -26,17 +37,6 @@
         "assets": {
             "type": "composer",
             "url": "https://asset-packagist.org"
-        }
-    },
-    "config": {
-        "allow-plugins": {
-            "dealerdirect/phpcodesniffer-composer-installer": true,
-            "composer/installers": true,
-            "cweagans/composer-patches": true,
-            "ergebnis/composer-normalize": true,
-            "drupal/core-composer-scaffold": true,
-            "phpro/grumphp-shim": true,
-            "oomphinc/composer-installers-extender": true
         }
     }
 }

--- a/modules/acquia_cms_page/composer.json
+++ b/modules/acquia_cms_page/composer.json
@@ -17,5 +17,16 @@
             "type": "composer",
             "url": "https://asset-packagist.org"
         }
+    },
+    "config": {
+        "allow-plugins": {
+            "dealerdirect/phpcodesniffer-composer-installer": true,
+            "composer/installers": true,
+            "cweagans/composer-patches": true,
+            "ergebnis/composer-normalize": true,
+            "drupal/core-composer-scaffold": true,
+            "phpro/grumphp-shim": true,
+            "oomphinc/composer-installers-extender": true
+        }
     }
 }

--- a/modules/acquia_cms_page/composer.json
+++ b/modules/acquia_cms_page/composer.json
@@ -16,7 +16,8 @@
             "drupal/core-composer-scaffold": true,
             "ergebnis/composer-normalize": true,
             "oomphinc/composer-installers-extender": true,
-            "phpro/grumphp-shim": true
+            "phpro/grumphp-shim": true,
+            "webdriver-binary/binary-chromedriver": true
         }
     },
     "repositories": {

--- a/modules/acquia_cms_page/composer.json
+++ b/modules/acquia_cms_page/composer.json
@@ -8,6 +8,17 @@
         "drupal/acquia_cms_site_studio": "^1.0",
         "drupal/field_group": "^3"
     },
+    "config": {
+        "allow-plugins": {
+            "composer/installers": true,
+            "cweagans/composer-patches": true,
+            "dealerdirect/phpcodesniffer-composer-installer": true,
+            "drupal/core-composer-scaffold": true,
+            "ergebnis/composer-normalize": true,
+            "oomphinc/composer-installers-extender": true,
+            "phpro/grumphp-shim": true
+        }
+    },
     "repositories": {
         "drupal": {
             "type": "composer",
@@ -16,17 +27,6 @@
         "assets": {
             "type": "composer",
             "url": "https://asset-packagist.org"
-        }
-    },
-    "config": {
-        "allow-plugins": {
-            "dealerdirect/phpcodesniffer-composer-installer": true,
-            "composer/installers": true,
-            "cweagans/composer-patches": true,
-            "ergebnis/composer-normalize": true,
-            "drupal/core-composer-scaffold": true,
-            "phpro/grumphp-shim": true,
-            "oomphinc/composer-installers-extender": true
         }
     }
 }

--- a/modules/acquia_cms_person/composer.json
+++ b/modules/acquia_cms_person/composer.json
@@ -15,7 +15,8 @@
             "drupal/core-composer-scaffold": true,
             "ergebnis/composer-normalize": true,
             "oomphinc/composer-installers-extender": true,
-            "phpro/grumphp-shim": true
+            "phpro/grumphp-shim": true,
+            "webdriver-binary/binary-chromedriver": true
         }
     },
     "repositories": {

--- a/modules/acquia_cms_person/composer.json
+++ b/modules/acquia_cms_person/composer.json
@@ -16,5 +16,16 @@
             "type": "composer",
             "url": "https://asset-packagist.org"
         }
+    },
+    "config": {
+        "allow-plugins": {
+            "dealerdirect/phpcodesniffer-composer-installer": true,
+            "composer/installers": true,
+            "cweagans/composer-patches": true,
+            "ergebnis/composer-normalize": true,
+            "drupal/core-composer-scaffold": true,
+            "phpro/grumphp-shim": true,
+            "oomphinc/composer-installers-extender": true
+        }
     }
 }

--- a/modules/acquia_cms_person/composer.json
+++ b/modules/acquia_cms_person/composer.json
@@ -7,6 +7,17 @@
         "drupal/acquia_cms_place": "^1.0",
         "drupal/scheduler": "^1.3"
     },
+    "config": {
+        "allow-plugins": {
+            "composer/installers": true,
+            "cweagans/composer-patches": true,
+            "dealerdirect/phpcodesniffer-composer-installer": true,
+            "drupal/core-composer-scaffold": true,
+            "ergebnis/composer-normalize": true,
+            "oomphinc/composer-installers-extender": true,
+            "phpro/grumphp-shim": true
+        }
+    },
     "repositories": {
         "drupal": {
             "type": "composer",
@@ -15,17 +26,6 @@
         "assets": {
             "type": "composer",
             "url": "https://asset-packagist.org"
-        }
-    },
-    "config": {
-        "allow-plugins": {
-            "dealerdirect/phpcodesniffer-composer-installer": true,
-            "composer/installers": true,
-            "cweagans/composer-patches": true,
-            "ergebnis/composer-normalize": true,
-            "drupal/core-composer-scaffold": true,
-            "phpro/grumphp-shim": true,
-            "oomphinc/composer-installers-extender": true
         }
     }
 }

--- a/modules/acquia_cms_place/composer.json
+++ b/modules/acquia_cms_place/composer.json
@@ -12,6 +12,17 @@
         "drupal/scheduler": "^1.3",
         "geocoder-php/google-maps-provider": "^4.6"
     },
+    "config": {
+        "allow-plugins": {
+            "composer/installers": true,
+            "cweagans/composer-patches": true,
+            "dealerdirect/phpcodesniffer-composer-installer": true,
+            "drupal/core-composer-scaffold": true,
+            "ergebnis/composer-normalize": true,
+            "oomphinc/composer-installers-extender": true,
+            "phpro/grumphp-shim": true
+        }
+    },
     "extra": {
         "enable-patching": true,
         "patches": {
@@ -28,17 +39,6 @@
         "assets": {
             "type": "composer",
             "url": "https://asset-packagist.org"
-        }
-    },
-    "config": {
-        "allow-plugins": {
-            "dealerdirect/phpcodesniffer-composer-installer": true,
-            "composer/installers": true,
-            "cweagans/composer-patches": true,
-            "ergebnis/composer-normalize": true,
-            "drupal/core-composer-scaffold": true,
-            "phpro/grumphp-shim": true,
-            "oomphinc/composer-installers-extender": true
         }
     }
 }

--- a/modules/acquia_cms_place/composer.json
+++ b/modules/acquia_cms_place/composer.json
@@ -20,7 +20,8 @@
             "drupal/core-composer-scaffold": true,
             "ergebnis/composer-normalize": true,
             "oomphinc/composer-installers-extender": true,
-            "phpro/grumphp-shim": true
+            "phpro/grumphp-shim": true,
+            "webdriver-binary/binary-chromedriver": true
         }
     },
     "extra": {

--- a/modules/acquia_cms_place/composer.json
+++ b/modules/acquia_cms_place/composer.json
@@ -29,5 +29,16 @@
             "type": "composer",
             "url": "https://asset-packagist.org"
         }
+    },
+    "config": {
+        "allow-plugins": {
+            "dealerdirect/phpcodesniffer-composer-installer": true,
+            "composer/installers": true,
+            "cweagans/composer-patches": true,
+            "ergebnis/composer-normalize": true,
+            "drupal/core-composer-scaffold": true,
+            "phpro/grumphp-shim": true,
+            "oomphinc/composer-installers-extender": true
+        }
     }
 }

--- a/modules/acquia_cms_search/composer.json
+++ b/modules/acquia_cms_search/composer.json
@@ -20,7 +20,8 @@
             "drupal/core-composer-scaffold": true,
             "ergebnis/composer-normalize": true,
             "oomphinc/composer-installers-extender": true,
-            "phpro/grumphp-shim": true
+            "phpro/grumphp-shim": true,
+            "webdriver-binary/binary-chromedriver": true
         }
     },
     "extra": {

--- a/modules/acquia_cms_search/composer.json
+++ b/modules/acquia_cms_search/composer.json
@@ -32,5 +32,16 @@
             "type": "composer",
             "url": "https://asset-packagist.org"
         }
+    },
+    "config": {
+        "allow-plugins": {
+            "dealerdirect/phpcodesniffer-composer-installer": true,
+            "composer/installers": true,
+            "cweagans/composer-patches": true,
+            "ergebnis/composer-normalize": true,
+            "drupal/core-composer-scaffold": true,
+            "phpro/grumphp-shim": true,
+            "oomphinc/composer-installers-extender": true
+        }
     }
 }

--- a/modules/acquia_cms_search/composer.json
+++ b/modules/acquia_cms_search/composer.json
@@ -12,6 +12,17 @@
         "drupal/search_api": "1.22",
         "drupal/search_api_autocomplete": "^1.6"
     },
+    "config": {
+        "allow-plugins": {
+            "composer/installers": true,
+            "cweagans/composer-patches": true,
+            "dealerdirect/phpcodesniffer-composer-installer": true,
+            "drupal/core-composer-scaffold": true,
+            "ergebnis/composer-normalize": true,
+            "oomphinc/composer-installers-extender": true,
+            "phpro/grumphp-shim": true
+        }
+    },
     "extra": {
         "enable-patching": true,
         "patches": {
@@ -31,17 +42,6 @@
         "assets": {
             "type": "composer",
             "url": "https://asset-packagist.org"
-        }
-    },
-    "config": {
-        "allow-plugins": {
-            "dealerdirect/phpcodesniffer-composer-installer": true,
-            "composer/installers": true,
-            "cweagans/composer-patches": true,
-            "ergebnis/composer-normalize": true,
-            "drupal/core-composer-scaffold": true,
-            "phpro/grumphp-shim": true,
-            "oomphinc/composer-installers-extender": true
         }
     }
 }

--- a/modules/acquia_cms_site_studio/composer.json
+++ b/modules/acquia_cms_site_studio/composer.json
@@ -20,7 +20,8 @@
             "drupal/core-composer-scaffold": true,
             "ergebnis/composer-normalize": true,
             "oomphinc/composer-installers-extender": true,
-            "phpro/grumphp-shim": true
+            "phpro/grumphp-shim": true,
+            "webdriver-binary/binary-chromedriver": true
         }
     },
     "extra": {

--- a/modules/acquia_cms_site_studio/composer.json
+++ b/modules/acquia_cms_site_studio/composer.json
@@ -37,5 +37,16 @@
             "type": "composer",
             "url": "https://asset-packagist.org"
         }
+    },
+    "config": {
+        "allow-plugins": {
+            "dealerdirect/phpcodesniffer-composer-installer": true,
+            "composer/installers": true,
+            "cweagans/composer-patches": true,
+            "ergebnis/composer-normalize": true,
+            "drupal/core-composer-scaffold": true,
+            "phpro/grumphp-shim": true,
+            "oomphinc/composer-installers-extender": true
+        }
     }
 }

--- a/modules/acquia_cms_site_studio/composer.json
+++ b/modules/acquia_cms_site_studio/composer.json
@@ -12,6 +12,17 @@
         "drupal/config_rewrite": "^1.4",
         "drupal/node_revision_delete": "^1.0@RC"
     },
+    "config": {
+        "allow-plugins": {
+            "composer/installers": true,
+            "cweagans/composer-patches": true,
+            "dealerdirect/phpcodesniffer-composer-installer": true,
+            "drupal/core-composer-scaffold": true,
+            "ergebnis/composer-normalize": true,
+            "oomphinc/composer-installers-extender": true,
+            "phpro/grumphp-shim": true
+        }
+    },
     "extra": {
         "drush": {
             "services": {
@@ -36,17 +47,6 @@
         "assets": {
             "type": "composer",
             "url": "https://asset-packagist.org"
-        }
-    },
-    "config": {
-        "allow-plugins": {
-            "dealerdirect/phpcodesniffer-composer-installer": true,
-            "composer/installers": true,
-            "cweagans/composer-patches": true,
-            "ergebnis/composer-normalize": true,
-            "drupal/core-composer-scaffold": true,
-            "phpro/grumphp-shim": true,
-            "oomphinc/composer-installers-extender": true
         }
     }
 }

--- a/modules/acquia_cms_starter/composer.json
+++ b/modules/acquia_cms_starter/composer.json
@@ -20,7 +20,8 @@
             "drupal/core-composer-scaffold": true,
             "ergebnis/composer-normalize": true,
             "oomphinc/composer-installers-extender": true,
-            "phpro/grumphp-shim": true
+            "phpro/grumphp-shim": true,
+            "webdriver-binary/binary-chromedriver": true
         }
     }
 }

--- a/modules/acquia_cms_starter/composer.json
+++ b/modules/acquia_cms_starter/composer.json
@@ -11,5 +11,16 @@
         "drupal/config_rewrite": "^1.4",
         "drupal/default_content": "2.0.0-alpha1",
         "drupal/webform": "^6.0"
+    },
+    "config": {
+        "allow-plugins": {
+            "dealerdirect/phpcodesniffer-composer-installer": true,
+            "composer/installers": true,
+            "cweagans/composer-patches": true,
+            "ergebnis/composer-normalize": true,
+            "drupal/core-composer-scaffold": true,
+            "phpro/grumphp-shim": true,
+            "oomphinc/composer-installers-extender": true
+        }
     }
 }

--- a/modules/acquia_cms_starter/composer.json
+++ b/modules/acquia_cms_starter/composer.json
@@ -14,13 +14,13 @@
     },
     "config": {
         "allow-plugins": {
-            "dealerdirect/phpcodesniffer-composer-installer": true,
             "composer/installers": true,
             "cweagans/composer-patches": true,
-            "ergebnis/composer-normalize": true,
+            "dealerdirect/phpcodesniffer-composer-installer": true,
             "drupal/core-composer-scaffold": true,
-            "phpro/grumphp-shim": true,
-            "oomphinc/composer-installers-extender": true
+            "ergebnis/composer-normalize": true,
+            "oomphinc/composer-installers-extender": true,
+            "phpro/grumphp-shim": true
         }
     }
 }

--- a/modules/acquia_cms_support/composer.json
+++ b/modules/acquia_cms_support/composer.json
@@ -7,13 +7,13 @@
     },
     "config": {
         "allow-plugins": {
-            "dealerdirect/phpcodesniffer-composer-installer": true,
             "composer/installers": true,
             "cweagans/composer-patches": true,
-            "ergebnis/composer-normalize": true,
+            "dealerdirect/phpcodesniffer-composer-installer": true,
             "drupal/core-composer-scaffold": true,
-            "phpro/grumphp-shim": true,
-            "oomphinc/composer-installers-extender": true
+            "ergebnis/composer-normalize": true,
+            "oomphinc/composer-installers-extender": true,
+            "phpro/grumphp-shim": true
         }
     }
 }

--- a/modules/acquia_cms_support/composer.json
+++ b/modules/acquia_cms_support/composer.json
@@ -13,7 +13,8 @@
             "drupal/core-composer-scaffold": true,
             "ergebnis/composer-normalize": true,
             "oomphinc/composer-installers-extender": true,
-            "phpro/grumphp-shim": true
+            "phpro/grumphp-shim": true,
+            "webdriver-binary/binary-chromedriver": true
         }
     }
 }

--- a/modules/acquia_cms_support/composer.json
+++ b/modules/acquia_cms_support/composer.json
@@ -4,5 +4,16 @@
     "description": "Compare the config that ships with Acquia CMS with the active config on the site.",
     "require": {
         "drupal/acquia_cms_common": "^1.0"
+    },
+    "config": {
+        "allow-plugins": {
+            "dealerdirect/phpcodesniffer-composer-installer": true,
+            "composer/installers": true,
+            "cweagans/composer-patches": true,
+            "ergebnis/composer-normalize": true,
+            "drupal/core-composer-scaffold": true,
+            "phpro/grumphp-shim": true,
+            "oomphinc/composer-installers-extender": true
+        }
     }
 }

--- a/modules/acquia_cms_toolbar/composer.json
+++ b/modules/acquia_cms_toolbar/composer.json
@@ -15,7 +15,8 @@
             "drupal/core-composer-scaffold": true,
             "ergebnis/composer-normalize": true,
             "oomphinc/composer-installers-extender": true,
-            "phpro/grumphp-shim": true
+            "phpro/grumphp-shim": true,
+            "webdriver-binary/binary-chromedriver": true
         }
     },
     "repositories": {

--- a/modules/acquia_cms_toolbar/composer.json
+++ b/modules/acquia_cms_toolbar/composer.json
@@ -16,5 +16,16 @@
             "type": "composer",
             "url": "https://asset-packagist.org"
         }
+    },
+    "config": {
+        "allow-plugins": {
+            "dealerdirect/phpcodesniffer-composer-installer": true,
+            "composer/installers": true,
+            "cweagans/composer-patches": true,
+            "ergebnis/composer-normalize": true,
+            "drupal/core-composer-scaffold": true,
+            "phpro/grumphp-shim": true,
+            "oomphinc/composer-installers-extender": true
+        }
     }
 }

--- a/modules/acquia_cms_toolbar/composer.json
+++ b/modules/acquia_cms_toolbar/composer.json
@@ -7,6 +7,17 @@
         "drupal/acquia_cms_common": "^1.0",
         "drupal/admin_toolbar": "^3.0"
     },
+    "config": {
+        "allow-plugins": {
+            "composer/installers": true,
+            "cweagans/composer-patches": true,
+            "dealerdirect/phpcodesniffer-composer-installer": true,
+            "drupal/core-composer-scaffold": true,
+            "ergebnis/composer-normalize": true,
+            "oomphinc/composer-installers-extender": true,
+            "phpro/grumphp-shim": true
+        }
+    },
     "repositories": {
         "drupal": {
             "type": "composer",
@@ -15,17 +26,6 @@
         "assets": {
             "type": "composer",
             "url": "https://asset-packagist.org"
-        }
-    },
-    "config": {
-        "allow-plugins": {
-            "dealerdirect/phpcodesniffer-composer-installer": true,
-            "composer/installers": true,
-            "cweagans/composer-patches": true,
-            "ergebnis/composer-normalize": true,
-            "drupal/core-composer-scaffold": true,
-            "phpro/grumphp-shim": true,
-            "oomphinc/composer-installers-extender": true
         }
     }
 }

--- a/modules/acquia_cms_tour/composer.json
+++ b/modules/acquia_cms_tour/composer.json
@@ -7,13 +7,13 @@
     },
     "config": {
         "allow-plugins": {
-            "dealerdirect/phpcodesniffer-composer-installer": true,
             "composer/installers": true,
             "cweagans/composer-patches": true,
-            "ergebnis/composer-normalize": true,
+            "dealerdirect/phpcodesniffer-composer-installer": true,
             "drupal/core-composer-scaffold": true,
-            "phpro/grumphp-shim": true,
-            "oomphinc/composer-installers-extender": true
+            "ergebnis/composer-normalize": true,
+            "oomphinc/composer-installers-extender": true,
+            "phpro/grumphp-shim": true
         }
     }
 }

--- a/modules/acquia_cms_tour/composer.json
+++ b/modules/acquia_cms_tour/composer.json
@@ -4,5 +4,16 @@
     "description": "Provides a tour page for Acquia CMS.",
     "require": {
         "drupal/acquia_cms_common": "^1.0"
+    },
+    "config": {
+        "allow-plugins": {
+            "dealerdirect/phpcodesniffer-composer-installer": true,
+            "composer/installers": true,
+            "cweagans/composer-patches": true,
+            "ergebnis/composer-normalize": true,
+            "drupal/core-composer-scaffold": true,
+            "phpro/grumphp-shim": true,
+            "oomphinc/composer-installers-extender": true
+        }
     }
 }

--- a/modules/acquia_cms_tour/composer.json
+++ b/modules/acquia_cms_tour/composer.json
@@ -13,7 +13,8 @@
             "drupal/core-composer-scaffold": true,
             "ergebnis/composer-normalize": true,
             "oomphinc/composer-installers-extender": true,
-            "phpro/grumphp-shim": true
+            "phpro/grumphp-shim": true,
+            "webdriver-binary/binary-chromedriver": true
         }
     }
 }

--- a/modules/acquia_cms_video/composer.json
+++ b/modules/acquia_cms_video/composer.json
@@ -15,7 +15,8 @@
             "drupal/core-composer-scaffold": true,
             "ergebnis/composer-normalize": true,
             "oomphinc/composer-installers-extender": true,
-            "phpro/grumphp-shim": true
+            "phpro/grumphp-shim": true,
+            "webdriver-binary/binary-chromedriver": true
         }
     },
     "repositories": {

--- a/modules/acquia_cms_video/composer.json
+++ b/modules/acquia_cms_video/composer.json
@@ -7,6 +7,17 @@
         "drupal/acquia_cms_common": "^1.0",
         "drupal/field_group": "^3"
     },
+    "config": {
+        "allow-plugins": {
+            "composer/installers": true,
+            "cweagans/composer-patches": true,
+            "dealerdirect/phpcodesniffer-composer-installer": true,
+            "drupal/core-composer-scaffold": true,
+            "ergebnis/composer-normalize": true,
+            "oomphinc/composer-installers-extender": true,
+            "phpro/grumphp-shim": true
+        }
+    },
     "repositories": {
         "drupal": {
             "type": "composer",
@@ -15,17 +26,6 @@
         "assets": {
             "type": "composer",
             "url": "https://asset-packagist.org"
-        }
-    },
-    "config": {
-        "allow-plugins": {
-            "dealerdirect/phpcodesniffer-composer-installer": true,
-            "composer/installers": true,
-            "cweagans/composer-patches": true,
-            "ergebnis/composer-normalize": true,
-            "drupal/core-composer-scaffold": true,
-            "phpro/grumphp-shim": true,
-            "oomphinc/composer-installers-extender": true
         }
     }
 }

--- a/modules/acquia_cms_video/composer.json
+++ b/modules/acquia_cms_video/composer.json
@@ -16,5 +16,16 @@
             "type": "composer",
             "url": "https://asset-packagist.org"
         }
+    },
+    "config": {
+        "allow-plugins": {
+            "dealerdirect/phpcodesniffer-composer-installer": true,
+            "composer/installers": true,
+            "cweagans/composer-patches": true,
+            "ergebnis/composer-normalize": true,
+            "drupal/core-composer-scaffold": true,
+            "phpro/grumphp-shim": true,
+            "oomphinc/composer-installers-extender": true
+        }
     }
 }

--- a/tests/travis/install.sh
+++ b/tests/travis/install.sh
@@ -44,6 +44,10 @@ fi
 # Allow acquia_cms as allowed package dependencies, so that composer scaffolds acquia_cms files.
 composer config --json extra.drupal-scaffold.allowed-packages '["acquia/acquia_cms"]'
 
+# Allow third party plugins so that they are not blocked when CI jobs run by ORCA.
+composer config --no-plugins allow-plugins.dealerdirect/phpcodesniffer-composer-installer true;
+composer config --no-plugins allow-plugins.ergebnis/composer-normalize true;
+
 # Install dev dependencies.
 composer require --dev weitzman/drupal-test-traits phpspec/prophecy-phpunit:^2
 

--- a/themes/acquia_claro/composer.json
+++ b/themes/acquia_claro/composer.json
@@ -4,13 +4,13 @@
     "description": "A clean, accessible, and powerful Drupal administration theme.",
     "config": {
         "allow-plugins": {
-            "dealerdirect/phpcodesniffer-composer-installer": true,
             "composer/installers": true,
             "cweagans/composer-patches": true,
-            "ergebnis/composer-normalize": true,
+            "dealerdirect/phpcodesniffer-composer-installer": true,
             "drupal/core-composer-scaffold": true,
-            "phpro/grumphp-shim": true,
-            "oomphinc/composer-installers-extender": true
+            "ergebnis/composer-normalize": true,
+            "oomphinc/composer-installers-extender": true,
+            "phpro/grumphp-shim": true
         }
     }
 }

--- a/themes/acquia_claro/composer.json
+++ b/themes/acquia_claro/composer.json
@@ -1,5 +1,16 @@
 {
     "name": "drupal/acquia_claro",
     "type": "drupal-theme",
-    "description": "A clean, accessible, and powerful Drupal administration theme."
+    "description": "A clean, accessible, and powerful Drupal administration theme.",
+    "config": {
+        "allow-plugins": {
+            "dealerdirect/phpcodesniffer-composer-installer": true,
+            "composer/installers": true,
+            "cweagans/composer-patches": true,
+            "ergebnis/composer-normalize": true,
+            "drupal/core-composer-scaffold": true,
+            "phpro/grumphp-shim": true,
+            "oomphinc/composer-installers-extender": true
+        }
+    }
 }

--- a/themes/acquia_claro/composer.json
+++ b/themes/acquia_claro/composer.json
@@ -10,7 +10,8 @@
             "drupal/core-composer-scaffold": true,
             "ergebnis/composer-normalize": true,
             "oomphinc/composer-installers-extender": true,
-            "phpro/grumphp-shim": true
+            "phpro/grumphp-shim": true,
+            "webdriver-binary/binary-chromedriver": true
         }
     }
 }


### PR DESCRIPTION
**Motivation**
Fixes #[1060](https://backlog.acquia.com/browse/ACMS-1060)

**Proposed changes**
- Update composer to ^2.2
- add plugins in allowed section

**Alternatives considered**
NA

**Testing steps**
- update composer to ^2.2
- run composer install
- it should not be blocked by any plugins when running composer install

**Merge requirements**
- [ ] _Major change_, _Minor change_, _Bug_, _Enhancement_, and/or _Chore_ label applied
- [ ] Manual testing by a reviewer
