### PR TITLE
ACMS-1359: Visiting headless dashboard page throws error

### DIFF
--- a/modules/acquia_cms_headless/src/Plugin/AcquiaCmsHeadless/AcquiaHeadlessApiDocs.php
+++ b/modules/acquia_cms_headless/src/Plugin/AcquiaCmsHeadless/AcquiaHeadlessApiDocs.php
@@ -2,7 +2,7 @@
 
 namespace Drupal\acquia_cms_headless\Plugin\AcquiaCmsHeadless;
 
-use Drupal\acquia_cms_tour\Form\AcquiaCMSDashboardBase;
+use Drupal\acquia_cms_tour\Form\AcquiaCmsDashboardBase;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Url;
 
@@ -15,7 +15,7 @@ use Drupal\Core\Url;
  *   weight = 2
  * )
  */
-class AcquiaHeadlessApiDocs extends AcquiaCMSDashboardBase {
+class AcquiaHeadlessApiDocs extends AcquiaCmsDashboardBase {
 
   /**
    * Provides module name.

--- a/modules/acquia_cms_headless/src/Plugin/AcquiaCmsHeadless/AcquiaHeadlessApiUrl.php
+++ b/modules/acquia_cms_headless/src/Plugin/AcquiaCmsHeadless/AcquiaHeadlessApiUrl.php
@@ -2,7 +2,7 @@
 
 namespace Drupal\acquia_cms_headless\Plugin\AcquiaCmsHeadless;
 
-use Drupal\acquia_cms_tour\Form\AcquiaCMSDashboardBase;
+use Drupal\acquia_cms_tour\Form\AcquiaCmsDashboardBase;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Url;
 use Symfony\Component\DependencyInjection\ContainerInterface;
@@ -16,7 +16,7 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
  *   weight = 1
  * )
  */
-class AcquiaHeadlessApiUrl extends AcquiaCMSDashboardBase {
+class AcquiaHeadlessApiUrl extends AcquiaCmsDashboardBase {
 
   /**
    * Provides module name.

--- a/modules/acquia_cms_headless/src/Plugin/AcquiaCmsHeadless/HeadlessApiKeys.php
+++ b/modules/acquia_cms_headless/src/Plugin/AcquiaCmsHeadless/HeadlessApiKeys.php
@@ -3,7 +3,7 @@
 namespace Drupal\acquia_cms_headless\Plugin\AcquiaCmsHeadless;
 
 use Drupal\acquia_cms_headless\Service\StarterkitNextjsService;
-use Drupal\acquia_cms_tour\Form\AcquiaCMSDashboardBase;
+use Drupal\acquia_cms_tour\Form\AcquiaCmsDashboardBase;
 use Drupal\Component\Serialization\Json;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Extension\InfoParserInterface;
@@ -24,7 +24,7 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
  *   weight = 4
  * )
  */
-class HeadlessApiKeys extends AcquiaCMSDashboardBase {
+class HeadlessApiKeys extends AcquiaCmsDashboardBase {
   /**
    * The state interface.
    *

--- a/modules/acquia_cms_headless/src/Plugin/AcquiaCmsHeadless/HeadlessApiUsers.php
+++ b/modules/acquia_cms_headless/src/Plugin/AcquiaCmsHeadless/HeadlessApiUsers.php
@@ -3,7 +3,7 @@
 namespace Drupal\acquia_cms_headless\Plugin\AcquiaCmsHeadless;
 
 use Drupal\acquia_cms_headless\Service\StarterkitNextjsService;
-use Drupal\acquia_cms_tour\Form\AcquiaCMSDashboardBase;
+use Drupal\acquia_cms_tour\Form\AcquiaCmsDashboardBase;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Extension\InfoParserInterface;
 use Drupal\Core\Extension\ModuleHandlerInterface;
@@ -23,7 +23,7 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
  *   weight = 6
  * )
  */
-class HeadlessApiUsers extends AcquiaCMSDashboardBase {
+class HeadlessApiUsers extends AcquiaCmsDashboardBase {
   /**
    * The state interface.
    *

--- a/modules/acquia_cms_headless/src/Plugin/AcquiaCmsHeadless/HeadlessNextEntityTypes.php
+++ b/modules/acquia_cms_headless/src/Plugin/AcquiaCmsHeadless/HeadlessNextEntityTypes.php
@@ -3,7 +3,7 @@
 namespace Drupal\acquia_cms_headless\Plugin\AcquiaCmsHeadless;
 
 use Drupal\acquia_cms_headless\Service\StarterkitNextjsService;
-use Drupal\acquia_cms_tour\Form\AcquiaCMSDashboardBase;
+use Drupal\acquia_cms_tour\Form\AcquiaCmsDashboardBase;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Extension\InfoParserInterface;
 use Drupal\Core\Extension\ModuleHandlerInterface;
@@ -23,7 +23,7 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
  *   weight = 5
  * )
  */
-class HeadlessNextEntityTypes extends AcquiaCMSDashboardBase {
+class HeadlessNextEntityTypes extends AcquiaCmsDashboardBase {
   /**
    * The state interface.
    *

--- a/modules/acquia_cms_headless/src/Plugin/AcquiaCmsHeadless/HeadlessNextSites.php
+++ b/modules/acquia_cms_headless/src/Plugin/AcquiaCmsHeadless/HeadlessNextSites.php
@@ -3,7 +3,7 @@
 namespace Drupal\acquia_cms_headless\Plugin\AcquiaCmsHeadless;
 
 use Drupal\acquia_cms_headless\Service\StarterkitNextjsService;
-use Drupal\acquia_cms_tour\Form\AcquiaCMSDashboardBase;
+use Drupal\acquia_cms_tour\Form\AcquiaCmsDashboardBase;
 use Drupal\Component\Serialization\Json;
 use Drupal\Core\Database\Connection;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
@@ -25,7 +25,7 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
  *   weight = 3
  * )
  */
-class HeadlessNextSites extends AcquiaCMSDashboardBase {
+class HeadlessNextSites extends AcquiaCmsDashboardBase {
   /**
    * The state interface.
    *

--- a/modules/acquia_cms_headless/src/Plugin/AcquiaCmsTour/AcquiaHeadlessForm.php
+++ b/modules/acquia_cms_headless/src/Plugin/AcquiaCmsTour/AcquiaHeadlessForm.php
@@ -2,7 +2,7 @@
 
 namespace Drupal\acquia_cms_headless\Plugin\AcquiaCmsTour;
 
-use Drupal\acquia_cms_tour\Form\AcquiaCMSDashboardBase;
+use Drupal\acquia_cms_tour\Form\AcquiaCmsDashboardBase;
 use Drupal\Component\Plugin\Exception\InvalidPluginDefinitionException;
 use Drupal\Component\Plugin\Exception\PluginNotFoundException;
 use Drupal\Core\Entity\EntityStorageException;
@@ -23,7 +23,7 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
  *   weight = 8
  * )
  */
-class AcquiaHeadlessForm extends AcquiaCMSDashboardBase {
+class AcquiaHeadlessForm extends AcquiaCmsDashboardBase {
 
   /**
    * The module installer.

--- a/modules/acquia_cms_search/src/Plugin/AcquiaCmsTour/AcquiaConnectorForm.php
+++ b/modules/acquia_cms_search/src/Plugin/AcquiaCmsTour/AcquiaConnectorForm.php
@@ -2,7 +2,7 @@
 
 namespace Drupal\acquia_cms_search\Plugin\AcquiaCmsTour;
 
-use Drupal\acquia_cms_tour\Form\AcquiaCMSDashboardBase;
+use Drupal\acquia_cms_tour\Form\AcquiaCmsDashboardBase;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Url;
 
@@ -15,7 +15,7 @@ use Drupal\Core\Url;
  *   weight = 7
  * )
  */
-class AcquiaConnectorForm extends AcquiaCMSDashboardBase {
+class AcquiaConnectorForm extends AcquiaCmsDashboardBase {
 
   /**
    * Provides module name.

--- a/modules/acquia_cms_search/src/Plugin/AcquiaCmsTour/AcquiaSearchForm.php
+++ b/modules/acquia_cms_search/src/Plugin/AcquiaCmsTour/AcquiaSearchForm.php
@@ -2,7 +2,7 @@
 
 namespace Drupal\acquia_cms_search\Plugin\AcquiaCmsTour;
 
-use Drupal\acquia_cms_tour\Form\AcquiaCMSDashboardBase;
+use Drupal\acquia_cms_tour\Form\AcquiaCmsDashboardBase;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Url;
 
@@ -15,7 +15,7 @@ use Drupal\Core\Url;
  *   weight = 3
  * )
  */
-class AcquiaSearchForm extends AcquiaCMSDashboardBase {
+class AcquiaSearchForm extends AcquiaCmsDashboardBase {
 
   /**
    * Provides module name.

--- a/modules/acquia_cms_site_studio/src/Plugin/AcquiaCmsTour/SiteStudioCoreForm.php
+++ b/modules/acquia_cms_site_studio/src/Plugin/AcquiaCmsTour/SiteStudioCoreForm.php
@@ -2,7 +2,7 @@
 
 namespace Drupal\acquia_cms_site_studio\Plugin\AcquiaCmsTour;
 
-use Drupal\acquia_cms_tour\Form\AcquiaCMSDashboardBase;
+use Drupal\acquia_cms_tour\Form\AcquiaCmsDashboardBase;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Url;
 
@@ -15,7 +15,7 @@ use Drupal\Core\Url;
  *   weight = 8
  * )
  */
-class SiteStudioCoreForm extends AcquiaCMSDashboardBase {
+class SiteStudioCoreForm extends AcquiaCmsDashboardBase {
 
   /**
    * Provides module name.


### PR DESCRIPTION
**Motivation**
Fixes #ACMS-1359

**Proposed changes**
update reference from AcquiaCMSDashboardBase to AcquiaCmsDashboardBase

**Alternatives considered**
NA

**Testing steps**
- Log in to application as admin
- visit headless dashboard page
- it should not throw error

**Merge requirements**
- [ ] _Major change_, _Minor change_, _Bug_, _Enhancement_, and/or _Chore_ label applied
- [ ] Manual testing by a reviewer
