### PR TITLE
ACMS-1312: Revamped the redirection code for site preview.

### DIFF
--- a/modules/acquia_cms_headless/acquia_cms_headless.module
+++ b/modules/acquia_cms_headless/acquia_cms_headless.module
@@ -4,22 +4,3 @@
  * @file
  * Contains hook implementations for the acquia_cms_headless module.
  */
-
-use Drupal\Core\Url;
-use Drupal\node\NodeInterface;
-use Symfony\Component\HttpFoundation\RedirectResponse;
-
-/**
- * Implements hook_node_presave().
- */
-function acquia_cms_headless_node_update(NodeInterface $node) {
-  $url = Url::fromRoute('entity.node.headless_preview', ['node' => $node->id()]);
-  $headlessConfigurations = \Drupal::config('acquia_cms_headless.settings');
-  // Redirect only when headless mode & next.js starterkit are enabled.
-  if ($headlessConfigurations->get('headless_mode') && $headlessConfigurations->get('starterkit_nextjs')) {
-    if (!$node->isPublished()) {
-      $response = new RedirectResponse($url->toString());
-      $response->send();
-    }
-  }
-}

--- a/modules/acquia_cms_headless/composer.json
+++ b/modules/acquia_cms_headless/composer.json
@@ -25,6 +25,11 @@
         }
     },
     "extra": {
+        "drush": {
+            "services": {
+                "drush.services.yml": "^10.6 || ^11"
+            }
+        },
         "enable-patching": true,
         "installer-paths": {
             "docroot/core": [
@@ -56,16 +61,11 @@
             "drupal/decoupled_router": {
                 "Unable to resolve path on node in other language than default": "https://www.drupal.org/files/issues/2021-05-05/3111456-34.patch"
             },
-            "drupal/subrequests": {
-                "Get same results on different request": "https://www.drupal.org/files/issues/2019-07-18/change_request_type-63049395-09.patch"
-            },
             "drupal/next": {
                 "Next Module Patchn for Preview Button display on unplubshied node": "https://gist.githubusercontent.com/panshulK/0b86ed1be39b30a8b5bb87f1d3e5e2ff/raw/1ccda257455900363a543b3b00975b5e1c9c491c/next-module-unpublished-preview-button-url-fix.patch"
-            }
-        },
-        "drush": {
-            "services": {
-                "drush.services.yml": "^10.6 || ^11"
+            },
+            "drupal/subrequests": {
+                "Get same results on different request": "https://www.drupal.org/files/issues/2019-07-18/change_request_type-63049395-09.patch"
             }
         }
     },

--- a/modules/acquia_cms_headless/modules/acquia_cms_headless_ui/acquia_cms_headless_ui.module
+++ b/modules/acquia_cms_headless/modules/acquia_cms_headless_ui/acquia_cms_headless_ui.module
@@ -12,9 +12,11 @@ use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Render\Element;
 use Drupal\Core\Template\Attribute;
 use Drupal\Core\Url;
+use Drupal\node\NodeInterface;
 use Drupal\node\NodeTypeInterface;
 use Drupal\user\UserInterface;
 use Drupal\views\ViewEntityInterface;
+use Symfony\Component\HttpFoundation\RedirectResponse;
 
 /**
  * Implements hook_help().
@@ -26,6 +28,20 @@ function acquia_cms_headless_ui_help($route_name) {
 
     default:
       return NULL;
+  }
+}
+
+/**
+ * Implements hook_node_update().
+ */
+function acquia_cms_headless_ui_node_update(NodeInterface $node) {
+  $url = Url::fromRoute('entity.node.headless_preview', ['node' => $node->id()]);
+  // Check for destination query param.
+  $current_request = \Drupal::service('request_stack')->getCurrentRequest();
+  // If not set, then redirect to site-preview.
+  if (!$current_request->query->get('destination')) {
+    $response = new RedirectResponse($url->toString());
+    $response->send();
   }
 }
 
@@ -302,7 +318,7 @@ function acquia_cms_headless_ui_menu_links_discovered_alter(array &$links) {
       'admin.content_models',
       'acquia_cms_tour.tour',
       'system.admin_content',
-      'admin_toolbar_tools.help'
+      'admin_toolbar_tools.help',
     ];
     if (in_array($name, $bypass)) {
       continue;

--- a/modules/acquia_cms_headless/modules/acquia_cms_headless_ui/acquia_cms_headless_ui.module
+++ b/modules/acquia_cms_headless/modules/acquia_cms_headless_ui/acquia_cms_headless_ui.module
@@ -12,11 +12,9 @@ use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Render\Element;
 use Drupal\Core\Template\Attribute;
 use Drupal\Core\Url;
-use Drupal\node\NodeInterface;
 use Drupal\node\NodeTypeInterface;
 use Drupal\user\UserInterface;
 use Drupal\views\ViewEntityInterface;
-use Symfony\Component\HttpFoundation\RedirectResponse;
 
 /**
  * Implements hook_help().
@@ -28,20 +26,6 @@ function acquia_cms_headless_ui_help($route_name) {
 
     default:
       return NULL;
-  }
-}
-
-/**
- * Implements hook_node_update().
- */
-function acquia_cms_headless_ui_node_update(NodeInterface $node) {
-  $url = Url::fromRoute('entity.node.headless_preview', ['node' => $node->id()]);
-  // Check for destination query param.
-  $current_request = \Drupal::service('request_stack')->getCurrentRequest();
-  // If not set, then redirect to site-preview.
-  if (!$current_request->query->get('destination')) {
-    $response = new RedirectResponse($url->toString());
-    $response->send();
   }
 }
 
@@ -269,7 +253,6 @@ function acquia_cms_headless_ui_local_tasks_alter(array &$local_tasks) {
       $local_tasks[$id]['entity_type_id'] = $matches[2];
     }
   }
-
   $local_tasks['oauth2_token.settings_tab']['title'] = t('API settings');
   $local_tasks['oauth2_token.settings_tab']['base_route'] = 'admin.access_control';
   $local_tasks['oauth2_token.settings_tab']['weight'] = 1;

--- a/modules/acquia_cms_headless/modules/acquia_cms_headless_ui/acquia_cms_headless_ui.services.yml
+++ b/modules/acquia_cms_headless/modules/acquia_cms_headless_ui/acquia_cms_headless_ui.services.yml
@@ -15,3 +15,7 @@ services:
       - '@messenger'
       - '@module_handler'
       - '@theme_handler'
+  acquia_cms_headless.site_preview_route_subscriber:
+    class: 'Drupal\acquia_cms_headless_ui\Routing\SitePreviewRouteSubscriber'
+    tags:
+      - { name: event_subscriber }

--- a/modules/acquia_cms_headless/modules/acquia_cms_headless_ui/src/Routing/SitePreviewRouteSubscriber.php
+++ b/modules/acquia_cms_headless/modules/acquia_cms_headless_ui/src/Routing/SitePreviewRouteSubscriber.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Drupal\acquia_cms_headless_ui\Routing;
+
+use Drupal\Core\Routing\RouteSubscriberBase;
+use Symfony\Component\Routing\RouteCollection;
+
+/**
+ * Class to alter the route controller.
+ */
+class SitePreviewRouteSubscriber extends RouteSubscriberBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function alterRoutes(RouteCollection $collection) {
+    // Change the controller for the latest version tab to site-preview.
+    if ($route = $collection->get("entity.node.latest_version")) {
+      $route->setDefault('_controller', '\Drupal\next\Controller\SitePreviewController::nodePreview');
+    }
+  }
+
+}


### PR DESCRIPTION
**Motivation**
* To remove the re-direction code from acquia_cms_headless module and move to acquia_cms_headless_ui module.
* To re-write the redirection logic to work only when destination params are not set.
* Loom recording - https://www.loom.com/share/8fc6be4203a6428c97c4f98d1b97bb39
Fixes #NNN

**Proposed changes**
* To remove the re-direction code from acquia_cms_headless module and move to acquia_cms_headless_ui module.
* To re-write the redirection logic to work only when destination params are not set.

**Alternatives considered**
* None

**Testing steps**
* Enable headless mode and head towards - /admin/content page.
* Edit any node and notice that node edit URL has the destination query params ex. `?destination=/acquia_cms/admin/content`
* Make changes and notice that the user is redirected to destination url from query params.
* Edit the content again, remove the query params completely and then save.
* Notice that user is redirected to `/node/<id>/site-preview` page.

Loom Recording - https://www.loom.com/share/8fc6be4203a6428c97c4f98d1b97bb39

**Merge requirements**
- [ ] _Major change_, _Minor change_, _Bug_, _Enhancement_, and/or _Chore_ label applied
- [ ] Manual testing by a reviewer
