### PR TITLE
ACMS-1332: Updated the config pauthauto pattern files and added update hooks

### DIFF
--- a/modules/acquia_cms_article/acquia_cms_article.install
+++ b/modules/acquia_cms_article/acquia_cms_article.install
@@ -50,3 +50,26 @@ function acquia_cms_article_update_8002() {
     $field->save();
   }
 }
+
+/**
+ * Implements hook_update_N().
+ *
+ * Update node type conditions from node_type to entity_bundle.
+ */
+function acquia_cms_article_update_8003() {
+  // Load all pattern configuration entities.
+  $pattern_config = \Drupal::configFactory()->getEditable('pathauto.pattern.article');
+
+  // Loop patterns and swap the node_type plugin by the entity_bundle:node
+  // plugin.
+  if ($pattern_config->get('type') === 'canonical_entities:node') {
+    $selection_criteria = $pattern_config->get('selection_criteria');
+    foreach ($selection_criteria as $uuid => $condition) {
+      if ($condition['id'] === 'node_type') {
+        $pattern_config->set("selection_criteria.$uuid.id", 'entity_bundle:node');
+        $pattern_config->save();
+        break;
+      }
+    }
+  }
+}

--- a/modules/acquia_cms_article/config/optional/pathauto.pattern.article.yml
+++ b/modules/acquia_cms_article/config/optional/pathauto.pattern.article.yml
@@ -9,13 +9,13 @@ type: 'canonical_entities:node'
 pattern: 'article/[node:field_article_type]/[node:title]'
 selection_criteria:
   96d501c7-103e-4c5c-943b-2f91d8125aff:
-    id: node_type
-    bundles:
-      article: article
+    id: 'entity_bundle:node'
     negate: false
+    uuid: 96d501c7-103e-4c5c-943b-2f91d8125aff
     context_mapping:
       node: node
-    uuid: 96d501c7-103e-4c5c-943b-2f91d8125aff
+    bundles:
+      article: article
 selection_logic: and
 weight: -5
 relationships: {  }

--- a/modules/acquia_cms_event/acquia_cms_event.install
+++ b/modules/acquia_cms_event/acquia_cms_event.install
@@ -38,3 +38,26 @@ function acquia_cms_event_update_8001() {
       ->set('display.past_events_block.display_options.title', '')->save();
   }
 }
+
+/**
+ * Implements hook_update_N().
+ *
+ * Update node type conditions from node_type to entity_bundle.
+ */
+function acquia_cms_event_update_8002() {
+  // Load all pattern configuration entities.
+  $pattern_config = \Drupal::configFactory()->getEditable('pathauto.pattern.event');
+
+  // Loop patterns and swap the node_type plugin by the entity_bundle:node
+  // plugin.
+  if ($pattern_config->get('type') === 'canonical_entities:node') {
+    $selection_criteria = $pattern_config->get('selection_criteria');
+    foreach ($selection_criteria as $uuid => $condition) {
+      if ($condition['id'] === 'node_type') {
+        $pattern_config->set("selection_criteria.$uuid.id", 'entity_bundle:node');
+        $pattern_config->save();
+        break;
+      }
+    }
+  }
+}

--- a/modules/acquia_cms_event/config/optional/pathauto.pattern.event_path.yml
+++ b/modules/acquia_cms_event/config/optional/pathauto.pattern.event_path.yml
@@ -9,13 +9,13 @@ type: 'canonical_entities:node'
 pattern: 'event/[node:field_event_type]/[node:field_event_start:date:custom:Y]/[node:field_event_start:date:custom:m]/[node:title]'
 selection_criteria:
   02726a68-6063-4416-8fb1-0e32a4f82593:
-    id: node_type
-    bundles:
-      event: event
+    id: 'entity_bundle:node'
     negate: false
+    uuid: 02726a68-6063-4416-8fb1-0e32a4f82593
     context_mapping:
       node: node
-    uuid: 02726a68-6063-4416-8fb1-0e32a4f82593
+    bundles:
+      event: event
 selection_logic: and
 weight: -5
 relationships: {  }

--- a/modules/acquia_cms_page/acquia_cms_page.install
+++ b/modules/acquia_cms_page/acquia_cms_page.install
@@ -37,3 +37,26 @@ function acquia_cms_page_modules_installed(array $module) {
     \Drupal::service('module_installer')->install(['acquia_cms_page_content']);
   }
 }
+
+/**
+ * Implements hook_update_N().
+ *
+ * Update node type conditions from node_type to entity_bundle.
+ */
+function acquia_cms_page_update_8001() {
+  // Load all pattern configuration entities.
+  $pattern_config = \Drupal::configFactory()->getEditable('pathauto.pattern.page');
+
+  // Loop patterns and swap the node_type plugin by the entity_bundle:node
+  // plugin.
+  if ($pattern_config->get('type') === 'canonical_entities:node') {
+    $selection_criteria = $pattern_config->get('selection_criteria');
+    foreach ($selection_criteria as $uuid => $condition) {
+      if ($condition['id'] === 'node_type') {
+        $pattern_config->set("selection_criteria.$uuid.id", 'entity_bundle:node');
+        $pattern_config->save();
+        break;
+      }
+    }
+  }
+}

--- a/modules/acquia_cms_page/config/optional/pathauto.pattern.page.yml
+++ b/modules/acquia_cms_page/config/optional/pathauto.pattern.page.yml
@@ -9,13 +9,13 @@ type: "canonical_entities:node"
 pattern: "[node:title]"
 selection_criteria:
   f857cec1-a605-4339-ade9-00dc7145597c:
-    id: node_type
-    bundles:
-      page: page
+    id: 'entity_bundle:node'
     negate: false
+    uuid: f857cec1-a605-4339-ade9-00dc7145597c
     context_mapping:
       node: node
-    uuid: f857cec1-a605-4339-ade9-00dc7145597c
+    bundles:
+      page: page
 selection_logic: and
 weight: -5
 relationships: {}

--- a/modules/acquia_cms_person/acquia_cms_person.install
+++ b/modules/acquia_cms_person/acquia_cms_person.install
@@ -26,3 +26,26 @@ function acquia_cms_person_install() {
 function acquia_cms_person_module_preinstall($module) {
   \Drupal::service('acquia_cms_common.utility')->setModulePreinstallTriggered($module);
 }
+
+/**
+ * Implements hook_update_N().
+ *
+ * Update node type conditions from node_type to entity_bundle.
+ */
+function acquia_cms_person_update_8001() {
+  // Load all pattern configuration entities.
+  $pattern_config = \Drupal::configFactory()->getEditable('pathauto.pattern.person');
+
+  // Loop patterns and swap the node_type plugin by the entity_bundle:node
+  // plugin.
+  if ($pattern_config->get('type') === 'canonical_entities:node') {
+    $selection_criteria = $pattern_config->get('selection_criteria');
+    foreach ($selection_criteria as $uuid => $condition) {
+      if ($condition['id'] === 'node_type') {
+        $pattern_config->set("selection_criteria.$uuid.id", 'entity_bundle:node');
+        $pattern_config->save();
+        break;
+      }
+    }
+  }
+}

--- a/modules/acquia_cms_person/config/optional/pathauto.pattern.person.yml
+++ b/modules/acquia_cms_person/config/optional/pathauto.pattern.person.yml
@@ -9,13 +9,13 @@ type: 'canonical_entities:node'
 pattern: 'person/[node:field_person_type]/[node:title]'
 selection_criteria:
   c97ba0fc-5cd3-46f1-be0e-c8e165db8962:
-    id: node_type
-    bundles:
-      person: person
+    id: 'entity_bundle:node'
     negate: false
+    uuid: c97ba0fc-5cd3-46f1-be0e-c8e165db8962
     context_mapping:
       node: node
-    uuid: c97ba0fc-5cd3-46f1-be0e-c8e165db8962
+    bundles:
+      person: person
 selection_logic: and
 weight: -5
 relationships: {  }

--- a/modules/acquia_cms_place/acquia_cms_place.install
+++ b/modules/acquia_cms_place/acquia_cms_place.install
@@ -26,3 +26,26 @@ function acquia_cms_place_install() {
 function acquia_cms_place_module_preinstall($module) {
   \Drupal::service('acquia_cms_common.utility')->setModulePreinstallTriggered($module);
 }
+
+/**
+ * Implements hook_update_N().
+ *
+ * Update node type conditions from node_type to entity_bundle.
+ */
+function acquia_cms_place_update_8001() {
+  // Load all pattern configuration entities.
+  $pattern_config = \Drupal::configFactory()->getEditable('pathauto.pattern.place');
+
+  // Loop patterns and swap the node_type plugin by the entity_bundle:node
+  // plugin.
+  if ($pattern_config->get('type') === 'canonical_entities:node') {
+    $selection_criteria = $pattern_config->get('selection_criteria');
+    foreach ($selection_criteria as $uuid => $condition) {
+      if ($condition['id'] === 'node_type') {
+        $pattern_config->set("selection_criteria.$uuid.id", 'entity_bundle:node');
+        $pattern_config->save();
+        break;
+      }
+    }
+  }
+}

--- a/modules/acquia_cms_place/config/optional/pathauto.pattern.place_path.yml
+++ b/modules/acquia_cms_place/config/optional/pathauto.pattern.place_path.yml
@@ -9,13 +9,13 @@ type: 'canonical_entities:node'
 pattern: 'place/[node:field_place_type]/[node:title]'
 selection_criteria:
   fd66c02c-c164-41be-b4a1-68a7ebc56056:
-    id: node_type
-    bundles:
-      place: place
+    id: 'entity_bundle:node'
     negate: false
+    uuid: fd66c02c-c164-41be-b4a1-68a7ebc56056
     context_mapping:
       node: node
-    uuid: fd66c02c-c164-41be-b4a1-68a7ebc56056
+    bundles:
+      place: place
 selection_logic: and
 weight: -5
 relationships: {  }

--- a/tests/travis/install.sh
+++ b/tests/travis/install.sh
@@ -71,15 +71,6 @@ if [[ "$ACMS_JOB" == "base" ]] && [[ -n "$ACMS_DB_ARTIFACT" ]] && [[ -n "$ACMS_F
   drush sqlq 'UPDATE `config` SET `data` = replace(data, "s:10:\"acquia_cms\"", "s:7:\"minimal\"") where name="core.extension";'
   drush cr
 
-  # Workaround added to fix error: `The  context is not a valid context`.
-  # @todo Remove below code after ACMS-1332 is completed.
-  drush "php:eval" "module_load_include('install', 'pathauto', 'pathauto'); pathauto_update_8108();"
-  drush cget pathauto.pattern.article | sed '/^uuid: /d' | sed '/_core:/,+1d' | sed '$ d' > docroot/modules/contrib/acquia_cms/modules/acquia_cms_article/config/optional/pathauto.pattern.article.yml
-  drush cget pathauto.pattern.event_path | sed '/^uuid: /d' | sed '/_core:/,+1d' | sed '$ d' > docroot/modules/contrib/acquia_cms/modules/acquia_cms_event/config/optional/pathauto.pattern.event_path.yml
-  drush cget pathauto.pattern.place_path | sed '/^uuid: /d' | sed '/_core:/,+1d' | sed '$ d' > docroot/modules/contrib/acquia_cms/modules/acquia_cms_place/config/optional/pathauto.pattern.place_path.yml
-  drush cget pathauto.pattern.person | sed '/^uuid: /d' | sed '/_core:/,+1d' | sed '$ d' > docroot/modules/contrib/acquia_cms/modules/acquia_cms_person/config/optional/pathauto.pattern.person.yml
-  drush cget pathauto.pattern.page | sed '/^uuid: /d' | sed '/_core:/,+1d' | sed '$ d' > docroot/modules/contrib/acquia_cms/modules/acquia_cms_page/config/optional/pathauto.pattern.page.yml
-
   drush updatedb --cache-clear --yes -vvv
   drush cr
 fi
@@ -95,16 +86,7 @@ if [[ "$ACMS_JOB" == "starter" ]] && [[ -n "$ACMS_STARTER_DB_ARTIFACT" ]] && [[ 
   # @todo Remove this after we update tests artifacts, which is created based on release 2.0.x.
   drush sqlq 'UPDATE `config` SET `data` = replace(data, "s:10:\"acquia_cms\"", "s:7:\"minimal\"") where name="core.extension";'
   drush cr
-
-  # Workaround added to fix error: `The  context is not a valid context`.
-  # @todo Remove below code after ACMS-1332 is completed.
-  drush "php:eval" "module_load_include('install', 'pathauto', 'pathauto'); pathauto_update_8108();"
-  drush cget pathauto.pattern.article | sed '/^uuid: /d' | sed '/_core:/,+1d' | sed '$ d' > docroot/modules/contrib/acquia_cms/modules/acquia_cms_article/config/optional/pathauto.pattern.article.yml
-  drush cget pathauto.pattern.event_path | sed '/^uuid: /d' | sed '/_core:/,+1d' | sed '$ d' > docroot/modules/contrib/acquia_cms/modules/acquia_cms_event/config/optional/pathauto.pattern.event_path.yml
-  drush cget pathauto.pattern.place_path | sed '/^uuid: /d' | sed '/_core:/,+1d' | sed '$ d' > docroot/modules/contrib/acquia_cms/modules/acquia_cms_place/config/optional/pathauto.pattern.place_path.yml
-  drush cget pathauto.pattern.person | sed '/^uuid: /d' | sed '/_core:/,+1d' | sed '$ d' > docroot/modules/contrib/acquia_cms/modules/acquia_cms_person/config/optional/pathauto.pattern.person.yml
-  drush cget pathauto.pattern.page | sed '/^uuid: /d' | sed '/_core:/,+1d' | sed '$ d' > docroot/modules/contrib/acquia_cms/modules/acquia_cms_page/config/optional/pathauto.pattern.page.yml
-
+  
   drush updatedb --cache-clear --yes -vvv
 fi
 


### PR DESCRIPTION
**Motivation**
* The site installation is breaking due to pathauto config containing the "node" deprecated bundle.
Fixes #NNN

**Proposed changes**
* Remove deprecated "node" bundle, update the config file.
* Added update hook for the same.

**Alternatives considered**
* None

**Testing steps**
* Switch to branch ACMS-1332 on local and run command - "./bin/acms acms:install"
* Notice that installation completes without any issues.

**Testing Screenshots**
<img width="1524" alt="Screenshot 2022-08-01 at 4 19 06 PM" src="https://user-images.githubusercontent.com/15887127/182135516-cb63a41d-aa0a-44fe-89f7-64710215ed52.png">
<img width="774" alt="Screenshot 2022-08-01 at 4 19 20 PM" src="https://user-images.githubusercontent.com/15887127/182135522-566943ef-8476-473e-8aef-d5373a62235a.png">

**Merge requirements**
- [ ] _Major change_, _Minor change_, _Bug_, _Enhancement_, and/or _Chore_ label applied
- [ ] Manual testing by a reviewer
