### PR TITLE
ACMS-1190: Decouple Acquia CMS Page module.

### DIFF
--- a/acquia_cms.info.yml
+++ b/acquia_cms.info.yml
@@ -14,6 +14,7 @@ install:
   - acquia_cms_event
   - acquia_cms_page
   - acquia_cms_search
+  - acquia_cms_site_studio
   - acquia_cms_toolbar
   - acquia_cms_tour
   - acquia_cms_video
@@ -21,9 +22,9 @@ install:
   - address
   - admin_toolbar_tools
   - captcha
-  - config_ignore
   - collapsiblock
   - config
+  - config_ignore
   - config_translation
   - content_translation
   - datetime


### PR DESCRIPTION
**Motivation**
<!-- What problem does this solve? Why is it important? What's the context? If this fixes an issue, link to it above. -->
Fixes #[ACMS-1190](https://backlog.acquia.com/browse/ACMS-1190)

**Proposed changes**
<!-- What does this PR change? How does this impact end users? Are manual or automatic updates required? -->

- When Downloading Acquia CMS page module, it shouldn't download Acquia CMS Site Studio module.
- User should be able to install & enable module Acquia CMS page without enabling Acquia CMS Site Studio module.
- When Acquia CMS page module is installed user should see the new content type i.e page.
- Following should happen when Acquia CMS Site Studio module is not installed, when enabling Acquia CMS Page module:
  - User shouldn't see layout canvas field on Page content type.
  - The Search Description field should be labelled as Body.

- Following should happen when Acquia CMS Site Studio module is already enabled, when enabling Acquia CMS Page module:
  - User should see layout canvas field on page content type.
  - The Body field label should be reverted back to Search Description.

**Alternatives considered**
<!-- How else could the original issue / use case be addressed? Why did you choose this solution over any others? -->

**Testing steps**
<!-- How can we replicate the issue and verify that this PR fixes it? -->

**Merge requirements**
- [ ] _Major change_, _Minor change_, _Bug_, _Enhancement_, and/or _Chore_ label applied
- [ ] Manual testing by a reviewer
