### PR TITLE
ACMS-1290: Removing code duplicacy for roles permissions in acquia_cm…

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -164,7 +164,7 @@ before_install:
   # Download AWS cli, only for starter jobs as we store tests artifacts on s3 buckets.
   - if [ "${ACMS_JOB}" = "starter" ] || [ "${ACMS_JOB}" = "starter_full" ] || [ "${ACMS_JOB}" = "base" ]; then curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip" && unzip awscliv2.zip && sudo ./aws/install && rm -fr aws && aws s3 cp --recursive ${AWS_S3_BUCKET_PATH}/artifacts/ ${TRAVIS_BUILD_DIR}/tests/; fi
   # Optionally, remove SUT-provided tests with a specific PHPUnit test group.
-  - if [ ! -z $ACMS__JOB_EXCLUDE_PHPUNIT_TEST_GROUP ]; then find ./ -type f | xargs grep -l "@group $ACMS__JOB_EXCLUDE_PHPUNIT_TEST_GROUP$" | xargs rm -v; fi
+  # - if [ ! -z $ACMS__JOB_EXCLUDE_PHPUNIT_TEST_GROUP ]; then find ./ -type f | xargs grep -l "@group $ACMS__JOB_EXCLUDE_PHPUNIT_TEST_GROUP$" | xargs rm -v; fi
   #- sed -i 's/<\/ruleset>/ <rule ref="Drupal.InfoFiles.AutoAddedKeys.Version">\n <exclude-pattern>acquia_cms\.info\.yml<\/exclude-pattern>\n <\/rule>\n\n<\/ruleset>/' ../orca/phpcs.xml.dist && cat ../orca/phpcs.xml.dist
   - ../orca/bin/travis/before_install.sh
 

--- a/composer.json
+++ b/composer.json
@@ -42,7 +42,7 @@
         "drupal/acquia_cms_video": "*"
     },
     "require-dev": {
-        "acquia/coding-standards": "^0.7.0",
+        "acquia/coding-standards": "^1.0",
         "axelerant/drupal-quality-checker": "^1.1",
         "drupal/core-composer-scaffold": "^9.0.0",
         "drupal/core-dev": "^9",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "f68a5ab97aada7bc74e6dabc52f211f4",
+    "content-hash": "5c89e2293d92ce7721a20311e37150d8",
     "packages": [
         {
             "name": "acquia/acquia-cms-starterkit",
@@ -16947,16 +16947,16 @@
     "packages-dev": [
         {
             "name": "acquia/coding-standards",
-            "version": "v0.7.0",
+            "version": "v1.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/acquia/coding-standards-php.git",
-                "reference": "4e34786e72586924da72c2096874dd4d9a0c90e7"
+                "reference": "81ded5bf94829265eae688d1a8e41c08577b5fb1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/acquia/coding-standards-php/zipball/4e34786e72586924da72c2096874dd4d9a0c90e7",
-                "reference": "4e34786e72586924da72c2096874dd4d9a0c90e7",
+                "url": "https://api.github.com/repos/acquia/coding-standards-php/zipball/81ded5bf94829265eae688d1a8e41c08577b5fb1",
+                "reference": "81ded5bf94829265eae688d1a8e41c08577b5fb1",
                 "shasum": ""
             },
             "require": {
@@ -17001,7 +17001,7 @@
                 "issues": "https://github.com/acquia/coding-standards/issues",
                 "source": "https://github.com/acquia/coding-standards"
             },
-            "time": "2021-06-14T18:22:18+00:00"
+            "time": "2022-05-12T15:06:06+00:00"
         },
         {
             "name": "axelerant/drupal-quality-checker",

--- a/modules/acquia_cms_common/src/Facade/RolePermissionsFacade.php
+++ b/modules/acquia_cms_common/src/Facade/RolePermissionsFacade.php
@@ -1,0 +1,284 @@
+<?php
+
+namespace Drupal\acquia_cms_common\Facade;
+
+use Drupal\Core\DependencyInjection\ContainerInjectionInterface;
+use Drupal\Core\Extension\ModuleHandlerInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * Provides a facade for integrating with RolesPermissions.
+ *
+ * @internal
+ *   This is a totally internal part of Acquia CMS and may be changed in any
+ *   way, or removed outright, at any time without warning. External code should
+ *   not use this class!
+ */
+final class RolePermissionsFacade implements ContainerInjectionInterface {
+
+  /**
+   * The module handler.
+   *
+   * @var \Drupal\Core\Extension\ModuleHandlerInterface
+   */
+  protected $moduleHandler;
+
+  /**
+   * RolePermissionsFacade constructor.
+   *
+   * @param \Drupal\Core\Extension\ModuleHandlerInterface $module_handler
+   *   The module handler.
+   */
+  public function __construct(ModuleHandlerInterface $module_handler) {
+    $this->moduleHandler = $module_handler;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container) {
+    return new static(
+      $container->get('module_handler')
+    );
+  }
+
+  /**
+   * An array of default permissions based on roles and modules.
+   *
+   * @return array
+   *   Returns an array of roles and permissions.
+   */
+  public function defaultRolePermissions(string $module): array {
+    // Check for module exists and installed.
+    if ($this->moduleHandler->moduleExists($module)) {
+      // General permissions for admin and author.
+      $acms_general_admin_author_permissions = [
+        'access content overview',
+        'access media overview',
+        'clone node entity',
+        'use editorial transition create_new_draft',
+        'use editorial transition review',
+        'use moderation dashboard',
+        'use moderation sidebar',
+        'view latest version',
+      ];
+
+      // Covered site-builder and developer permissions.
+      $acms_common_permissions = [
+        'use text format filtered_html',
+        'use text format full_html',
+        'view the administration theme',
+      ];
+      $acms_content_editor_permissions = array_merge($acms_general_admin_author_permissions,
+        $acms_common_permissions,
+        [
+          'schedule publishing of nodes',
+          'use editorial transition archive',
+          'view any unpublished content',
+          'view scheduled content',
+        ]);
+      $acms_content_admin_permissions = array_merge($acms_content_editor_permissions,
+        [
+          'access taxonomy overview',
+          'administer media',
+          'administer moderation sidebar',
+          'administer nodes',
+          'administer taxonomy',
+          'bypass node access',
+          'schedule publishing of nodes',
+          'use editorial transition archived_published',
+          'use editorial transition publish',
+          'view any moderation dashboard',
+        ]);
+      $acms_content_author_permissions = array_merge($acms_general_admin_author_permissions,
+        $acms_common_permissions,
+        [
+          'administer menu',
+          'view own unpublished content',
+        ]);
+
+      $acms_user_admin_permissions = [
+        'administer CAPTCHA settings',
+        'administer honeypot',
+        'administer recaptcha',
+        'administer seckit',
+        'administer shield',
+        'administer site configuration',
+        'administer users',
+        'manage password reset',
+        'view the administration theme',
+      ];
+
+      // Conditional check for specific module.
+      if ($module === 'acquia_cms_headless') {
+        // Mapping roles with their permissions.
+        $roles_permissions = [
+          'site_builder' => $acms_common_permissions,
+          'user_administrator' => $acms_user_admin_permissions,
+          'headless' => [
+            'access acquia cms headless api dashboard',
+            'access user profiles',
+            'administer acquia cms headless configuration',
+            'administer acquia cms headless keys',
+            'bypass node access',
+            'issue subrequests',
+          ],
+          'frontend_preview_headless' => [
+            'view latest version',
+            'view any unpublished content',
+          ],
+        ];
+      }
+      elseif ($module === 'acquia_cms_site_studio') {
+        // Define site studio basic permissions.
+        $basic_site_studio_permissions = [
+          'access animate on view',
+          'access component builder elements group',
+          'access component content',
+          'access components',
+          'access content elements group',
+          'access custom elements group',
+          'access drupal core elements group',
+          'access elements',
+          'access fields',
+          'access form fields fields group',
+          'access form help fields group',
+          'access form layout fields group',
+          'access helpers',
+          'access interactive elements group',
+          'access layout elements group',
+          'access media elements group',
+          'access menu elements group',
+          'access view elements group',
+          'use text format cohesion',
+        ];
+
+        // Site-studio component and helper group permissions.
+        $components_helpers_permissions = array_merge($basic_site_studio_permissions,
+          [
+            'access cpt_cat_dynamic_components cohesion_component_category group',
+            'access cpt_cat_general_components cohesion_component_category group',
+            'access cpt_cat_hero_components cohesion_component_category group',
+            'access cpt_cat_interactive_components cohesion_component_category group',
+            'access cpt_cat_layout_components cohesion_component_category group',
+            'access cpt_cat_map_components cohesion_component_category group',
+            'access cpt_cat_media_components cohesion_component_category group',
+            'access cpt_cat_template_components cohesion_component_category group',
+            'access hlp_cat_dynamic_helpers cohesion_helper_category group',
+            'access hlp_cat_general_helpers cohesion_helper_category group',
+            'access hlp_cat_interactive_helpers cohesion_helper_category group',
+            'access hlp_cat_layout_helpers cohesion_helper_category group',
+            'access hlp_cat_media_helpers cohesion_helper_category group',
+          ]);
+
+        // Define site studio content administration permissions.
+        $content_admin_author_permissions = array_merge($components_helpers_permissions,
+          [
+            'access accordion_sections cohesion_helper_category group',
+            'access card_sections cohesion_helper_category group',
+            'access cpt_cat_accordion_components cohesion_component_category group',
+            'access cpt_cat_basic_components cohesion_component_category group',
+            'access cpt_cat_card_components cohesion_component_category group',
+            'access cpt_cat_feature_sections cohesion_component_category group',
+            'access cpt_cat_read_more_components cohesion_component_category group',
+            'access cpt_cat_slider_components cohesion_component_category group',
+            'access cpt_cat_tab_components cohesion_component_category group',
+            'access hlp_cat_miscellaneous cohesion_helper_category group',
+            'access hlp_cat_page_layouts cohesion_helper_category group',
+            'access hlp_cat_slider_sections cohesion_helper_category group',
+            'access hlp_cat_text_sections cohesion_helper_category group',
+            'access tabbed_sections cohesion_helper_category group',
+            'access visual page builder',
+          ]
+        );
+
+        // Site-studio Site-builder permissions.
+        $site_building_administrative_permissions = [
+          'access cohesion sync',
+          'administer cohesion',
+          'administer component categories',
+          'administer component content',
+          'administer components',
+          'administer custom styles',
+          'administer helper categories',
+          'administer helpers',
+          'administer style helpers',
+          'administer style_guide',
+        ];
+
+        // Mapping roles with their permissions.
+        $roles_permissions = [
+          'content_administrator' => $content_admin_author_permissions,
+          'content_author' => $content_admin_author_permissions,
+          'content_editor' => $components_helpers_permissions,
+          'developer' => array_merge($basic_site_studio_permissions,
+            $acms_common_permissions,
+            $site_building_administrative_permissions,
+            [
+              'access analytics',
+              'access color_picker',
+              'access context visibility',
+              'access hide no data',
+              'access markup',
+              'access seo',
+              'access styles',
+              'access tokens',
+              'administer base styles',
+              'administer cohesion settings',
+              'administer content templates',
+              'administer master templates',
+              'administer menu templates',
+              'administer view templates',
+              'administer website settings',
+            ]),
+          'site_builder' => array_merge($site_building_administrative_permissions,
+            $acms_common_permissions,
+            ['use text format cohesion']),
+          'user_administrator' => $acms_user_admin_permissions,
+        ];
+      }
+      elseif ($module === 'acquia_cms_tour') {
+        $roles_permissions = [
+          'content_administrator' => array_merge($acms_content_admin_permissions,
+            [
+              'access acquia cms tour',
+              'access acquia cms tour dashboard',
+            ]),
+          'content_author' => array_merge($acms_content_author_permissions,
+            ['access acquia cms tour']),
+          'content_editor' => array_merge($acms_content_editor_permissions,
+            ['access acquia cms tour']),
+          'site_builder' => $acms_common_permissions,
+          'user_administrator' => $acms_user_admin_permissions,
+        ];
+      }
+      elseif ($module === 'acquia_cms_toolbar') {
+        $roles_permissions = [
+          'content_administrator' => array_merge($acms_content_admin_permissions,
+            ['access toolbar']),
+          'content_author' => array_merge($acms_content_author_permissions,
+            ['access toolbar']),
+          'content_editor' => array_merge($acms_content_editor_permissions,
+            ['access toolbar']),
+          'site_builder' => array_merge($acms_common_permissions,
+            ['access toolbar']),
+          'user_administrator' => array_merge($acms_user_admin_permissions,
+            ['access toolbar']),
+        ];
+      }
+      else {
+        // Mapping roles with their permissions.
+        $roles_permissions = [
+          'content_administrator' => $acms_content_admin_permissions,
+          'content_author' => $acms_content_author_permissions,
+          'content_editor' => $acms_content_editor_permissions,
+          'site_builder' => $acms_common_permissions,
+          'user_administrator' => $acms_user_admin_permissions,
+        ];
+      }
+    }
+
+    return $roles_permissions ?? [];
+  }
+
+}

--- a/modules/acquia_cms_common/tests/src/Functional/BasicPermissionsTest.php
+++ b/modules/acquia_cms_common/tests/src/Functional/BasicPermissionsTest.php
@@ -2,6 +2,7 @@
 
 namespace Drupal\Tests\acquia_cms_common\Functional;
 
+use Drupal\acquia_cms_common\Facade\RolePermissionsFacade;
 use Drupal\Tests\BrowserTestBase;
 use Drupal\user\Entity\Role;
 
@@ -25,9 +26,13 @@ class BasicPermissionsTest extends BrowserTestBase {
   protected static $modules = [
     'acquia_cms_common',
     'media',
-    'toolbar',
     'views',
   ];
+
+  /**
+   * @var \Drupal\acquia_cms_common\Facade\RolePermissionsFacade
+   */
+  protected $rolePermissionsFacade;
 
   /**
    * Disable strict config schema checks in this test.
@@ -45,6 +50,14 @@ class BasicPermissionsTest extends BrowserTestBase {
   // @codingStandardsIgnoreEnd
 
   /**
+   * {@inheritdoc}
+   */
+  protected function setUp(): void {
+    parent::setUp();
+    $this->rolePermissionsFacade = $this->container->get('class_resolver')->getInstanceFromDefinition(RolePermissionsFacade::class);
+  }
+
+  /**
    * Tests basic capabilities of our user roles.
    *
    * - Content authors, editors, and administrators should all be able to access
@@ -53,169 +66,28 @@ class BasicPermissionsTest extends BrowserTestBase {
    *   overview.
    */
   public function testBasicPermissions() {
+    // Assert sessions started.
     $assert_session = $this->assertSession();
+    $roles_permissions = $this->getRolesPermissions();
+    foreach ($roles_permissions as $role => $permissions) {
+      // Check for permissions assigned to the role.
+      $this->assertPermissions($role, $permissions);
 
-    $contributor_permissions = [
-      'access animate on view',
-      'access component builder elements group',
-      'access component content',
-      'access components',
-      'access content elements group',
-      'access cpt_cat_dynamic_components cohesion_component_category group',
-      'access cpt_cat_general_components cohesion_component_category group',
-      'access cpt_cat_hero_components cohesion_component_category group',
-      'access cpt_cat_interactive_components cohesion_component_category group',
-      'access cpt_cat_layout_components cohesion_component_category group',
-      'access cpt_cat_map_components cohesion_component_category group',
-      'access cpt_cat_media_components cohesion_component_category group',
-      'access cpt_cat_template_components cohesion_component_category group',
-      'access custom elements group',
-      'access drupal core elements group',
-      'access elements',
-      'access fields',
-      'access form fields fields group',
-      'access form help fields group',
-      'access form layout fields group',
-      'access helpers',
-      'access hlp_cat_dynamic_helpers cohesion_helper_category group',
-      'access hlp_cat_general_helpers cohesion_helper_category group',
-      'access hlp_cat_interactive_helpers cohesion_helper_category group',
-      'access hlp_cat_layout_helpers cohesion_helper_category group',
-      'access hlp_cat_media_helpers cohesion_helper_category group',
-      'access interactive elements group',
-      'access layout elements group',
-      'access media elements group',
-      'access menu elements group',
-      'access view elements group',
-      'use text format cohesion',
-      'view the administration theme',
-      'use moderation dashboard',
-      'use moderation sidebar',
-      'clone node entity',
-    ];
-    $this->assertPermissions('content_author', $contributor_permissions);
-    $this->assertPermissions('content_editor', $contributor_permissions);
-    $this->assertPermissions('content_administrator', $contributor_permissions);
-
-    $content_administrator_permissions = [
-      'administer nodes',
-      'administer media',
-      'administer taxonomy',
-      'bypass node access',
-    ];
-    $this->assertNoPermissions('content_author', $content_administrator_permissions);
-    $this->assertNoPermissions('content_editor', $content_administrator_permissions);
-    $this->assertPermissions('content_administrator', $content_administrator_permissions);
-
-    $this->assertPermissions('user_administrator', [
-      'administer users',
-      'view the administration theme',
-    ]);
-
-    // Site Studio element permissions test.
-    $site_studio_elements_permissions = [
-      'access cpt_cat_accordion_components cohesion_component_category group',
-      'access cpt_cat_basic_components cohesion_component_category group',
-      'access cpt_cat_card_components cohesion_component_category group',
-      'access cpt_cat_feature_sections cohesion_component_category group',
-      'access cpt_cat_read_more_components cohesion_component_category group',
-      'access cpt_cat_slider_components cohesion_component_category group',
-      'access cpt_cat_tab_components cohesion_component_category group',
-      'access hlp_cat_hero_sections cohesion_helper_category group',
-      'access hlp_cat_miscellaneous cohesion_helper_category group',
-      'access hlp_cat_page_layouts cohesion_helper_category group',
-      'access hlp_cat_slider_sections cohesion_helper_category group',
-      'access hlp_cat_text_sections cohesion_helper_category group',
-      'access visual page builder',
-    ];
-    $this->assertPermissions('content_author', $site_studio_elements_permissions);
-    $this->assertPermissions('content_administrator', $site_studio_elements_permissions);
-
-    $cohesion_permissions = [
-      'use text format cohesion',
-      'access cohesion sync',
-      'administer cohesion',
-      'administer component categories',
-      'administer component content',
-      'administer components',
-      'administer custom styles',
-      'administer helper categories',
-      'administer helpers',
-      'administer style helpers',
-      'administer style_guide',
-      'view the administration theme',
-    ];
-    $this->assertPermissions('developer', $cohesion_permissions);
-    $this->assertPermissions('site_builder', $cohesion_permissions);
-
-    $developer_permissions = [
-      'access analytics',
-      'access animate on view',
-      'access color_picker',
-      'access component builder elements group',
-      'access component content',
-      'access components',
-      'access content elements group',
-      'access context visibility',
-      'access custom elements group',
-      'access drupal core elements group',
-      'access elements',
-      'access fields',
-      'access form fields fields group',
-      'access form help fields group',
-      'access form layout fields group',
-      'access helpers',
-      'access hide no data',
-      'access interactive elements group',
-      'access layout elements group',
-      'access markup',
-      'access media elements group',
-      'access menu elements group',
-      'access seo',
-      'access styles',
-      'access tokens',
-      'access view elements group',
-      'administer base styles',
-      'administer cohesion settings',
-      'administer content templates',
-      'administer master templates',
-      'administer menu templates',
-      'administer view templates',
-      'administer website settings',
-    ];
-    $this->assertPermissions('developer', $developer_permissions);
-    $this->assertNoPermissions('site_builder', $developer_permissions);
-
-    $map = [
-      'content_author' => [
-        '/admin/content',
-        '/admin/content/media',
-      ],
-      'content_editor' => [
-        '/admin/content',
-        '/admin/content/media',
-      ],
-      'content_administrator' => [
-        '/admin/content',
-        '/admin/content/media',
-      ],
-      'user_administrator' => [
-        '/admin/people',
-      ],
-      'developer' => [],
-      'site_builder' => [],
-    ];
-    foreach ($map as $role => $paths) {
+      // Create user and check for the routes/paths.
       $account = $this->drupalCreateUser();
       $account->addRole($role);
       $account->save();
-
       $this->drupalLogin($account);
-      // The role should be able to access the toolbar.
-      $assert_session->elementExists('css', '#toolbar-administration');
-
-      foreach ($paths as $path) {
-        $this->drupalGet($path);
+      if ($role === 'user_administrator') {
+        $this->drupalGet('/admin/people');
+        $assert_session->statusCodeEquals(200);
+      }
+      elseif ($role === 'developer' || $role === 'site_builder') {
+        $assert_session->statusCodeEquals(200);
+      }
+      else {
+        $this->drupalGet('/admin/content');
+        $this->drupalGet('/admin/content/media');
         $assert_session->statusCodeEquals(200);
       }
     }
@@ -229,24 +101,20 @@ class BasicPermissionsTest extends BrowserTestBase {
    * @param string[] $permissions
    *   An array of permissions the role is expected to have.
    */
-  private function assertPermissions(string $role, array $permissions) : void {
+  private function assertPermissions(string $role, array $permissions): void {
     $role = Role::load($role);
     $missing_permissions = array_diff($permissions, $role->getPermissions());
     $this->assertEmpty($missing_permissions);
   }
 
   /**
-   * Asserts that a role does not have a set of permissions.
+   * Get role permissions based on acms modules.
    *
-   * @param string $role
-   *   The ID of the role to check.
-   * @param string[] $permissions
-   *   An array of permissions the role is not expected to have.
+   * @return array
+   *   List of roles and permissions.
    */
-  private function assertNoPermissions(string $role, array $permissions) : void {
-    $role = Role::load($role);
-    $granted_permissions = array_intersect($role->getPermissions(), $permissions);
-    $this->assertEmpty($granted_permissions);
+  protected function getRolesPermissions(): array {
+    return $this->rolePermissionsFacade->defaultRolePermissions('acquia_cms_common');
   }
 
 }

--- a/modules/acquia_cms_site_studio/acquia_cms_site_studio.install
+++ b/modules/acquia_cms_site_studio/acquia_cms_site_studio.install
@@ -5,10 +5,10 @@
  * Contains install-time code for the Acquia CMS profile.
  */
 
+use Drupal\acquia_cms_common\Facade\RolePermissionsFacade;
 use Drupal\Core\Config\FileStorage;
 use Drupal\Core\Installer\InstallerKernel;
 use Drupal\node\Entity\NodeType;
-use Drupal\user\Entity\Role;
 
 /**
  * Implements hook_install().
@@ -148,148 +148,12 @@ function acquia_cms_site_studio_uninstall() {
  * Update role permission handler.
  */
 function update_site_studio_role_permission() {
-  $roles = Role::loadMultiple();
+  $roles_permissions = \Drupal::classResolver(RolePermissionsFacade::class)->defaultRolePermissions('acquia_cms_site_studio');
 
-  // Define roles having access to site studio components.
-  $roles_admin_author_editor_develop = [
-    'content_administrator',
-    'content_author',
-    'content_editor',
-    'developer',
-  ];
-
-  // Define site studio basic permission.
-  $permissions = [
-    'access animate on view',
-    'access component builder elements group',
-    'access component content',
-    'access components',
-    'access content elements group',
-    'access custom elements group',
-    'access drupal core elements group',
-    'access elements',
-    'access fields',
-    'access form fields fields group',
-    'access form help fields group',
-    'access form layout fields group',
-    'access helpers',
-    'access interactive elements group',
-    'access layout elements group',
-    'access media elements group',
-    'access menu elements group',
-    'access view elements group',
-    'use text format cohesion',
-  ];
-
-  // Define site studio content administration permission.
-  $permissions_content_admin_author = [
-    'access accordion_sections cohesion_helper_category group',
-    'access card_sections cohesion_helper_category group',
-    'access cpt_cat_accordion_components cohesion_component_category group',
-    'access cpt_cat_basic_components cohesion_component_category group',
-    'access cpt_cat_card_components cohesion_component_category group',
-    'access cpt_cat_dynamic_components cohesion_component_category group',
-    'access cpt_cat_feature_sections cohesion_component_category group',
-    'access cpt_cat_general_components cohesion_component_category group',
-    'access cpt_cat_hero_components cohesion_component_category group',
-    'access cpt_cat_interactive_components cohesion_component_category group',
-    'access cpt_cat_layout_components cohesion_component_category group',
-    'access cpt_cat_map_components cohesion_component_category group',
-    'access cpt_cat_media_components cohesion_component_category group',
-    'access cpt_cat_read_more_components cohesion_component_category group',
-    'access cpt_cat_slider_components cohesion_component_category group',
-    'access cpt_cat_tab_components cohesion_component_category group',
-    'access cpt_cat_template_components cohesion_component_category group',
-    'access hlp_cat_dynamic_helpers cohesion_helper_category group',
-    'access hlp_cat_general_helpers cohesion_helper_category group',
-    'access hlp_cat_hero_sections cohesion_helper_category group',
-    'access hlp_cat_interactive_helpers cohesion_helper_category group',
-    'access hlp_cat_layout_helpers cohesion_helper_category group',
-    'access hlp_cat_media_helpers cohesion_helper_category group',
-    'access hlp_cat_miscellaneous cohesion_helper_category group',
-    'access hlp_cat_page_layouts cohesion_helper_category group',
-    'access hlp_cat_slider_sections cohesion_helper_category group',
-    'access hlp_cat_text_sections cohesion_helper_category group',
-    'access tabbed_sections cohesion_helper_category group',
-    'access visual page builder',
-  ];
-  foreach ($roles_admin_author_editor_develop as $role) {
-    if (isset($roles[$role])) {
-      user_role_grant_permissions($role, $permissions);
-    }
-  }
-  if (isset($roles['content_administrator'])) {
-    user_role_grant_permissions('content_administrator', $permissions_content_admin_author);
-  }
-  if (isset($roles['content_author'])) {
-    user_role_grant_permissions('content_author', $permissions_content_admin_author);
-  }
-
-  // Define content editor permissions.
-  if (isset($roles['content_editor'])) {
-    user_role_grant_permissions('content_editor', [
-      'access cpt_cat_dynamic_components cohesion_component_category group',
-      'access cpt_cat_general_components cohesion_component_category group',
-      'access cpt_cat_hero_components cohesion_component_category group',
-      'access cpt_cat_interactive_components cohesion_component_category group',
-      'access cpt_cat_layout_components cohesion_component_category group',
-      'access cpt_cat_map_components cohesion_component_category group',
-      'access cpt_cat_media_components cohesion_component_category group',
-      'access cpt_cat_template_components cohesion_component_category group',
-      'access hlp_cat_dynamic_helpers cohesion_helper_category group',
-      'access hlp_cat_general_helpers cohesion_helper_category group',
-      'access hlp_cat_interactive_helpers cohesion_helper_category group',
-      'access hlp_cat_layout_helpers cohesion_helper_category group',
-      'access hlp_cat_media_helpers cohesion_helper_category group',
-    ]);
-  }
-
-  // Define site studio etra permissions for developer role.
-  if (isset($roles['developer'])) {
-    user_role_grant_permissions('developer', [
-      'access analytics',
-      'access cohesion sync',
-      'access color_picker',
-      'access context visibility',
-      'access hide no data',
-      'access markup',
-      'access seo',
-      'access styles',
-      'access tokens',
-      'administer base styles',
-      'administer cohesion',
-      'administer cohesion settings',
-      'administer component categories',
-      'administer component content',
-      'administer components',
-      'administer content templates',
-      'administer custom styles',
-      'administer helper categories',
-      'administer helpers',
-      'administer master templates',
-      'administer menu templates',
-      'administer style helpers',
-      'administer style_guide',
-      'administer view templates',
-      'administer website settings',
-    ]);
-  }
-
-  // Define site studion permission for site builder role.
-  if (isset($roles['site_builder'])) {
-    user_role_grant_permissions('site_builder', [
-      'access cohesion sync',
-      'administer cohesion',
-      'administer component categories',
-      'administer component content',
-      'administer components',
-      'administer custom styles',
-      'administer helper categories',
-      'administer helpers',
-      'administer style helpers',
-      'administer style_guide',
-      'use text format cohesion',
-    ]);
+  // Iterate roles to assign permissions as per usage.
+  foreach ($roles_permissions as $role => $permissions) {
+    // Assign permissions based on roles.
+    user_role_grant_permissions($role, $permissions);
   }
 }
 

--- a/modules/acquia_cms_site_studio/tests/src/Functional/SiteStudioPermissionsTest.php
+++ b/modules/acquia_cms_site_studio/tests/src/Functional/SiteStudioPermissionsTest.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Drupal\Tests\acquia_cms_site_studio\Functional;
+
+use Drupal\Tests\acquia_cms_common\Functional\BasicPermissionsTest;
+
+/**
+ * Tests basic, broad permissions of the user roles included with Acquia CMS.
+ *
+ * @group acquia_cms_site_studio
+ * @group acquia_cms
+ * @group risky
+ */
+class SiteStudioPermissionsTest extends BasicPermissionsTest {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected static $modules = [
+    'acquia_cms_site_studio',
+  ];
+
+  /**
+   * Get role permissions based on acms modules.
+   *
+   * @return array
+   *   List of roles and permissions.
+   */
+  protected function getRolesPermissions(): array {
+    // Return the role permissions data.
+    return $this->rolePermissionsFacade->defaultRolePermissions('acquia_cms_site_studio');
+  }
+
+}

--- a/modules/acquia_cms_toolbar/acquia_cms_toolbar.install
+++ b/modules/acquia_cms_toolbar/acquia_cms_toolbar.install
@@ -11,13 +11,13 @@ use Drupal\user\Entity\Role;
  * Implements hook_install().
  */
 function acquia_cms_toolbar_install() {
-  update_toolabr_role_permission();
+  update_toolbar_role_permission();
 }
 
 /**
  * Update role permission handler.
  */
-function update_toolabr_role_permission() {
+function update_toolbar_role_permission() {
   $get_all_roles = Role::loadMultiple();
   $roles = [
     'content_administrator',
@@ -38,5 +38,5 @@ function update_toolabr_role_permission() {
  * Update role permissions.
  */
 function acquia_cms_toolbar_update_8001() {
-  update_toolabr_role_permission();
+  update_toolbar_role_permission();
 }

--- a/modules/acquia_cms_toolbar/tests/src/Functional/ToolbarPermissionsTest.php
+++ b/modules/acquia_cms_toolbar/tests/src/Functional/ToolbarPermissionsTest.php
@@ -1,0 +1,96 @@
+<?php
+
+namespace Drupal\Tests\acquia_cms_toolbar\Functional;
+
+use Drupal\Tests\BrowserTestBase;
+use Drupal\user\Entity\Role;
+
+/**
+ * Tests basic, broad permissions of the user roles included with Acquia CMS.
+ *
+ * @group acquia_cms_toolbar
+ * @group acquia_cms
+ * @group risky
+ */
+class ToolbarPermissionsTest extends BrowserTestBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected $defaultTheme = 'stark';
+
+  /**
+   * {@inheritdoc}
+   */
+  protected static $modules = [
+    'acquia_cms_toolbar',
+    'toolbar',
+  ];
+
+  /**
+   * Tests basic capabilities of our user roles.
+   *
+   * - Content authors, editors, and administrators should all be able to access
+   *   the toolbar and the content overview.
+   * - User administrator should be able to access the toolbar and the user
+   *   overview.
+   *
+   * @param string $role
+   *   The ID of the user role to test with.
+   *
+   * @dataProvider providerRoles
+   */
+  public function testBasicPermissions(string $role) {
+    $account = $this->createUser();
+    $account->addRole($role);
+    $account->save();
+    $this->drupalLogin($account);
+
+    $assert_session = $this->assertSession();
+    $this->assertPermissions($role, ['access toolbar']);
+    if ($role === 'user_administrator') {
+      $this->drupalGet('/admin/people');
+      $assert_session->statusCodeEquals(200);
+    }
+    elseif ($role === 'developer' || $role === 'site_builder') {
+      $assert_session->statusCodeEquals(200);
+    }
+    else {
+      $this->drupalGet('/admin/content');
+      $this->drupalGet('/admin/content/media');
+      $assert_session->statusCodeEquals(200);
+    }
+  }
+
+  /**
+   * Data provider for ::testBasicPermissions().
+   *
+   * @return array
+   *   Sets of arguments to pass to the test method.
+   */
+  public function providerRoles() {
+    return [
+      ['content_administrator'],
+      ['content_author'],
+      ['content_editor'],
+      ['developer'],
+      ['site_builder'],
+      ['user_administrator'],
+    ];
+  }
+
+  /**
+   * Asserts that a role has a set of permissions.
+   *
+   * @param string $role
+   *   The ID of the role to check.
+   * @param string[] $permissions
+   *   An array of permissions the role is expected to have.
+   */
+  private function assertPermissions(string $role, array $permissions): void {
+    $role = Role::load($role);
+    $missing_permissions = array_diff($permissions, $role->getPermissions());
+    $this->assertEmpty($missing_permissions);
+  }
+
+}

--- a/modules/acquia_cms_tour/tests/src/Functional/TourPermissionsTest.php
+++ b/modules/acquia_cms_tour/tests/src/Functional/TourPermissionsTest.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Drupal\Tests\acquia_cms_tour\Functional;
+
+use Drupal\Tests\acquia_cms_common\Functional\BasicPermissionsTest;
+
+/**
+ * Tests basic, broad permissions of the user roles included with Acquia CMS.
+ *
+ * @group acquia_cms_tour
+ * @group acquia_cms
+ * @group risky
+ */
+class TourPermissionsTest extends BasicPermissionsTest {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected static $modules = [
+    'acquia_cms_tour',
+  ];
+
+  /**
+   * Get role permissions based on acms modules.
+   *
+   * @return array
+   *   List of roles and permissions.
+   */
+  protected function getRolesPermissions(): array {
+    // Return the role permissions data.
+    return $this->rolePermissionsFacade->defaultRolePermissions('acquia_cms_site_tour');
+  }
+
+}

--- a/tests/src/ExistingSite/LoginRedirectionTest.php
+++ b/tests/src/ExistingSite/LoginRedirectionTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Drupal\Tests\acquia_cms_common\ExistingSite;
+namespace Drupal\Tests\acquia_cms\ExistingSite;
 
 use Drupal\Component\Serialization\Yaml;
 use weitzman\DrupalTestTraits\ExistingSiteBase;


### PR DESCRIPTION
…s_site_studio.

**Motivation**
<!-- What problem does this solve? Why is it important? What's the context? If this fixes an issue, link to it above. -->
Fixes #ACMS-1290

**Proposed changes**

- Wrote one facade(including headless roles too)
- optimise code for acquia_cms_site_studio.install
- create new functional test under acquia_cms_tour and acquia_cms_site_studio for basicpermissions
- optimise code in BasicPermissionsTest under acquia_cms_common.
- Move test Drupal\Tests\acquia_cms_common\ExistingSite\LoginRedirectionTest::testLoginDestination acquia_cms as integrated test

