### PR TITLE
ACMS-1183: Site install with existing configuration gives error

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -47,7 +47,7 @@
         "drupal/focal_point": "1.5",
         "drupal/geocoder": "3.25",
         "drupal/geofield": "^1",
-        "drupal/google_analytics": "^4.0",
+        "drupal/google_analytics": "4.0.0",
         "drupal/google_tag": "^1.5",
         "drupal/honeypot": "^2.0",
         "drupal/imagemagick": "^3",
@@ -196,6 +196,9 @@
             },
             "drupal/geocoder": {
                 "3224364 - Replace deprecated boolean return in uksort() for PHP 8 compatibility.": "https://www.drupal.org/files/issues/2021-07-19/3224364-2.patch"
+            },
+            "drupal/google_analytics": {
+                "3246597 - Add dependency on drupal:path_alias": "https://www.drupal.org/files/issues/2021-11-25/google_analytics-3246597-7.patch"
             },
             "drupal/search_api": {
                 "3236696 - Call to a member function preExecute() on null in SearchApiTagCache->alterCacheMetadata()": "https://www.drupal.org/files/issues/2021-09-20/search_api_condition_cacheable_metadata.patch"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "1fe1307a55578f48765e347192d6c9f6",
+    "content-hash": "5a793ab035048c300965ed7ac5773759",
     "packages": [
         {
             "name": "acquia/acsf-contenthub-console",
@@ -267,7 +267,7 @@
             "homepage": "https://github.com/acquia/content-hub-php",
             "support": {
                 "issues": "https://github.com/acquia/content-hub-php/issues",
-                "source": "https://github.com/acquia/content-hub-php/tree/2.x"
+                "source": "https://github.com/acquia/content-hub-php/tree/2.1.2"
             },
             "time": "2022-03-24T09:08:45+00:00"
         },
@@ -2132,8 +2132,8 @@
                     "dev-8.x-2.x": "2.x-dev"
                 },
                 "drupal": {
-                    "version": "8.x-2.31+4-dev",
-                    "datestamp": "1648632420",
+                    "version": "8.x-2.32+1-dev",
+                    "datestamp": "1652167270",
                     "security-coverage": {
                         "status": "not-covered",
                         "message": "Dev releases are not covered by Drupal security advisories."
@@ -3896,8 +3896,8 @@
                     "dev-8.x-1.x": "1.x-dev"
                 },
                 "drupal": {
-                    "version": "8.x-1.10+1-dev",
-                    "datestamp": "1646918719",
+                    "version": "8.x-1.11+1-dev",
+                    "datestamp": "1651738896",
                     "security-coverage": {
                         "status": "not-covered",
                         "message": "Dev releases are not covered by Drupal security advisories."
@@ -3920,6 +3920,10 @@
                 {
                     "name": "amangrover90",
                     "homepage": "https://www.drupal.org/user/3602433"
+                },
+                {
+                    "name": "amarlata",
+                    "homepage": "https://www.drupal.org/user/3504572"
                 },
                 {
                     "name": "jmoreira",
@@ -4806,7 +4810,7 @@
             "extra": {
                 "drupal": {
                     "version": "2.0.2",
-                    "datestamp": "1638391833",
+                    "datestamp": "1651895165",
                     "security-coverage": {
                         "status": "covered",
                         "message": "Covered by Drupal's security advisory policy"
@@ -5020,6 +5024,10 @@
                 {
                     "name": "RobLoach",
                     "homepage": "https://www.drupal.org/user/61114"
+                },
+                {
+                    "name": "bnjmnm",
+                    "homepage": "https://www.drupal.org/user/2369194"
                 },
                 {
                     "name": "jjeff",


### PR DESCRIPTION
**Motivation**
Fixes #[ACMS-1183](https://backlog.acquia.com/browse/ACMS-1183)

**Proposed changes**
Add patch in root composer.json file for google_analytics.

**Alternatives considered**
NA

**Testing steps**
- Install acquia_cms
  - `composer create-project acquia/drupal-recommended-project`
  - `cd /drupal-recommended-project`
  - `composer acms:install`
  - `drush cex`
- Export configs
  - `drush cex`
- Install acquia_cms using existing config
  - `drush site:install --account-pass admin --existing-config`
- Site should install without any error

**Merge requirements**
- [ ] _Major change_, _Minor change_, _Bug_, _Enhancement_, and/or _Chore_ label applied
- [ ] Manual testing by a reviewer
