### PR TITLE
ACMS-1368: Auto checking the checkbox for enable nextjs starterkit.

### DIFF
--- a/modules/acquia_cms_headless/src/Plugin/AcquiaCmsTour/AcquiaHeadlessForm.php
+++ b/modules/acquia_cms_headless/src/Plugin/AcquiaCmsTour/AcquiaHeadlessForm.php
@@ -91,6 +91,13 @@ class AcquiaHeadlessForm extends AcquiaCmsDashboardBase {
           '#suffix' => "</span>",
         ];
       }
+
+      // Get label for nextjs.
+      $next_js_label = $this->starterkitNextjsService->getHeadlessConsumerData()->label();
+      // Label of nextjs site should not be default consumer and
+      // store the value in bool.
+      $is_next_js = ($next_js_label != 'Default Consumer') ? TRUE : FALSE;
+
       $form[$module] = [
         '#type' => 'details',
         '#title' => $this->t('Headless'),
@@ -106,7 +113,8 @@ class AcquiaHeadlessForm extends AcquiaCmsDashboardBase {
           dependencies related to the Next.js module will be enabled and a default
           configuration will be initialized to ready Drupal to be connected with
           a next.js application.'),
-        '#default_value' => (bool) $config->get('starterkit_nextjs'),
+        '#disabled' => $is_next_js,
+        '#default_value' => $is_next_js,
         '#prefix' => '<div class= "dashboard-fields-wrapper">' . $module_info['description'],
       ];
       $form[$module]['headless_mode'] = [
@@ -202,9 +210,6 @@ class AcquiaHeadlessForm extends AcquiaCmsDashboardBase {
         catch (InvalidPluginDefinitionException | PluginNotFoundException | EntityStorageException | ExtensionNotLoadedException | FilesystemValidationException $e) {
           $this->messenger()->addError($e);
         }
-      }
-      else {
-        $this->messenger()->addStatus($this->t('Acquia CMS Next.js starter kit has been disabled.'));
       }
     }
 

--- a/modules/acquia_cms_headless/src/Service/StarterkitNextjsService.php
+++ b/modules/acquia_cms_headless/src/Service/StarterkitNextjsService.php
@@ -411,19 +411,22 @@ class StarterkitNextjsService {
   /**
    * A function that obtains our init headless consumer data.
    *
+   * @param string $site_name
+   *   Site label.
+   *
    * @return \Drupal\Core\Entity\EntityInterface|null
    *   Returns a consumer object or a NULL response.
    *
    * @throws \Drupal\Component\Plugin\Exception\InvalidPluginDefinitionException
    * @throws \Drupal\Component\Plugin\Exception\PluginNotFoundException
    */
-  public function getHeadlessConsumerData($site_name) {
+  public function getHeadlessConsumerData(string $site_name = NULL): ?object {
     $consumerStorage = $this->entityTypeManager->getStorage('consumer');
     $query = $consumerStorage->getQuery();
-    $cids = $query
-      ->condition('label', $site_name)
-      ->range(0, 1)
-      ->execute();
+    if ($site_name) {
+      $query->condition('label', $site_name);
+    }
+    $cids = $query->range(0, 1)->execute();
     $cid = array_keys($cids);
 
     return !empty($cid) ? $consumerStorage->load($cid[0]) : NULL;


### PR DESCRIPTION
**Motivation**
<!-- What problem does this solve? Why is it important? What's the context? If this fixes an issue, link to it above. -->
Fixes #ACMS-1368

**Proposed changes**
Check the checkbox if nextjs starterkit installed.

**Testing steps**
Install headless starterkit opt for nextjs via CLI, drush and UI

**Merge requirements**
- [ ] _Major change_, _Minor change_, _Bug_, _Enhancement_, and/or _Chore_ label applied
- [ ] Manual testing by a reviewer
