### PR TITLE
ACMS-1094: Added conditions in twig file for role based button display.

### DIFF
--- a/modules/acquia_cms_tour/acquia_cms_tour.module
+++ b/modules/acquia_cms_tour/acquia_cms_tour.module
@@ -27,7 +27,9 @@ function acquia_cms_tour_menu_links_discovered_alter(array &$links) {
 function acquia_cms_tour_theme() {
   return [
     'acquia_cms_tour' => [
-      'variables' => [],
+      'variables' => [
+        'data' => [],
+      ],
     ],
     'acquia_cms_tour_checklist_form' => [
       'render element' => 'form',

--- a/modules/acquia_cms_tour/src/Controller/TourController.php
+++ b/modules/acquia_cms_tour/src/Controller/TourController.php
@@ -3,6 +3,8 @@
 namespace Drupal\acquia_cms_tour\Controller;
 
 use Drupal\Core\Controller\ControllerBase;
+use Drupal\Core\Session\AccountProxy;
+use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
  * Defines a route controller providing a simple tour of Acquia CMS.
@@ -15,15 +17,45 @@ use Drupal\Core\Controller\ControllerBase;
 final class TourController extends ControllerBase {
 
   /**
+   * Drupal\Core\Session\AccountProxy definition.
+   *
+   * @var \Drupal\Core\Session\AccountProxy
+   */
+  protected $currentUser;
+
+  /**
+   * {@inheritdoc}
+   */
+  public function __construct(AccountProxy $current_user) {
+    $this->currentUser = $current_user;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container) {
+    return new static(
+      $container->get('current_user')
+    );
+  }
+
+  /**
    * Returns a renderable array for a tour page.
    */
   public function build() {
+    $showButton = 0;
+    if ($this->currentUser->hasPermission('access acquia cms tour dashboard')) {
+      $showButton = 1;
+    }
     return [
       '#theme' => 'acquia_cms_tour',
       '#attached' => [
         'library' => [
           'acquia_cms_tour/acquia_cms_tour',
         ],
+      ],
+      '#data' => [
+        'showButton' => $showButton,
       ],
     ];
   }

--- a/modules/acquia_cms_tour/templates/acquia-cms-tour.html.twig
+++ b/modules/acquia_cms_tour/templates/acquia-cms-tour.html.twig
@@ -1,4 +1,3 @@
-{% set module_path = _self|split('/templates') %}
 <div class="tour-page">
   <div class="section-hero">
     <h2>Welcome to Acquia CMS</h2>
@@ -30,10 +29,12 @@
           Academy, our learning platform.
         </p>
       </div>
-      <div class="button-section">
-        <a class="button button--primary" href="/admin/tour/dashboard">Get started</a>
-        <p><strong>Click here to get started!</strong></p>
-      </div>
+      {% if data.showButton == 1 %}
+        <div class="button-section">
+          <a class="button button--primary" href="/admin/tour/dashboard">Get started</a>
+          <p><strong>Click here to get started!</strong></p>
+        </div>
+      {% endif %}
     </div>
   </div>
   <div class="layout-container section-content">

--- a/modules/acquia_cms_tour/tests/src/Functional/GetStartedButtonTest.php
+++ b/modules/acquia_cms_tour/tests/src/Functional/GetStartedButtonTest.php
@@ -1,0 +1,99 @@
+<?php
+
+namespace Drupal\Tests\acquia_cms_tour\Functional;
+
+use Drupal\Tests\BrowserTestBase;
+
+/**
+ * Tests the dasboard redirection button access.
+ *
+ * @group acquia_cms
+ * @group acquia_cms_tour
+ */
+class GetStartedButtonTest extends BrowserTestBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected $defaultTheme = 'stark';
+
+  /**
+   * {@inheritdoc}
+   */
+  protected static $modules = [
+    'acquia_cms_tour',
+  ];
+
+  /**
+   * Tests that specified roles have no access to the dashboard.
+   *
+   * @param string $role
+   *   The ID of the user role to test with.
+   *
+   * @dataProvider providerNoButtonAccess
+   */
+  public function testNoButtonAccess(string $role) {
+    $assert_session = $this->assertSession();
+
+    $account = $this->createUser();
+    $account->addRole($role);
+    $account->save();
+    $this->drupalLogin($account);
+
+    // Visit the admin tour page.
+    $this->drupalGet('/admin/tour');
+    $assert_session->statusCodeEquals(200);
+
+    $container = $assert_session->elementNotExists('css', '.button-section');
+  }
+
+  /**
+   * Tests that specified roles have access to the dashboard.
+   *
+   * @param string $role
+   *   The ID of the user role to test with.
+   *
+   * @dataProvider providerButtonAccess
+   */
+  public function testButtonAccess(string $role) {
+    $assert_session = $this->assertSession();
+
+    $account = $this->createUser();
+    $account->addRole($role);
+    $account->save();
+    $this->drupalLogin($account);
+
+    // Visit the admin tour page.
+    $this->drupalGet('/admin/tour');
+    $assert_session->statusCodeEquals(200);
+
+    $container = $assert_session->elementExists('css', '.button-section');
+  }
+
+  /**
+   * Data provider for ::testNoButtonAccess().
+   *
+   * @return array[]
+   *   Sets of arguments to pass to the test method.
+   */
+  public function providerNoButtonAccess() {
+    return [
+      ['content_author'],
+      ['content_editor'],
+    ];
+  }
+
+  /**
+   * Data provider for ::testButtonAccess().
+   *
+   * @return array[]
+   *   Sets of arguments to pass to the test method.
+   */
+  public function providerButtonAccess() {
+    return [
+      ['administrator'],
+      ['content_administrator'],
+    ];
+  }
+
+}


### PR DESCRIPTION
**Motivation**
* Added condition in twig file for role based button display.
Fixes #NNN

**Proposed changes**
* Added condition in twig file for role based button display.

**Alternatives considered**
* None

**Testing steps**
* Login as adminitrator, site builder or developer and notice that these roles have access to get started button.
* Login as other user roles apart from above and they don't have access to button.

**Merge requirements**
- [ ] _Major change_, _Minor change_, _Bug_, _Enhancement_, and/or _Chore_ label applied
- [ ] Manual testing by a reviewer
