### PR TITLE
ACMS-1337: Drush commands for Nextjs environment variables.

### DIFF
--- a/modules/acquia_cms_headless/composer.json
+++ b/modules/acquia_cms_headless/composer.json
@@ -62,6 +62,11 @@
             "drupal/next": {
                 "Next Module Patchn for Preview Button display on unplubshied node": "https://gist.githubusercontent.com/panshulK/0b86ed1be39b30a8b5bb87f1d3e5e2ff/raw/1ccda257455900363a543b3b00975b5e1c9c491c/next-module-unpublished-preview-button-url-fix.patch"
             }
+        },
+        "drush": {
+            "services": {
+                "drush.services.yml": "^10.6 || ^11"
+            }
         }
     },
     "repositories": {

--- a/modules/acquia_cms_headless/drush.services.yml
+++ b/modules/acquia_cms_headless/drush.services.yml
@@ -1,0 +1,8 @@
+services:
+  acquia_cms_headless.commands:
+    class: \Drupal\acquia_cms_headless\Commands\AcquiaCmsHeadlessCommands
+    arguments:
+      - '@acquia_cms_headless.starterkit_nextjs'
+      - '@entity_type.manager'
+    tags:
+      - { name: drush.command }

--- a/modules/acquia_cms_headless/drush.services.yml
+++ b/modules/acquia_cms_headless/drush.services.yml
@@ -4,5 +4,6 @@ services:
     arguments:
       - '@acquia_cms_headless.starterkit_nextjs'
       - '@entity_type.manager'
+      - '@file_system'
     tags:
       - { name: drush.command }

--- a/modules/acquia_cms_headless/src/Commands/AcquiaCmsHeadlessCommands.php
+++ b/modules/acquia_cms_headless/src/Commands/AcquiaCmsHeadlessCommands.php
@@ -1,0 +1,131 @@
+<?php
+
+namespace Drupal\acquia_cms_headless\Commands;
+
+use Consolidation\AnnotatedCommand\CommandData;
+use Consolidation\AnnotatedCommand\CommandError;
+use Drupal\acquia_cms_headless\Service\StarterkitNextjsService;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drush\Commands\DrushCommands;
+
+/**
+ * Implements Acquia CMS Headless commands for Drush.
+ */
+class AcquiaCmsHeadlessCommands extends DrushCommands {
+
+  /**
+   * The next.js starter kit service.
+   *
+   * @var \Drupal\acquia_cms_headless\Service\StarterkitNextjsService
+   */
+  private $starterKit;
+
+  /**
+   * The EntityTypeManager service.
+   *
+   * @var \Drupal\Core\Entity\EntityTypeManagerInterface
+   */
+  protected $entityTypeManager;
+
+  /**
+   * Constructs an AcquiaCmsHeadlessCommands object.
+   *
+   * @param \Drupal\acquia_cms_headless\Service\StarterkitNextjsService $starter_kit
+   *   The next.js starter kit service.
+   * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager
+   *   The entity type manager.
+   */
+  public function __construct(StarterkitNextjsService $starter_kit, EntityTypeManagerInterface $entity_type_manager) {
+    $this->starterKit = $starter_kit;
+    $this->entityTypeManager = $entity_type_manager;
+  }
+
+  /**
+   * Sets up a next.js app backend.
+   *
+   * @option site-url
+   *   The base URl of the site.
+   * @option site-name
+   *   The site name for setting up.
+   * @option env-file
+   *   The file where the generated environment variables should be written.
+   * @usage acms:headless:new-nextjs  --site-url='http://localhost:3000' --site-name='Headless site'
+   *   Initializes a next.js app backend.
+   *
+   * @command acms:headless:new-nextjs
+   */
+  public function acmsHeadlessNewNextjs(array $options = [
+    'site-url' => NULL,
+    'site-name' => NULL,
+    'env-file' => NULL,
+  ]): void {
+    $existing_sites = $this->entityTypeManager->getStorage('next_site')->loadMultiple();
+    $site_id = $this->getSiteMachineName($options['site-name']);
+    $data = [
+      'site-name' => $options['site-name'],
+      'site-url' => $options['site-url'],
+    ];
+    // Check if there's no Next.js site available.
+    if (empty($existing_sites)) {
+      $site = $this->starterKit->initStarterkitNextjs($site_id, $data);
+    }
+    // Let's create the one requested.
+    else {
+      // Create a new Next.js Consumer.
+      $this->starterKit->createHeadlessConsumer($data);
+      // Create a new Next.js Site.
+      $site = $this->starterKit->createHeadlessSite($site_id, $data);
+      // Create a set of Next.js Entity types based on available Node Types.
+      $this->starterKit->createHeadlessSiteEntities();
+    }
+    $env = $this->starterKit->getEnvironmentVariablesAsString($site);
+    if ($options['env-file']) {
+      $file = realpath($options['env-file']);
+
+      file_put_contents($file, $env);
+      $this->logger()->success("Environment variables were written to $file.");
+    }
+    $this->logger()->info($env);
+  }
+
+  /**
+   * Hook validates for acms:headless:new-nextjs command.
+   *
+   * @hook validate acms:headless:new-nextjs
+   */
+  public function validateAcmsHeadlessNewNextJs(CommandData $commandData) {
+    $options = $commandData->input()->getOptions();
+    $messages = [];
+    if (!isset($options['site-url'])) {
+      $messages[] = dt("Missing required parameter site URL.");
+    }
+    if (!isset($options['site-name'])) {
+      $messages[] = dt("Missing required parameter site name.");
+    }
+    if (isset($options['site-url']) && isset($options['site-name'])) {
+      $site_machine_name = $this->getSiteMachineName($options['site-name']);
+      if ($this->starterKit->getHeadlessSite($site_machine_name)) {
+        $messages[] = dt("Site with name [@site] already exists!", ['@site' => $options['site-name']]);
+      }
+    }
+    if ($messages) {
+      return new CommandError(implode('\n', $messages));
+    }
+  }
+
+  /**
+   * Get site machine name out of name.
+   *
+   * @param string $site_name
+   *   The site-name.
+   *
+   * @return string
+   *   The site machine name.
+   */
+  private function getSiteMachineName(string $site_name): string {
+    $site_name_lower = strtolower($site_name);
+    $site_machine_name = preg_replace('/[^a-z0-9_]+/', '_', $site_name_lower);
+    return preg_replace('/_+/', '_', $site_machine_name);
+  }
+
+}

--- a/modules/acquia_cms_headless/src/Plugin/AcquiaCmsTour/AcquiaHeadlessForm.php
+++ b/modules/acquia_cms_headless/src/Plugin/AcquiaCmsTour/AcquiaHeadlessForm.php
@@ -189,8 +189,12 @@ class AcquiaHeadlessForm extends AcquiaCmsDashboardBase {
     if ($config_starterkit_nextjs != $acms_starterkit_nextjs) {
       if ($acms_starterkit_nextjs) {
         try {
+          $site_data = [
+            'site-name' => 'Headless Site 1',
+            'site-url' => 'http://localhost:3000',
+          ];
           // Run the Next.js starter kit Initialization service.
-          $this->starterkitNextjsService->initStarterkitNextjs();
+          $this->starterkitNextjsService->initStarterkitNextjs('headless', $site_data);
 
           // Return a message to the user that the set has completed.
           $this->messenger()->addStatus($this->t('Acquia CMS Next.js starter kit has been enabled.'));

--- a/modules/acquia_cms_headless/src/Service/StarterkitNextjsService.php
+++ b/modules/acquia_cms_headless/src/Service/StarterkitNextjsService.php
@@ -144,20 +144,23 @@ class StarterkitNextjsService {
 
   /**
    * Create a new consumer for Headless.
+   *
+   * @param array $consumer_data
+   *   The consumer data.
    */
-  public function createHeadlessConsumer() {
+  public function createHeadlessConsumer(array $consumer_data) {
     try {
-      $consumers = $this->getHeadlessConsumerData();
+      $consumers = $this->getHeadlessConsumerData($consumer_data['site-name']);
       $user = $this->getHeadlessUserData();
 
       if (!empty($user) && empty($consumers)) {
         $this->consumerSecret = $this->createHeadlessSecret();
         $consumer = Consumer::create();
-        $consumer->set('label', 'Headless Site 1');
+        $consumer->set('label', $consumer_data['site-name']);
         $consumer->set('secret', $this->consumerSecret);
         $consumer->set('description', 'This client is provided by the acquia_cms_headless module.');
         $consumer->set('is_default', TRUE);
-        $consumer->set('redirect', 'http://localhost:3000');
+        $consumer->set('redirect', $consumer_data['site-url']);
         $consumer->set('roles', 'headless');
         $consumer->set('user_id', $user->id());
         $consumer->save();
@@ -181,24 +184,32 @@ class StarterkitNextjsService {
   /**
    * Creates a new headless Next.js site entity.
    *
+   * @param string $site_id
+   *   The site id.
+   * @param array $site_data
+   *   The site data.
+   *
+   * @return \Drupal\next\Entity\NextSite
+   *   The Next.js site object.
+   *
+   * @throws \Drupal\Core\Entity\EntityStorageException
    * @throws \Drupal\Component\Plugin\Exception\InvalidPluginDefinitionException
    * @throws \Drupal\Component\Plugin\Exception\PluginNotFoundException
-   * @throws \Drupal\Core\Entity\EntityStorageException
    */
-  public function createHeadlessSite() {
-    $next_site = $this->getHeadlessSite();
+  public function createHeadlessSite(string $site_id, array $site_data) {
+    $next_site = $this->getHeadlessSite($site_id);
     $next_object = $this->entityTypeManager->getStorage('next_site');
     $preview_secret = $this->createHeadlessSecret();
     if (!$next_site) {
       $next_object->create([
-        'id' => 'headless',
-        'label' => 'Headless Site 1',
-        'base_url' => 'http://localhost:3000/',
-        'preview_url' => 'http://localhost:3000/api/preview/',
+        'id' => $site_id,
+        'label' => $site_data['site-name'],
+        'base_url' => $site_data['site-url'],
+        'preview_url' => $site_data['site-url'] . '/api/preview/',
         'preview_secret' => $preview_secret,
       ])->save();
     }
-    return $this->getHeadlessSite();
+    return $this->getHeadlessSite($site_id);
   }
 
   /**
@@ -396,11 +407,11 @@ class StarterkitNextjsService {
    * @throws \Drupal\Component\Plugin\Exception\InvalidPluginDefinitionException
    * @throws \Drupal\Component\Plugin\Exception\PluginNotFoundException
    */
-  public function getHeadlessConsumerData() {
+  public function getHeadlessConsumerData($site_name) {
     $consumerStorage = $this->entityTypeManager->getStorage('consumer');
     $query = $consumerStorage->getQuery();
     $cids = $query
-      ->condition('label', 'Headless Site 1')
+      ->condition('label', $site_name)
       ->range(0, 1)
       ->execute();
     $cid = array_keys($cids);
@@ -432,11 +443,17 @@ class StarterkitNextjsService {
   /**
    * Check to see if our default next.js site exists.
    *
+   * @param string $site_id
+   *   The site id.
+   *
+   * @return \Drupal\Core\Entity\EntityInterface|null
+   *   The next site object or null.
+   *
    * @throws \Drupal\Component\Plugin\Exception\InvalidPluginDefinitionException
    * @throws \Drupal\Component\Plugin\Exception\PluginNotFoundException
    */
-  public function getHeadlessSite() {
-    return $this->entityTypeManager->getStorage('next_site')->load('headless');
+  public function getHeadlessSite(string $site_id) {
+    return $this->entityTypeManager->getStorage('next_site')->load($site_id);
   }
 
   /**
@@ -471,13 +488,21 @@ class StarterkitNextjsService {
   /**
    * A method that initializes the Next.js starter kit.
    *
+   * @param string $site_id
+   *   The site id.
+   * @param array $site_data
+   *   The site data.
+   *
+   * @return \Drupal\next\Entity\NextSite
+   *   The next site object.
+   *
+   * @throws \Drupal\Core\Entity\EntityStorageException
    * @throws \Drupal\Component\Plugin\Exception\InvalidPluginDefinitionException
    * @throws \Drupal\Component\Plugin\Exception\PluginNotFoundException
-   * @throws \Drupal\Core\Entity\EntityStorageException
    * @throws \Drupal\simple_oauth\Service\Exception\ExtensionNotLoadedException
    * @throws \Drupal\simple_oauth\Service\Exception\FilesystemValidationException
    */
-  public function initStarterkitNextjs() {
+  public function initStarterkitNextjs(string $site_id, array $site_data) {
     // Check to see if Headless user still exists, and if not, recreate it.
     $this->createHeadlessUser();
 
@@ -488,32 +513,64 @@ class StarterkitNextjsService {
     $this->updateDefaultConsumer(FALSE);
 
     // Create a new Next.js Consumer.
-    $this->createHeadlessConsumer();
+    $this->createHeadlessConsumer($site_data);
 
     // Create a Next.js Site.
-    $site = $this->createHeadlessSite();
+    $site = $this->createHeadlessSite($site_id, $site_data);
 
     // Create a set of Next.js Entity types based on available Node Types.
     $this->createHeadlessSiteEntities();
 
     // Add User and Consumer UUIDs to headless config.
     $config = $this->configFactory->getEditable('acquia_cms_headless.settings');
-    if (!empty($this->getHeadlessConsumerData())) {
-      $config->set('consumer_uuid', $this->getHeadlessConsumerData()->uuid());
+    if (!empty($this->getHeadlessConsumerData($site_data['site-name']))) {
+      $config->set('consumer_uuid', $this->getHeadlessConsumerData($site_data['site-name'])->uuid());
     }
     if (!empty($this->getHeadlessUserData())) {
       $config->set('user_uuid', $this->getHeadlessUserData()->uuid());
     }
-    $this->buildEnvironmentVariables($site);
+    $this->displayEnvironmentVariables($site);
+    return $site;
+  }
+
+  /**
+   * Displays the Next.js environment variables for the generated NextSite.
+   *
+   * @param \Drupal\next\Entity\NextSite $next_site
+   *   The NextSite to build environment variables for.
+   *
+   * @throws \Drupal\Component\Plugin\Exception\InvalidPluginDefinitionException
+   * @throws \Drupal\Component\Plugin\Exception\PluginNotFoundException
+   */
+  protected function displayEnvironmentVariables(NextSite $next_site) {
+    $this->messenger->addStatus($this->t("Use these environment variables for your Next.js application. Place them in your .env file: <pre class='codesnippet'>@code</pre>", [
+      '@code' => $this->getEnvironmentVariablesAsString($next_site),
+    ]));
+
+    if (!isset($this->consumerSecret)) {
+      $this->messenger->addWarning($this->t("The consumer secret cannot be retrieved. If you do not know this value, you can <a href=':link'>set a new secret</a>.", [
+        ':link' => Url::fromRoute('entity.consumer.edit_form',
+          [
+            'consumer' => $this->getHeadlessConsumerData($next_site->label())->id(),
+            ['destination' => Url::createFromRequest($this->request)->toString()],
+          ])->toString(),
+      ]));
+    }
   }
 
   /**
    * Build the Next.js environment variables for the generated NextSite.
    *
-   * @param Drupal\next\Entity\NextSite $next_site
+   * @param \Drupal\next\Entity\NextSite $next_site
    *   The NextSite to build environment variables for.
+   *
+   * @return string
+   *   The generated environment variables.
+   *
+   * @throws \Drupal\Component\Plugin\Exception\InvalidPluginDefinitionException
+   * @throws \Drupal\Component\Plugin\Exception\PluginNotFoundException
    */
-  protected function buildEnvironmentVariables(NextSite $next_site) {
+  public function getEnvironmentVariablesAsString(NextSite $next_site): string {
     $variables = [
       'NEXT_PUBLIC_DRUPAL_BASE_URL' => $this->request->getSchemeAndHttpHost(),
       'NEXT_IMAGE_DOMAIN' => $this->request->getHost(),
@@ -524,7 +581,7 @@ class StarterkitNextjsService {
     if ($secret = $next_site->getPreviewSecret()) {
       $variables += [
         'DRUPAL_PREVIEW_SECRET' => $secret,
-        'DRUPAL_CLIENT_ID' => $this->getHeadlessConsumerData()->uuid(),
+        'DRUPAL_CLIENT_ID' => $this->getHeadlessConsumerData($next_site->label())->uuid(),
         'DRUPAL_CLIENT_SECRET' => $this->consumerSecret ?? 'insert secret here',
       ];
     }
@@ -535,19 +592,7 @@ class StarterkitNextjsService {
         '@value' => $value,
       ]);
     }
-    $this->messenger->addStatus($this->t("Use these environment variables for your Next.js application. Place them in your .env file: <pre class='codesnippet'>@code</pre>", [
-      '@code' => $code,
-    ]));
-
-    if (!isset($this->consumerSecret)) {
-      $this->messenger->addWarning($this->t("The consumer secret cannot be retrieved. If you do not know this value, you can <a href=':link'>set a new secret</a>.", [
-        ':link' => Url::fromRoute('entity.consumer.edit_form',
-          [
-            'consumer' => $this->getHeadlessConsumerData()->id(),
-          ['destination' => Url::createFromRequest($this->request)->toString()],
-          ])->toString(),
-      ]));
-    }
+    return $code;
   }
 
   /**


### PR DESCRIPTION
**Motivation**
<!-- What problem does this solve? Why is it important? What's the context? If this fixes an issue, link to it above. -->
Fixes #[ACMS-1337](https://backlog.acquia.com/browse/ACMS-1337)

**Proposed changes**
<!-- What does this PR change? How does this impact end users? Are manual or automatic updates required? -->
Create a new drush command with name: drush acms:headless:init having following options:
--site-url: Required.
--site-name: Required.
--env-file: Optional.
Create a new drush command with name: drush acms:headless:regenerate-env having following options/arguments:
--site-url: Optional 
--env-file: Optional.

**Alternatives considered**
<!-- How else could the original issue / use case be addressed? Why did you choose this solution over any others? -->
NA

**Testing steps**
<!-- How can we replicate the issue and verify that this PR fixes it? -->
- vendor/bin/acms site:install --yes --account-pass admin
- vendor/bin/drush en acquia_cms_headless_ui

- vendor/bin/drush acms:headless:new-nextjs  --site-url='http://localhost:3000' --site-name='Headless site one' --env-file='../frontend/.env.local' --uri http://acms.dev.local/

- vendor/bin/drush acms:headless:regenerate-env  --site-url='http://localhost:3000' --env-file='../frontend/.env.local' --uri http://acms.dev.local/

**Merge requirements**
- [ ] _Major change_, _Minor change_, _Bug_, _Enhancement_, and/or _Chore_ label applied
- [ ] Manual testing by a reviewer
