### PR TITLE
ACMS-1378: Added code to enable syslog module on IDE env.

### DIFF
--- a/modules/acquia_cms_common/acquia_cms_common.install
+++ b/modules/acquia_cms_common/acquia_cms_common.install
@@ -75,6 +75,10 @@ function acquia_cms_common_install() {
     $config = \Drupal::service('purge.purgers');
     $config->setPluginsEnabled(['cee22bc3fe' => 'acquia_purge']);
   }
+
+  // Install the syslog module.
+  $module_installer = \Drupal::service('module_installer');
+  $module_installer->install(['syslog']);
 }
 
 /**

--- a/modules/acquia_cms_common/src/Services/ToggleModulesService.php
+++ b/modules/acquia_cms_common/src/Services/ToggleModulesService.php
@@ -13,17 +13,16 @@ class ToggleModulesService {
    * Toggle module based on environment.
    */
   public function toggleModules() {
-    $is_dev = Environment::isLocalEnv();
+    $is_dev = Environment::isAhIdeEnv() || Environment::isLocalEnv();
     $is_prod = Environment::isAhProdEnv();
     $module_installer = \Drupal::service('module_installer');
-    $to_install = [];
     $to_uninstall = [];
     if ($is_dev) {
       array_push($to_install, 'dblog', 'jsonapi_extras', 'field_ui', 'views_ui');
-      array_push($to_uninstall, 'syslog', 'autologout');
+      array_push($to_uninstall, 'autologout');
     }
     else {
-      array_push($to_install, 'syslog', 'autologout');
+      array_push($to_install, 'autologout');
     }
     if (!$is_prod) {
       array_push($to_install, 'reroute_email');

--- a/modules/acquia_cms_common/src/Services/ToggleModulesService.php
+++ b/modules/acquia_cms_common/src/Services/ToggleModulesService.php
@@ -13,7 +13,7 @@ class ToggleModulesService {
    * Toggle module based on environment.
    */
   public function toggleModules() {
-    $is_dev = Environment::isAhIdeEnv() || Environment::isLocalEnv();
+    $is_dev = Environment::isLocalEnv();
     $is_prod = Environment::isAhProdEnv();
     $module_installer = \Drupal::service('module_installer');
     $to_install = [];


### PR DESCRIPTION
**Motivation**
* Syslog Module should be enabled based on different environments.
Fixes #NNN

**Proposed changes**
* Managed the conditions for enabling the syslog module on different environments.

**Alternatives considered**
* None

**Testing steps**
* Install site using command - `vendor/bin/drush site:install minimal --account-pass admin -vvv`
* Once the site is installed, run the command - `vendor/bin/drush acms:toggle:modules` and verify that syslog module is enabled / disabled according to the criteria mentioned in the [ticket](https://backlog.acquia.com/browse/ACMS-1378).

Test 2
* Install site using `vendor/bin/acms acms:install` command.
* Visit site & notice that syslog module enablement/disablement is handled on it's own according to the environment installed on.

**Merge requirements**
- [ ] _Major change_, _Minor change_, _Bug_, _Enhancement_, and/or _Chore_ label applied
- [ ] Manual testing by a reviewer
