### PR TITLE
ACMS-1053: Acquia CMS Prevents Changing View Formats

### DIFF
--- a/modules/acquia_cms_article/acquia_cms_article.install
+++ b/modules/acquia_cms_article/acquia_cms_article.install
@@ -21,6 +21,13 @@ function acquia_cms_article_install() {
 }
 
 /**
+ * Implements hook_module_preinstall().
+ */
+function acquia_cms_article_module_preinstall($module) {
+  \Drupal::service('acquia_cms_common.utility')->setModulePreinstallTriggered($module);
+}
+
+/**
  * Implements hook_update_N().
  *
  * Forcefully import the Article Cards View configuration

--- a/modules/acquia_cms_common/src/EventSubscriber/ConfigEventsSubscriber.php
+++ b/modules/acquia_cms_common/src/EventSubscriber/ConfigEventsSubscriber.php
@@ -5,6 +5,7 @@ namespace Drupal\acquia_cms_common\EventSubscriber;
 use Drupal\Core\Config\ConfigCrudEvent;
 use Drupal\Core\Config\ConfigEvents;
 use Drupal\Core\Extension\ModuleHandlerInterface;
+use Drupal\Core\Installer\InstallerKernel;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
 /**
@@ -52,63 +53,67 @@ class ConfigEventsSubscriber implements EventSubscriberInterface {
    * @throws \Drupal\Core\Entity\EntityStorageException
    */
   public function configSave(ConfigCrudEvent $event) {
-    $config = $event->getConfig();
-    // Update views display_options's style type as cohesion_layout and
-    // option's views_template & master_template if acquia_cms_site_studio
-    // module is present else use default one.
-    if ($this->moduleHandler->moduleExists('acquia_cms_site_studio')) {
-      switch ($config->getName()) {
-        case 'views.view.event_cards':
-          _acquia_cms_common_update_view_display_options_style('event_cards', 'past_events_block', 'view_tpl_event_cards_slider');
-          _acquia_cms_common_update_view_display_options_style('event_cards', 'upcoming_events_block', 'view_tpl_event_cards_slider');
-          break;
+    $moduleInstallTriggered = \Drupal::service('acquia_cms_common.utility')->getModulePreinstallTriggered();
+    if (InstallerKernel::installationAttempted() || $moduleInstallTriggered) {
+      $config = $event->getConfig();
+      // During site install or module install Update views display_options's
+      // style type as cohesion_layout and option's views_template &
+      // master_template if acquia_cms_site_studio module is present
+      // otherwise use default one.
+      if ($this->moduleHandler->moduleExists('acquia_cms_site_studio')) {
+        switch ($config->getName()) {
+          case 'views.view.event_cards':
+            _acquia_cms_common_update_view_display_options_style('event_cards', 'past_events_block', 'view_tpl_event_cards_slider');
+            _acquia_cms_common_update_view_display_options_style('event_cards', 'upcoming_events_block', 'view_tpl_event_cards_slider');
+            break;
 
-        case 'views.view.article_cards':
-          _acquia_cms_common_update_view_display_options_style('article_cards', 'default', 'view_tpl_article_cards_slider');
-          break;
+          case 'views.view.article_cards':
+            _acquia_cms_common_update_view_display_options_style('article_cards', 'default', 'view_tpl_article_cards_slider');
+            break;
+        }
       }
-    }
-    if ($this->moduleHandler->moduleExists('acquia_cms_site_studio') && $this->moduleHandler->moduleExists('acquia_cms_search')) {
-      switch ($config->getName()) {
-        case 'views.view.articles':
-          _acquia_cms_common_update_view_display_options_style('articles');
-          break;
+      if ($this->moduleHandler->moduleExists('acquia_cms_site_studio') && $this->moduleHandler->moduleExists('acquia_cms_search')) {
+        switch ($config->getName()) {
+          case 'views.view.articles':
+            _acquia_cms_common_update_view_display_options_style('articles');
+            break;
 
-        case 'views.view.articles_fallback':
-          _acquia_cms_common_update_view_display_options_style('articles_fallback');
-          break;
+          case 'views.view.articles_fallback':
+            _acquia_cms_common_update_view_display_options_style('articles_fallback');
+            break;
 
-        case 'views.view.events':
-          _acquia_cms_common_update_view_display_options_style('events');
-          break;
+          case 'views.view.events':
+            _acquia_cms_common_update_view_display_options_style('events');
+            break;
 
-        case 'views.view.events_fallback':
-          _acquia_cms_common_update_view_display_options_style('events_fallback');
-          break;
+          case 'views.view.events_fallback':
+            _acquia_cms_common_update_view_display_options_style('events_fallback');
+            break;
 
-        case 'views.view.places':
-          _acquia_cms_common_update_view_display_options_style('places');
-          break;
+          case 'views.view.places':
+            _acquia_cms_common_update_view_display_options_style('places');
+            break;
 
-        case 'views.view.places_fallback':
-          _acquia_cms_common_update_view_display_options_style('places_fallback');
-          break;
+          case 'views.view.places_fallback':
+            _acquia_cms_common_update_view_display_options_style('places_fallback');
+            break;
 
-        case 'views.view.people':
-          _acquia_cms_common_update_view_display_options_style('people', 'default', 'view_tpl_people_grid');
-          break;
+          case 'views.view.people':
+            _acquia_cms_common_update_view_display_options_style('people', 'default', 'view_tpl_people_grid');
+            break;
 
-        case 'views.view.people_fallback':
-          _acquia_cms_common_update_view_display_options_style('people_fallback');
-          break;
+          case 'views.view.people_fallback':
+            _acquia_cms_common_update_view_display_options_style('people_fallback');
+            break;
 
-        case 'views.view.search':
-          _acquia_cms_common_update_view_display_options_style('search');
-          break;
+          case 'views.view.search':
+            _acquia_cms_common_update_view_display_options_style('search');
+            break;
 
-        case 'views.view.search_fallback':
-          _acquia_cms_common_update_view_display_options_style('search_fallback');
-          break;
+          case 'views.view.search_fallback':
+            _acquia_cms_common_update_view_display_options_style('search_fallback');
+            break;
+        }
       }
     }
   }

--- a/modules/acquia_cms_common/src/Services/AcmsUtilityService.php
+++ b/modules/acquia_cms_common/src/Services/AcmsUtilityService.php
@@ -26,6 +26,21 @@ class AcmsUtilityService {
   protected $configFactory;
 
   /**
+   * The module preinstall triggered status.
+   *
+   * @var string
+   *
+   * @see \Drupal\acquia_cms_common\Services\AcmsUtilityService::setModulePreinstallTriggered()
+   * @see acquia_cms_article_modules_installed()
+   * @see acquia_cms_event_modules_installed()
+   * @see acquia_cms_person_modules_installed()
+   * @see acquia_cms_place_modules_installed()
+   * @see acquia_cms_search_modules_installed()
+   */
+
+  private static $modulePreinstallTriggered;
+
+  /**
    * Constructs a new AcmsService object.
    *
    * @param \Drupal\Core\Extension\ModuleHandlerInterface $moduleHandler
@@ -168,6 +183,32 @@ class AcmsUtilityService {
     // Core can provide configuration.
     $enabled_extensions['core'] = 'core';
     return array_keys($enabled_extensions);
+  }
+
+  /**
+   * Set module preinstall triggered state variable.
+   *
+   * As service will be rebuild during the module install,
+   * set a private static variable is used to store this information.
+   *
+   * @param string $module
+   *   The module name.
+   */
+  public function setModulePreinstallTriggered(string $module) {
+    static::$modulePreinstallTriggered = $module;
+  }
+
+  /**
+   * Get module preinstall triggered state variable.
+   *
+   * @return string|null
+   *   The module name or null.
+   */
+  public function getModulePreinstallTriggered(): ?string {
+    if (static::$modulePreinstallTriggered !== NULL) {
+      return static::$modulePreinstallTriggered;
+    }
+    return NULL;
   }
 
 }

--- a/modules/acquia_cms_event/acquia_cms_event.install
+++ b/modules/acquia_cms_event/acquia_cms_event.install
@@ -21,6 +21,13 @@ function acquia_cms_event_install() {
 }
 
 /**
+ * Implements hook_module_preinstall().
+ */
+function acquia_cms_event_module_preinstall($module) {
+  \Drupal::service('acquia_cms_common.utility')->setModulePreinstallTriggered($module);
+}
+
+/**
  * Update past events views display & its title.
  */
 function acquia_cms_event_update_8001() {

--- a/modules/acquia_cms_person/acquia_cms_person.install
+++ b/modules/acquia_cms_person/acquia_cms_person.install
@@ -19,3 +19,10 @@ function acquia_cms_person_install() {
     'delete any person content',
   ]);
 }
+
+/**
+ * Implements hook_module_preinstall().
+ */
+function acquia_cms_person_module_preinstall($module) {
+  \Drupal::service('acquia_cms_common.utility')->setModulePreinstallTriggered($module);
+}

--- a/modules/acquia_cms_place/acquia_cms_place.install
+++ b/modules/acquia_cms_place/acquia_cms_place.install
@@ -19,3 +19,10 @@ function acquia_cms_place_install() {
     'delete any place content',
   ]);
 }
+
+/**
+ * Implements hook_module_preinstall().
+ */
+function acquia_cms_place_module_preinstall($module) {
+  \Drupal::service('acquia_cms_common.utility')->setModulePreinstallTriggered($module);
+}

--- a/modules/acquia_cms_search/acquia_cms_search.install
+++ b/modules/acquia_cms_search/acquia_cms_search.install
@@ -19,3 +19,10 @@ function acquia_cms_search_install() {
   $enabled_modules = array_keys($enabled_modules);
   acquia_cms_search_add_category_facet($enabled_modules);
 }
+
+/**
+ * Implements hook_module_preinstall().
+ */
+function acquia_cms_search_module_preinstall($module) {
+  \Drupal::service('acquia_cms_common.utility')->setModulePreinstallTriggered($module);
+}


### PR DESCRIPTION
**Motivation**
<!-- What problem does this solve? Why is it important? What's the context? If this fixes an issue, link to it above. -->
Fixes #[ACMS-1053](https://backlog.acquia.com/browse/ACMS-1053)

**Proposed changes**
<!-- What does this PR change? How does this impact end users? Are manual or automatic updates required? -->
Allow configuration to update on site installation and module installation only.

**Alternatives considered**
<!-- How else could the original issue / use case be addressed? Why did you choose this solution over any others? -->
NA

**Testing steps**
<!-- How can we replicate the issue and verify that this PR fixes it? -->

Check views settings with starter module
- Install site with acquia_cms and enable starter module
- Verify all pages like article, event, person, place and make sure all are align

Check views settings with installing/uninstalling content modules like article, event, person. place and search module
- Install site with acquia_cms
- Trying uninstalling/installing each modules 
- Verify views settings for corresponding modules and make  it has been updated correctly.

**Merge requirements**
- [_Bug_] _Major change_, _Minor change_, _Bug_, _Enhancement_, and/or _Chore_ label applied
- [ ] Manual testing by a reviewer
