### PR TITLE
ACMS-1328: Fixed warning errors for acquia cms headless module

### DIFF
--- a/modules/acquia_cms_headless/modules/acquia_cms_headless_ui/acquia_cms_headless_ui.module
+++ b/modules/acquia_cms_headless/modules/acquia_cms_headless_ui/acquia_cms_headless_ui.module
@@ -307,7 +307,7 @@ function acquia_cms_headless_ui_menu_links_discovered_alter(array &$links) {
     if (in_array($name, $bypass)) {
       continue;
     }
-    if ($link['parent'] == 'system.admin') {
+    if (isset($link['parent']) && $link['parent'] == 'system.admin') {
       $link['parent'] = 'admin.cms';
     }
   }


### PR DESCRIPTION
**Motivation**
<!-- What problem does this solve? Why is it important? What's the context? If this fixes an issue, link to it above. -->
Fixes (https://backlog.acquia.com/browse/ACMS-1328)

**Proposed changes**
<!-- What does this PR change? How does this impact end users? Are manual or automatic updates required? -->
$link parent is not checked for isset condition

**Alternatives considered**
<!-- How else could the original issue / use case be addressed? Why did you choose this solution over any others? -->

**Testing steps**
<!-- How can we replicate the issue and verify that this PR fixes it? -->
When travis job is run this error should be fixed when we install starter kit

**Merge requirements**
- [ ] _Major change_, _Minor change_, _Bug_, _Enhancement_, and/or _Chore_ label applied
- [ ] Manual testing by a reviewer
