### PR TITLE
ACMS-1363: Acquia Solr Search should work out of the box when enabled

### DIFF
--- a/modules/acquia_cms_search/acquia_cms_search.module
+++ b/modules/acquia_cms_search/acquia_cms_search.module
@@ -159,7 +159,7 @@ function acquia_cms_search_search_api_server_update(EntityInterface $entity) {
 /**
  * Implements hook_form_FORM_ID_alter().
  */
-function acquia_cms_search_form_acquia_cms_solr_search_form_alter(array &$form) {
+function acquia_cms_search_form_acquia_cms_search_form_alter(array &$form) {
   $form['#submit'][] = AcquiaSearchFacade::class . '::submitSettingsForm';
 }
 

--- a/modules/acquia_cms_search/src/Facade/AcquiaSearchFacade.php
+++ b/modules/acquia_cms_search/src/Facade/AcquiaSearchFacade.php
@@ -134,12 +134,16 @@ final class AcquiaSearchFacade implements ContainerInjectionInterface {
     // complain mildly about it. Also, it's possible that things might not work
     // as well as they should. To get past that, load the index that ships
     // with Acquia Search Solr and unlink it from the Solr server.
+    // Database server is now idle so disbale the database server.
     $index = $this->indexStorage->load('acquia_search_index');
+    /** @var \Drupal\search_api\ServerInterface $server */
+    $databaseServer = $this->serverStorage->load('database');
     if ($index && $index->getServerId() === $server->id()) {
       $index->setServer(NULL);
 
       try {
         $this->indexStorage->save($index);
+        $databaseServer->disable()->save();
       }
       catch (SolariumException $e) {
         // Look...we're just trying to unlink the index from the server, man.

--- a/modules/acquia_cms_search/src/Plugin/AcquiaCmsTour/AcquiaSearchForm.php
+++ b/modules/acquia_cms_search/src/Plugin/AcquiaCmsTour/AcquiaSearchForm.php
@@ -133,7 +133,9 @@ class AcquiaSearchForm extends AcquiaCmsDashboardBase {
     $solr_api_uuid = $form_state->getValue(['uuid']);
     $this->config('acquia_search.settings')->set('api_host', $solr_api_host)->save(TRUE);
     $this->state->set('acquia_search.identifier', $solr_identifier);
-    $this->state->set('acquia_search.api_key', $solr_api_key);
+    if ($solr_api_key) {
+      $this->state->set('acquia_search.api_key', $solr_api_key);
+    }
     $this->state->set('acquia_search.uuid', $solr_api_uuid);
     $this->setConfigurationState();
     $this->messenger()->addStatus('The configuration options have been saved.');


### PR DESCRIPTION
**Motivation**
Fixes #ACMS-1363

**Proposed changes**
Acquia Solr Search should work out of the box when enabled, and database server should be disabled.

**Alternatives considered**
NA

**Testing steps**
- install site with this code
- login into application as admin
- head towards /admin/tour/dashboard
- click on Acquia Search accordion 
- provide valid input to all fields
- click on save
- head towards /admin/config/search/search-api
- see Acquia Search Solr Index, Database Search Server should be disabled
- head towards /admin/config/search/search-api/index/content
- check index status

**Merge requirements**
- [ ] _Major change_, _Minor change_, _Bug_, _Enhancement_, and/or _Chore_ label applied
- [ ] Manual testing by a reviewer
