### PR TITLE
ACMS-1114: Fixed all PHPCS errors & warnings.

### DIFF
--- a/grumphp.yml
+++ b/grumphp.yml
@@ -15,7 +15,7 @@ grumphp:
       max_subject_width: 0
     twigcs:
       path: 'themes'
-      ruleset: 'Allocine\Twigcs\Ruleset\Official'
+      ruleset: 'FriendsOfTwig\Twigcs\Ruleset\Official'
     phplint: ~
     yamllint: ~
     composer: ~

--- a/modules/acquia_cms_common/src/Services/AcmsUtilityService.php
+++ b/modules/acquia_cms_common/src/Services/AcmsUtilityService.php
@@ -103,7 +103,7 @@ class AcmsUtilityService {
   public function validateDependencies(string $config_name, array $data, array $enabled_extensions, array $all_config): bool {
     if (!isset($data['dependencies'])) {
       // Simple config or a config entity without dependencies.
-      list($provider) = explode('.', $config_name, 2);
+      [$provider] = explode('.', $config_name, 2);
       return in_array($provider, $enabled_extensions, TRUE);
     }
 
@@ -131,7 +131,7 @@ class AcmsUtilityService {
   protected function getMissingDependencies(string $config_name, array $data, array $enabled_extensions, array $all_config): array {
     $missing = [];
     if (isset($data['dependencies'])) {
-      list($provider) = explode('.', $config_name, 2);
+      [$provider] = explode('.', $config_name, 2);
       $all_dependencies = $data['dependencies'];
 
       // Ensure enforced dependencies are included.

--- a/modules/acquia_cms_image/acquia_cms_image.install
+++ b/modules/acquia_cms_image/acquia_cms_image.install
@@ -58,7 +58,7 @@ function acquia_cms_image_update_8001() {
   foreach ($image_styles as $image_style => $size) {
     $imageStyle = ImageStyle::load($image_style);
     if ($imageStyle instanceof ImageStyle) {
-      list ($width, $height) = $size;
+      [$width, $height] = $size;
       $imageStyle->addImageEffect([
         'id' => 'focal_point_scale_and_crop',
         'weight' => 1,

--- a/modules/acquia_cms_place/tests/src/Functional/PlaceTest.php
+++ b/modules/acquia_cms_place/tests/src/Functional/PlaceTest.php
@@ -191,7 +191,7 @@ class PlaceTest extends ContentTypeTestBase {
     $assert_session->addressEquals('/place/residential/living-video');
     // Confirm that the Latitude and Longitude fields are filled.
     $this->drupalGet('/node/5/edit');
-    list ($previous_lat, $previous_lon) = $this->getCoordinates();
+    [$previous_lat, $previous_lon] = $this->getCoordinates();
 
     // Change the ZIP code, which should cause the coordinates to change on
     // save.
@@ -199,7 +199,7 @@ class PlaceTest extends ContentTypeTestBase {
     $page->pressButton('Save');
 
     $this->drupalGet('/node/5/edit');
-    list ($new_lat, $new_lon) = $this->getCoordinates();
+    [$new_lat, $new_lon] = $this->getCoordinates();
     $page->pressButton('Save');
     // Assert that coordinates are updated after address change.
     $this->assertNotSame($previous_lat, $new_lat);

--- a/modules/acquia_cms_tour/tests/src/Functional/GetStartedButtonTest.php
+++ b/modules/acquia_cms_tour/tests/src/Functional/GetStartedButtonTest.php
@@ -44,7 +44,7 @@ class GetStartedButtonTest extends BrowserTestBase {
     $this->drupalGet('/admin/tour');
     $assert_session->statusCodeEquals(200);
 
-    $container = $assert_session->elementNotExists('css', '.button-section');
+    $assert_session->elementNotExists('css', '.button-section');
   }
 
   /**
@@ -67,7 +67,7 @@ class GetStartedButtonTest extends BrowserTestBase {
     $this->drupalGet('/admin/tour');
     $assert_session->statusCodeEquals(200);
 
-    $container = $assert_session->elementExists('css', '.button-section');
+    $assert_session->elementExists('css', '.button-section');
   }
 
   /**

--- a/tests/src/ExistingSite/LoginRedirectionTest.php
+++ b/tests/src/ExistingSite/LoginRedirectionTest.php
@@ -99,7 +99,7 @@ class LoginRedirectionTest extends ExistingSiteBase {
     $assert_session = $this->assertSession();
 
     foreach ($destination_map as $destination) {
-      list ($destination_parameter, $expected_destination_after_login) = str_replace('{uid}', $account->id(), $destination);
+      [$destination_parameter, $expected_destination_after_login] = str_replace('{uid}', $account->id(), $destination);
 
       $options = [];
       if ($destination_parameter) {


### PR DESCRIPTION
**Motivation**
Fixes all PHPCS errors/warnings which was appearing earlier.

**Proposed changes**
- Ran phpcbf command to automatically fix most of the errors/warnings.
- Fixed some PHPCS errors/warnings manually.
- Change the twigcs rulset from: `Allocine\Twigcs\Ruleset\Official` to `FriendsOfTwig\Twigcs\Ruleset\Official`

**Alternatives considered**
N/A

**Testing steps**
Run command i.e `./vendor/bin/grumphp run` and you shouldn't see any error/warning.

**Merge requirements**
- [ ] _Minor change_
- [ ] Manual testing by a reviewer
