### PR TITLE
ACMS-1341: Added the patch for ctools for context is not valid context error

### DIFF
--- a/modules/acquia_cms_common/composer.json
+++ b/modules/acquia_cms_common/composer.json
@@ -105,6 +105,9 @@
             },
             "guzzlehttp/guzzle": {
                 "GuzzleHttp deprecation fix with PHP 8.1 support": "https://gist.githubusercontent.com/alpha1892/a6f283f354c15fba03a47454b08c3b10/raw/11e188f94e8e57c31fc2cf401d2a8c6757fada72/guzzle-cookie-cookiejar-deprecation.patch"
+            },
+            "drupal/ctools": {
+                "Fix the context is not a valid context error": "https://www.drupal.org/files/issues/2022-08-03/3300682-50.patch"
             }
         }
     },


### PR DESCRIPTION
**Motivation**
* We need to fix the CI error for page content type test.
Fixes #NNN

**Proposed changes**
* Ctools module patch that fixes the error - "Context is not a valid context."

**Alternatives considered**
* No

**Testing steps**
* Setup acquia_cms and notice that all pages are opening up without any issues ex. node/add/page.
* All travis CI issues should pass.

**Merge requirements**
- [ ] _Major change_, _Minor change_, _Bug_, _Enhancement_, and/or _Chore_ label applied
- [ ] Manual testing by a reviewer
