### PR TITLE
ACMS-1393: Added the required php generator password file.

### DIFF
--- a/modules/acquia_cms_common/src/Traits/PasswordGeneratorTrait.php
+++ b/modules/acquia_cms_common/src/Traits/PasswordGeneratorTrait.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace Drupal\acquia_cms_common\Traits;
+
+/**
+ * Provides helpers to generate random password.
+ */
+trait PasswordGeneratorTrait {
+
+  /**
+   * Generates the password based upon certain required conditions.
+   *
+   * @param int $length
+   *   Parameter that accepts the length of the password.
+   *
+   * @return string
+   *   Returns the shuffled string password.
+   */
+  public static function generateRandomPassword(int $length = 12): string {
+    // Define the character libraries.
+    $sets = [];
+    $sets[] = 'ABCDEFGHJKLMNPQRSTUVWXYZ';
+    $sets[] = 'abcdefghjkmnpqrstuvwxyz';
+    $sets[] = '0123456789';
+    $sets[] = '~!@#$%^&*(){}[],./?';
+    $password = '';
+
+    // Enforce the minimum length  of the password to be 12.
+    if ($length < 12) {
+      $length = 12;
+    }
+
+    // Append a character from each set - gets first 4 characters.
+    foreach ($sets as $set) {
+      $password .= $set[array_rand(str_split($set))];
+    }
+
+    // Use all characters to fill up to $length.
+    while (strlen($password) < $length) {
+      // Get a random set.
+      $randomSet = $sets[array_rand($sets)];
+      // Add a random char from the random set.
+      $password .= $randomSet[array_rand(str_split($randomSet))];
+    }
+
+    // Shuffle the password string before returning.
+    return str_shuffle($password);
+  }
+
+}

--- a/modules/acquia_cms_headless/src/Service/StarterkitNextjsService.php
+++ b/modules/acquia_cms_headless/src/Service/StarterkitNextjsService.php
@@ -3,6 +3,7 @@
 namespace Drupal\acquia_cms_headless\Service;
 
 use Acquia\DrupalEnvironmentDetector\AcquiaDrupalEnvironmentDetector;
+use Drupal\acquia_cms_common\Traits\PasswordGeneratorTrait;
 use Drupal\Component\Plugin\Exception\InvalidPluginDefinitionException;
 use Drupal\Component\Plugin\Exception\PluginNotFoundException;
 use Drupal\consumers\Entity\Consumer;
@@ -30,6 +31,7 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
  */
 class StarterkitNextjsService {
   use StringTranslationTrait;
+  use PasswordGeneratorTrait;
 
   /**
    * The config factory.
@@ -192,7 +194,7 @@ class StarterkitNextjsService {
    *   Returns a 21 character secret key string.
    */
   public function createHeadlessSecret(): string {
-    return $this->defaultPasswordGenerator->generate(21);
+    return PasswordGeneratorTrait::generateRandomPassword(12);
   }
 
   /**


### PR DESCRIPTION
**Motivation**
* Updated the password generation for Headless Consumer & Preview Secret
Fixes #NNN

**Proposed changes**
* Updated the password generation for Headless Consumer & Preview Secret
* Associated PR - https://github.com/acquia/acquia-cms-starterkit/pull/58

**Alternatives considered**
* None

**Testing steps**
* Run site install using acquia_cms_headless installation and notice that consumer & preview secret are password compliant.

**Merge requirements**
- [ ] _Major change_, _Minor change_, _Bug_, _Enhancement_, and/or _Chore_ label applied
- [ ] Manual testing by a reviewer

**Example Screenshot**
<img width="402" alt="Screenshot 2022-09-16 at 10 18 31 AM" src="https://user-images.githubusercontent.com/15887127/190558789-c23068f9-70f8-4b29-9db5-4ea25dc4c024.png">

