### PR TITLE
ACMS-1152: Making google analytics as last item in the wizard gives error

### DIFF
--- a/modules/acquia_cms_site_studio/src/Plugin/AcquiaCmsTour/SiteStudioCoreForm.php
+++ b/modules/acquia_cms_site_studio/src/Plugin/AcquiaCmsTour/SiteStudioCoreForm.php
@@ -130,6 +130,13 @@ class SiteStudioCoreForm extends AcquiaCMSDashboardBase {
   /**
    * {@inheritdoc}
    */
+  public function ignoreConfig(array &$form, FormStateInterface $form_state) {
+    $this->setConfigurationState();
+  }
+
+  /**
+   * {@inheritdoc}
+   */
   public function checkMinConfiguration() {
     $api_key = $this->config('cohesion.settings')->get('api_key');
     $agency_key = $this->config('cohesion.settings')->get('organization_key');

--- a/modules/acquia_cms_site_studio/src/Plugin/AcquiaCmsTour/SiteStudioCoreForm.php
+++ b/modules/acquia_cms_site_studio/src/Plugin/AcquiaCmsTour/SiteStudioCoreForm.php
@@ -130,13 +130,6 @@ class SiteStudioCoreForm extends AcquiaCMSDashboardBase {
   /**
    * {@inheritdoc}
    */
-  public function ignoreConfig(array &$form, FormStateInterface $form_state) {
-    $this->setConfigurationState();
-  }
-
-  /**
-   * {@inheritdoc}
-   */
   public function checkMinConfiguration() {
     $api_key = $this->config('cohesion.settings')->get('api_key');
     $agency_key = $this->config('cohesion.settings')->get('organization_key');

--- a/modules/acquia_cms_tour/src/Form/InstallationWizardForm.php
+++ b/modules/acquia_cms_tour/src/Form/InstallationWizardForm.php
@@ -271,15 +271,15 @@ class InstallationWizardForm extends FormBase {
    * Skip the current state and mark it as completed.
    */
   public function skipStepSubmit(array &$form, FormStateInterface $form_state) {
-    // Call ignoreConfig of corresponding form.
-    $formController = $this->getCurrentFormController()['class'];
-    $this->classResolver->getInstanceFromDefinition($formController)->ignoreConfig($form, $form_state);
 
     // Call default submitForm in case of last step.
     if ($this->isCurrentStepLast()) {
       $this->submitForm($form, $form_state);
     }
     else {
+      // Call ignoreConfig of corresponding form.
+      $formController = $this->getCurrentFormController()['class'];
+      $this->classResolver->getInstanceFromDefinition($formController)->ignoreConfig($form, $form_state);
       $this->currentStep += 1;
       $this->state->set('current_wizard_step', $this->currentStep);
       $form_state->setRebuild(TRUE);

--- a/modules/acquia_cms_tour/src/Form/InstallationWizardForm.php
+++ b/modules/acquia_cms_tour/src/Form/InstallationWizardForm.php
@@ -271,15 +271,15 @@ class InstallationWizardForm extends FormBase {
    * Skip the current state and mark it as completed.
    */
   public function skipStepSubmit(array &$form, FormStateInterface $form_state) {
+    // Call ignoreConfig of corresponding form.
+    $formController = $this->getCurrentFormController()['class'];
+    $this->classResolver->getInstanceFromDefinition($formController)->ignoreConfig($form, $form_state);
+
     // Call default submitForm in case of last step.
     if ($this->isCurrentStepLast()) {
       $this->submitForm($form, $form_state);
     }
     else {
-      // Call ignoreConfig of corresponding form.
-      $formController = $this->getCurrentFormController()['class'];
-      $this->classResolver->getInstanceFromDefinition($formController)->ignoreConfig($form, $form_state);
-
       $this->currentStep += 1;
       $this->state->set('current_wizard_step', $this->currentStep);
       $form_state->setRebuild(TRUE);

--- a/modules/acquia_cms_tour/src/Plugin/AcquiaCmsTour/GoogleAnalyticsForm.php
+++ b/modules/acquia_cms_tour/src/Plugin/AcquiaCmsTour/GoogleAnalyticsForm.php
@@ -112,10 +112,11 @@ class GoogleAnalyticsForm extends AcquiaCMSDashboardBase {
    */
   public function submitForm(array &$form, FormStateInterface $form_state) {
     $property_id = $form_state->getValue(['web_property_id']);
-    $this->config('google_analytics.settings')->set('account', $property_id)->save();
-    $this->state->set('google_analytics_progress', TRUE);
-    $this->messenger()->addStatus('The configuration options have been saved.');
-
+    if ($property_id) {
+      $this->config('google_analytics.settings')->set('account', $property_id)->save();
+      $this->state->set('google_analytics_progress', TRUE);
+      $this->messenger()->addStatus('The configuration options have been saved.');
+    }
     // Update state.
     $this->setConfigurationState();
   }


### PR DESCRIPTION

**Motivation**
Fixes #[ACMS-1152](https://backlog.acquia.com/browse/ACMS-1152)

**Proposed changes**
Fix application down error when google analytics is the last item in the tour wizard.

**Alternatives considered**
NA

**Testing steps**

- Install Vanilla Drupal application with:
    - google_analytics
    - acquia_cms_tour
- enable both modules listed above
- Head towards /admin/tour/dashboard
- Click on Wizard set-up
- You should see pop-up with Google Analytics config form
- Click on Skip this step
- You should see the status message(The configuration options have been saved.) and application should not be down 


**Merge requirements**
- [ ] _Major change_, _Minor change_, _Bug_, _Enhancement_, and/or _Chore_ label applied
- [ ] Manual testing by a reviewer
