### PR TITLE
ACMS-1360: Update Site Studio to 6.9.1

### DIFF
--- a/modules/acquia_cms_site_studio/composer.json
+++ b/modules/acquia_cms_site_studio/composer.json
@@ -4,7 +4,7 @@
     "description": "Handles code for Site Studio Installation & Related Configurations.",
     "license": "GPL-2.0-or-later",
     "require": {
-        "acquia/cohesion": "6.9.0",
+        "acquia/cohesion": "6.9.1",
         "acquia/cohesion-theme": "^6.8",
         "drupal/acquia_cms_common": "^1.3.5",
         "drupal/collapsiblock": "^3",


### PR DESCRIPTION
**Motivation**
Fixes #ACMS-1360

**Proposed changes**
Update site studio to 6.9.1

**Alternatives considered**
 PHP Unit test related to site studio i.e. [SiteStudioCoreTest::testSiteStudioCore](https://github.com/acquia/acquia_cms/blob/feature/new-site-studio/modules/acquia_cms_site_studio/tests/src/Functional/SiteStudioCoreTest.php) will fail and taken care in ACMS-1330.

**Testing steps**
- Install site with this branch use `./vendor/bin/acms site:install`
- enable starter module `drush in acquia_cms_starter`
- test everything works fine

**Merge requirements**
- [ ] _Major change_, _Minor change_, _Bug_, _Enhancement_, and/or _Chore_ label applied
- [ ] Manual testing by a reviewer
