### PR TITLE
ACMS-1085: Update Drupal core to 9.3.7.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -37,7 +37,7 @@
         "drupal/component": "1.0-rc3",
         "drupal/config_ignore": "2.3.0",
         "drupal/config_rewrite": "^1.4",
-        "drupal/core": "~9.2.6 || ^9.3",
+        "drupal/core": "~9.2.6 || ~9.3.7",
         "drupal/default_content": "2.0.0-alpha1",
         "drupal/diff": "^1",
         "drupal/entity_clone": "1.0-beta6",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "98df2f518b0c84f68f20a8b90ae5c2f1",
+    "content-hash": "a942536b9fb362419b6a05fd878997e6",
     "packages": [
         {
             "name": "acquia/acsf-contenthub-console",
@@ -3550,16 +3550,16 @@
         },
         {
             "name": "drupal/core",
-            "version": "9.3.6",
+            "version": "9.3.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/drupal/core.git",
-                "reference": "2c0c89a0f49fab56f8322721888cdfa28fe98c3a"
+                "reference": "a768174b00fa088027d460a80a13550e624b9bf8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/drupal/core/zipball/2c0c89a0f49fab56f8322721888cdfa28fe98c3a",
-                "reference": "2c0c89a0f49fab56f8322721888cdfa28fe98c3a",
+                "url": "https://api.github.com/repos/drupal/core/zipball/a768174b00fa088027d460a80a13550e624b9bf8",
+                "reference": "a768174b00fa088027d460a80a13550e624b9bf8",
                 "shasum": ""
             },
             "require": {
@@ -3801,9 +3801,9 @@
             ],
             "description": "Drupal is an open source content management platform powering millions of websites and applications.",
             "support": {
-                "source": "https://github.com/drupal/core/tree/9.3.6"
+                "source": "https://github.com/drupal/core/tree/9.3.7"
             },
-            "time": "2022-02-15T20:26:28+00:00"
+            "time": "2022-03-03T09:23:53+00:00"
         },
         {
             "name": "drupal/crop",


### PR DESCRIPTION
**Motivation**
Upgrade Drupal core to 9.3.7

**Proposed changes**
Update composer.json & composer.lock file to get the latest Drupal core i.e v9.3.7

**Alternatives considered**
N/A.

**Testing steps**
Navigate to Status Report page and you should see Drupal core version as 9.3.7.

**Merge requirements**
- [ ] _Minor change_
- [ ] Manual testing by a reviewer
