### PR TITLE
ACMS-1252: Added the logic to fetch the directory location.

### DIFF
--- a/modules/acquia_cms_headless/README.md
+++ b/modules/acquia_cms_headless/README.md
@@ -17,6 +17,12 @@ npx create-next-app -e https://github.com/acquia/next-acms/tree/main/starters/ba
 
 Once Acquia CMS and ACMS.NEXT library are installed, in your drupal site go to the Extend menu and enable Acquia CMS Headless module. In the top bar menu link select "Tour", which takes you to the "Get Started" page. Click the "Get Started" button. You will see your dashboard. Locate the "Headless" section to reveal two checkbox options: 
 
+* **Add the 'oauth_keys' directory path in approot/sites/default/settings.php** To fetch the public.key & private.key from the mentioned oauth_keys directory. You need to specify the location of the directory in approot settings.php as follows -
+```
+$settings['oauth_keys_directory'] = '../oauth_keys';
+
+```
+Please note that the key name `oauth_keys_directory` should be the same as shown in the example snippet above.
 * **Enable Next.js starter kit** When the Next.js starter kit option is enabled, dependencies related to the Next.js module will be enabled providing users with the ability to use Drupal as a backend for a decoupled NodeJS app while also retaining Drupal’s default front-end. E.g., with a custom theme.
  
 * **Enable Headless mode** When Headless Mode is enabled, it turns on all the capabilities that allows Drupal to be used as a backend for a decoupled Node JS app AND turns off all of Drupal’s front-end features so that the application is purely headless.

--- a/modules/acquia_cms_headless/src/Commands/AcquiaCmsHeadlessCommands.php
+++ b/modules/acquia_cms_headless/src/Commands/AcquiaCmsHeadlessCommands.php
@@ -157,7 +157,7 @@ class AcquiaCmsHeadlessCommands extends DrushCommands {
       }
     }
     if ($messages) {
-      return new CommandError(implode("\n", $messages));
+      return new CommandError(implode(PHP_EOL, $messages));
     }
   }
 
@@ -264,7 +264,7 @@ class AcquiaCmsHeadlessCommands extends DrushCommands {
     }
 
     if ($messages) {
-      return new CommandError(implode("\n", $messages));
+      return new CommandError(implode(PHP_EOL, $messages));
     }
   }
 

--- a/modules/acquia_cms_headless/src/Commands/AcquiaCmsHeadlessCommands.php
+++ b/modules/acquia_cms_headless/src/Commands/AcquiaCmsHeadlessCommands.php
@@ -7,6 +7,7 @@ use Consolidation\AnnotatedCommand\CommandError;
 use Drupal\acquia_cms_headless\Service\StarterkitNextjsService;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\File\FileSystemInterface;
+use Drupal\next\Entity\NextSite;
 use Drupal\simple_oauth\Service\Exception\ExtensionNotLoadedException;
 use Drupal\simple_oauth\Service\Exception\FilesystemValidationException;
 use Drush\Commands\DrushCommands;
@@ -156,7 +157,7 @@ class AcquiaCmsHeadlessCommands extends DrushCommands {
       }
     }
     if ($messages) {
-      return new CommandError(implode('\n', $messages));
+      return new CommandError(implode("\n", $messages));
     }
   }
 

--- a/modules/acquia_cms_headless/src/Plugin/AcquiaCmsTour/AcquiaHeadlessForm.php
+++ b/modules/acquia_cms_headless/src/Plugin/AcquiaCmsTour/AcquiaHeadlessForm.php
@@ -198,9 +198,10 @@ class AcquiaHeadlessForm extends AcquiaCmsDashboardBase {
 
           // Return a message to the user that the set has completed.
           $this->messenger()->addStatus($this->t('Acquia CMS Next.js starter kit has been enabled.'));
+          $this->config('acquia_cms_headless.settings')->set('starterkit_nextjs', $acms_starterkit_nextjs)->save();
         }
         catch (InvalidPluginDefinitionException | PluginNotFoundException | EntityStorageException | ExtensionNotLoadedException | FilesystemValidationException $e) {
-          $this->messenger()->addError($e);
+          $this->messenger()->addError($e->getMessage());
         }
       }
       else {
@@ -229,7 +230,6 @@ class AcquiaHeadlessForm extends AcquiaCmsDashboardBase {
 
     // Proceed with form save and configuration settings actions.
     // Set and save the form values.
-    $this->config('acquia_cms_headless.settings')->set('starterkit_nextjs', $acms_starterkit_nextjs)->save();
     $this->config('acquia_cms_headless.settings')->set('headless_mode', $acms_headless_mode)->save();
 
     // Set the config state.

--- a/modules/acquia_cms_headless/src/Service/StarterkitNextjsService.php
+++ b/modules/acquia_cms_headless/src/Service/StarterkitNextjsService.php
@@ -388,7 +388,10 @@ class StarterkitNextjsService {
   public function generateOauthKeys() {
 
     // Get oauth_keys_directory path from settings.php if available.
-    $dir = Settings::get('oauth_keys_directory', $this->getDefaultOauthKeysDirectory());
+    $dir = Settings::get('oauth_keys_directory');
+    if (!$dir) {
+      $dir = $this->getDefaultOauthKeysDirectory();
+    }
 
     $this->generateOauthKeysDirectory($dir);
     // Generate a public and private oauth key.

--- a/modules/acquia_cms_headless/src/Service/StarterkitNextjsService.php
+++ b/modules/acquia_cms_headless/src/Service/StarterkitNextjsService.php
@@ -12,6 +12,7 @@ use Drupal\Core\File\FileSystemInterface;
 use Drupal\Core\Http\RequestStack;
 use Drupal\Core\Messenger\MessengerInterface;
 use Drupal\Core\Password\DefaultPasswordGenerator;
+use Drupal\Core\Site\Settings;
 use Drupal\Core\StringTranslation\StringTranslationTrait;
 use Drupal\Core\Url;
 use Drupal\next\Entity\NextSite;
@@ -391,6 +392,8 @@ class StarterkitNextjsService {
 
     // Set the base path of the keys directory.
     $dir = "../oauth_keys/$site_path[0]/$site_path[1]";
+    // @todo remove the above mentioned directory fetching code line. //
+    $dir = $this->generateOauthKeysDirectoryUrl();
 
     // Create the directory if it doesn't already exist.
     if (!is_dir($dir)) {
@@ -406,6 +409,25 @@ class StarterkitNextjsService {
       ->set('public_key', "$dir/public.key")
       ->set('private_key', "$dir/private.key")
       ->save();
+  }
+
+  /**
+   * Generates & returns the OAuth keys directory path.
+   *
+   * @throws \Drupal\simple_oauth\Service\Exception\FilesystemValidationException
+   * @throws \Drupal\simple_oauth\Service\Exception\ExtensionNotLoadedException
+   */
+  public function generateOauthKeysDirectoryUrl() {
+    $dirUrl = '';
+    // Pick up the directory path from settings.php.
+    $dirUrl = Settings::get('oauth_keys_directory', '');
+    if (!empty($dirUrl)) {
+      $file_system->prepareDirectory($dirUrl, FileSystemInterface::CREATE_DIRECTORY);
+    }
+    else {
+      // TBD.
+    }
+    return $dirUrl;
   }
 
   /**

--- a/modules/acquia_cms_headless/src/Service/StarterkitNextjsService.php
+++ b/modules/acquia_cms_headless/src/Service/StarterkitNextjsService.php
@@ -20,6 +20,7 @@ use Drupal\next\Entity\NextSite;
 use Drupal\simple_oauth\Service\Exception\FilesystemValidationException;
 use Drupal\simple_oauth\Service\KeyGeneratorService;
 use Drupal\user\Entity\User;
+use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
  * A service for the initialization of the Headless Next.js starter kit.
@@ -388,8 +389,8 @@ class StarterkitNextjsService {
 
     // Get oauth_keys_directory path from settings.php if available.
     $dir = Settings::get('oauth_keys_directory', $this->getDefaultOauthKeysDirectory());
-    $this->generateOauthKeysDirectory($dir);
 
+    $this->generateOauthKeysDirectory($dir);
     // Generate a public and private oauth key.
     $this->keyGeneratorService->generateKeys($dir);
 
@@ -439,13 +440,13 @@ class StarterkitNextjsService {
       $created = $this->fileSystem->prepareDirectory($dir, FileSystemInterface::CREATE_DIRECTORY);
       if (!$created) {
         throw new FilesystemValidationException(
-          strtr('Directory "@path" is not a valid directory.', ['@path' => $dir])
+          strtr("The specified directory '@path' is not properly configured. This may be caused by a problem with directory permissions.", ['@path' => $dir])
         );
       }
     }
     if (is_dir($dir) && !is_writable($dir)) {
       throw new FilesystemValidationException(
-        strtr('Path "@path" is not writable.', ['@path' => $dir])
+        strtr('The specified directory "@path" is not writable.', ['@path' => $dir])
       );
     }
   }
@@ -592,10 +593,10 @@ class StarterkitNextjsService {
    * @throws \Drupal\Core\Entity\EntityStorageException
    * @throws \Drupal\Component\Plugin\Exception\InvalidPluginDefinitionException
    * @throws \Drupal\Component\Plugin\Exception\PluginNotFoundException
-   * @throws \Drupal\simple_oauth\Service\Exception\ExtensionNotLoadedException
-   * @throws \Drupal\simple_oauth\Service\Exception\FilesystemValidationException
+   * @throws \Drupal\simple_oauth\Service\Exception\ExtensionNotLoadedException|FilesystemValidationException
    */
   public function initStarterkitNextjs(string $site_id, array $site_data) {
+
     // Check to see if Headless user still exists, and if not, recreate it.
     $this->createHeadlessUser();
 


### PR DESCRIPTION
### WORK IN PROGRESS

We are aiming to achieve the following - 

* Check if the oauth_keys directory path is set in Settings.php file of the project. If set, then accept that path as it is.
* Also add instructions for setting the directory path in settings.php in the README.md file of acquia_cms_headless module.
* Check if directory at path provided in settings.php file is writable or not, if not - then log the error using Drupal logger
* Check if file already exist in the above mentioned path, then overwrite if already exists.
* If path does is not mentioned in settings.php & also the environment in not the Acquia Environment then pick up path already mentioned in StarterkitNextjsService.php file line no. 393 
{noformat}
    $dir = "../oauth_keys/$site_path[0]/$site_path[1]";
{noformat}
* Lastly, If environment is an Acquia Environment then create/use nobackup path.

**Motivation**
Fixes #NNN

**Proposed changes**
<!-- What does this PR change? How does this impact end users? Are manual or automatic updates required? -->

**Alternatives considered**
<!-- How else could the original issue / use case be addressed? Why did you choose this solution over any others? -->

**Testing steps**
<!-- How can we replicate the issue and verify that this PR fixes it? -->

**Merge requirements**
- [ ] _Major change_, _Minor change_, _Bug_, _Enhancement_, and/or _Chore_ label applied
- [ ] Manual testing by a reviewer
