### PR TITLE
Remove references to Cog

### DIFF
--- a/tests/packages_alter.yml
+++ b/tests/packages_alter.yml
@@ -2,9 +2,6 @@ acquia/acquia_cms:
   type: drupal-profile
   version_dev: 1.x-dev
 
-# Cog has a composer bug as of 3/16.
-drupal/cog: ~
-
 # Do not install Lightning modules explicitly excluded by ACMS.
 drupal/lightning_layout: ~
 drupal/lightning_page: ~


### PR DESCRIPTION
**Motivation**

Cog has been dead and unmaintained for a while (possibly years). It was removed from ORCA last year, so there's no need to remove it yourself via packages_alter: https://github.com/acquia/orca/pull/168

**Proposed changes**
<!-- What does this PR change? How does this impact end users? Are manual or automatic updates required? -->

Remove Cog from packages_alter

**Merge requirements**
- [ ] _Major change_, _Minor change_, _Bug_, _Enhancement_, and/or _Chore_ label applied
- [ ] Manual testing by a reviewer
