### PR TITLE
ACMS-1380: Removed node_revision_delete config from node.type.page

### DIFF
--- a/modules/acquia_cms_page/acquia_cms_page.install
+++ b/modules/acquia_cms_page/acquia_cms_page.install
@@ -5,8 +5,25 @@
  * Install, update and uninstall functions for the acquia_cms_page module.
  */
 
-use Drupal\user\RoleInterface;
 use Drupal\node\Entity\NodeType;
+use Drupal\user\RoleInterface;
+
+/**
+ * Implements hook_install().
+ */
+function acquia_cms_page_install() {
+  // Set default node revision delete configuration for Page content type.
+  $moduleHandler = \Drupal::service('module_handler');
+  if ($moduleHandler->moduleExists('node_revision_delete')) {
+    $type = NodeType::load('page');
+    if ($type) {
+      $type->setThirdPartySetting('node_revision_delete', 'minimum_revisions_to_keep', '30');
+      $type->setThirdPartySetting('node_revision_delete', 'minimum_age_to_delete', '0');
+      $type->setThirdPartySetting('node_revision_delete', 'when_to_delete', '0');
+      $type->save();
+    }
+  }
+}
 
 /**
  * Implements hook_content_model_role_presave_alter().

--- a/modules/acquia_cms_page/acquia_cms_page.install
+++ b/modules/acquia_cms_page/acquia_cms_page.install
@@ -6,6 +6,7 @@
  */
 
 use Drupal\user\RoleInterface;
+use Drupal\node\Entity\NodeType;
 
 /**
  * Implements hook_content_model_role_presave_alter().
@@ -55,6 +56,27 @@ function acquia_cms_page_update_8001() {
         $pattern_config->set("selection_criteria.$uuid.id", 'entity_bundle:node');
         $pattern_config->save();
         break;
+      }
+    }
+  }
+}
+
+/**
+ * Remove Page:Node Revision Delete settings if site studio is not installed.
+ */
+function acquia_cms_page_update_8002() {
+  $moduleHandler = \Drupal::service('module_handler');
+  if (!$moduleHandler->moduleExists('node_revision_delete')) {
+    $node = NodeType::load('page');
+    if ($node) {
+      // Getting the config file.
+      $third_party_settings = $node->get('third_party_settings');
+      // Checking if the config exists.
+      if (isset($third_party_settings['node_revision_delete'])) {
+        // Deleting the value from the array.
+        unset($third_party_settings['node_revision_delete']);
+        // Saving the values in the config.
+        $node->set('third_party_settings', $third_party_settings)->save();
       }
     }
   }

--- a/modules/acquia_cms_page/config/optional/node.type.page.yml
+++ b/modules/acquia_cms_page/config/optional/node.type.page.yml
@@ -37,10 +37,6 @@ third_party_settings:
     unpublish_enable: true
     unpublish_required: false
     unpublish_revision: false
-  node_revision_delete:
-    minimum_revisions_to_keep: 30
-    minimum_age_to_delete: 0
-    when_to_delete: 0
 name: Page
 type: page
 description: 'An unstructured content type that provides unique landing pages - e.g., a homepage, or marketing event landing page.'

--- a/modules/acquia_cms_site_studio/acquia_cms_site_studio.install
+++ b/modules/acquia_cms_site_studio/acquia_cms_site_studio.install
@@ -84,6 +84,19 @@ function acquia_cms_site_studio_install() {
       ->save();
   }
 
+  // Set default node revision delete configuration for Page content type.
+  $moduleHandler = \Drupal::service('module_handler');
+  if ($moduleHandler->moduleExists('acquia_cms_page')) {
+    $type = NodeType::load('page');
+    $third_party_settings = $type->get('third_party_settings');
+    if ($type && !isset($third_party_settings['node_revision_delete'])) {
+      $type->setThirdPartySetting('node_revision_delete', 'minimum_revisions_to_keep', '30');
+      $type->setThirdPartySetting('node_revision_delete', 'minimum_age_to_delete', '0');
+      $type->setThirdPartySetting('node_revision_delete', 'when_to_delete', '0');
+      $type->save();
+    }
+  }
+
   // Re-write the editor and filter format config from
   // optional directory since we have don some update to it.
   $module_path = \Drupal::moduleHandler()->getModule('acquia_cms_site_studio')->getPath();

--- a/modules/acquia_cms_site_studio/acquia_cms_site_studio.module
+++ b/modules/acquia_cms_site_studio/acquia_cms_site_studio.module
@@ -14,7 +14,6 @@ use Drupal\cohesion_website_settings\Controller\WebsiteSettingsController;
 use Drupal\Core\Ajax\CloseDialogCommand;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\media_library\MediaLibraryState;
-use Drupal\node\Entity\NodeType;
 use Drupal\user\RoleInterface;
 use Symfony\Component\HttpFoundation\Request;
 

--- a/modules/acquia_cms_site_studio/acquia_cms_site_studio.module
+++ b/modules/acquia_cms_site_studio/acquia_cms_site_studio.module
@@ -14,6 +14,7 @@ use Drupal\cohesion_website_settings\Controller\WebsiteSettingsController;
 use Drupal\Core\Ajax\CloseDialogCommand;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\media_library\MediaLibraryState;
+use Drupal\node\Entity\NodeType;
 use Drupal\user\RoleInterface;
 use Symfony\Component\HttpFoundation\Request;
 


### PR DESCRIPTION
**Motivation**
Fixes #ACMS-1380

**Proposed changes**
- Remove node_revision_delete config from acquia_cms_page/config/optional/node.type.page.yml
- Add update hook to remove node_revision_delete config from node.type.page

**Alternatives considered**
NA

**Testing steps**
**New site:**
- Install site with this branch
- Install acquia_cms_page, node_revision_delete config shouldn't be there 
- Install acquia_cms_site_studio, node_revision_delete third party config must be available
- Follow 2 and 3 in reverse manner with new install
- Verify site working fine

**Existing site:**
- Upgrade codebase this branch
- Execute `drush updb`
- Now execute `drush cex` so node_revision_delete does not exist in your exported configs
- Now execute `drush cim`
- Verify site working fine

**Merge requirements**
- [ ] _Major change_, _Minor change_, _Bug_, _Enhancement_, and/or _Chore_ label applied
- [ ] Manual testing by a reviewer
