### PR TITLE
ACMS 965: ACMS QA Environment is down

### DIFF
--- a/patches/d9-acms-settings.patch
+++ b/patches/d9-acms-settings.patch
@@ -24,9 +24,10 @@ if (AcquiaDrupalEnvironmentDetector::isAhEnv()) {
     $default_settings['default']['default'] = [
       'init_commands' => [
         'wait_timeout' => "SET SESSION wait_timeout=3600",
+        'interactive_timeout' => "SET SESSION interactive_timeout=3600"
       ],
     ];
-    $databases = array_merge_recursive($databases, $default_settings);
+    $databases = array_replace_recursive($databases, $default_settings);
     // Only call this function on the cloud, not on a local environment.
     if (function_exists('acquia_hosting_db_choose_active')) {
       acquia_hosting_db_choose_active();

--- a/patches/maintenance_theme.settings.patch
+++ b/patches/maintenance_theme.settings.patch
@@ -1,2 +1,0 @@
-// Setting to change the theme for maintenance page and update.php page.
-$settings['maintenance_theme'] = 'acquia_claro';

--- a/patches/maintenance_theme.settings.patch
+++ b/patches/maintenance_theme.settings.patch
@@ -1,0 +1,2 @@
+// Setting to change the theme for maintenance page and update.php page.
+$settings['maintenance_theme'] = 'acquia_claro';


### PR DESCRIPTION
**Motivation**
Fixes #[ACMS-965](https://backlog.acquia.com/browse/ACMS-965)

**Proposed changes**
QA environment should be up and running

**Alternatives considered**
NA

**Testing steps**
 - Visit http://orionacmsode1.prod.acquia-sites.com and verify application.

**Merge requirements**
- [ ] _Major change_, _Minor change_, _Bug_, _Enhancement_, and/or _Chore_ label applied
- [ ] Manual testing by a reviewer
