### PR TITLE
ACMS-1089: 'Install Drupal' Cloud Action has an out of date version o…

### DIFF
--- a/create-tarball.sh
+++ b/create-tarball.sh
@@ -1,22 +1,24 @@
 #!/bin/bash
 
-ARCHIVE=acms-$1
+# Create tarball with acms version specific.
+if [ $1 ] ; then
+  ARCHIVE=acms-$1
+# Create tarball with latest version of acquia CMS
+else
+  ARCHIVE=acms
+fi
 
-composer create-project --stability beta --no-install drupal/legacy-project:~9.1.0 $ARCHIVE
+composer create-project --no-install acquia/acquia-cms-project $ARCHIVE
 composer dump-autoload
 composer configure-tarball $ARCHIVE
 
 cd $ARCHIVE
-composer config minimum-stability dev
-composer config prefer-stable true
-composer config repositories.assets composer https://asset-packagist.org
-
-composer config repositories.acms vcs git@github.com:acquia/acquia_cms.git
-composer require --no-update "ext-dom:*" "acquia/acquia_cms:$1" cweagans/composer-patches
+if [ $1 ] ; then
+  composer require --no-update "ext-dom:*" "acquia/acquia_cms:$1"
+else
+  composer require --no-update "ext-dom:*"
+fi
 composer update
-
-# Add the version number to the info file.
-echo "version: $1" >> ./profiles/contrib/acquia_cms/acquia_cms.info.yml
 
 # Wrap it all up in a nice compressed tarball.
 cd ..


### PR DESCRIPTION
…f ACMS

**Motivation**
<!-- What problem does this solve? Why is it important? What's the context? If this fixes an issue, link to it above. -->
Fixes #[ACMS-1098](https://backlog.acquia.com/browse/ACMS-1089)

**Proposed changes**
<!-- What does this PR change? How does this impact end users? Are manual or automatic updates required? -->
Update tarball creation script use latest project creation command

**Alternatives considered**
<!-- How else could the original issue / use case be addressed? Why did you choose this solution over any others? -->

**Testing steps**
<!-- How can we replicate the issue and verify that this PR fixes it? -->
Run tarball creation command without specifying acms version it will automatically create tarball with latest version of acquia_cms
` ./create-tarball.sh`
If you want to create tarball for specific version, then specify the version argument.
` ./create-tarball.sh 1.4.4`
Verify this tarball by running site install and make sure everything is working fine.

**Merge requirements**
- [ ] _Major change_, _Minor change_, _Bug_, _Enhancement_, and/or _Chore_ label applied
- [ ] Manual testing by a reviewer
