### PR TITLE
ACMS-1218: Updated the pathauto settings for default frontpage.

### DIFF
--- a/modules/acquia_cms_starter/modules/acquia_cms_site_studio_content/content/node/d513a098-2322-4f8a-b61f-58d986cd4197.yml
+++ b/modules/acquia_cms_starter/modules/acquia_cms_site_studio_content/content/node/d513a098-2322-4f8a-b61f-58d986cd4197.yml
@@ -39,7 +39,7 @@ default:
     -
       alias: /home-sitestudio
       langcode: en
-      pathauto: 1
+      pathauto: 0
   publish_state:
     -
       value: _none


### PR DESCRIPTION
**Motivation**
* The home page default is not working for low code starter kit installation
Fixes #NNN

**Proposed changes**
* Fixed the home page for low code installation.

**Alternatives considered**
* None

**Testing steps**
* Install site using starterkit - low code, community or headless and notice that home page shows up correctly for all three starter kits.

**Merge requirements**
- [ ] _Major change_, _Minor change_, _Bug_, _Enhancement_, and/or _Chore_ label applied
- [ ] Manual testing by a reviewer
