### PR TITLE
ACMS-1408: Added access check for content to show preview link.

### DIFF
--- a/modules/acquia_cms_headless/acquia_cms_headless.services.yml
+++ b/modules/acquia_cms_headless/acquia_cms_headless.services.yml
@@ -13,3 +13,12 @@ services:
   plugin.manager.acquia_cms_headless:
     class: Drupal\acquia_cms_headless\AcquiaCmsHeadlessManager
     parent: default_plugin_manager
+  acquia_cms_headless.preview_link_route_subscriber:
+    class: 'Drupal\acquia_cms_headless\Routing\PreviewLinkRouteSubscriber'
+    tags:
+      - { name: event_subscriber }  
+  acquia_cms_headless.preview_link_access:
+    class: Drupal\acquia_cms_headless\Access\PreviewLinkAccessCheck
+    arguments: ['@current_user']
+    tags:
+      - { name: access_check, applies_to: _preview_link_access_check }

--- a/modules/acquia_cms_headless/src/Access/PreviewLinkAccessCheck.php
+++ b/modules/acquia_cms_headless/src/Access/PreviewLinkAccessCheck.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Drupal\acquia_cms_headless\Access;
+
+use Drupal\Core\Access\AccessResult;
+use Drupal\Core\Routing\Access\AccessInterface;
+use Drupal\Core\Session\AccountInterface;
+use Drupal\node\Entity\Node;
+
+/**
+ * Determines access to for block add pages.
+ */
+class PreviewLinkAccessCheck implements AccessInterface {
+
+  /**
+   * Checks access to the block add page for the block type.
+   */
+  public function access(AccountInterface $account, Node $node) {
+    // These permissions will be checked for the access to the preview link.
+    $nodeType = $node->bundle();
+    $permissions = [
+      "create $nodeType content",
+      "edit own $nodeType content",
+      "edit any $nodeType content",
+    ];
+    return AccessResult::allowedIfHasPermissions($account, $permissions, 'OR');
+  }
+
+}

--- a/modules/acquia_cms_headless/src/Routing/PreviewLinkRouteSubscriber.php
+++ b/modules/acquia_cms_headless/src/Routing/PreviewLinkRouteSubscriber.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Drupal\acquia_cms_headless\Routing;
+
+use Drupal\Core\Routing\RouteSubscriberBase;
+use Symfony\Component\Routing\RouteCollection;
+
+/**
+ * Class to alter the route controller.
+ */
+class PreviewLinkRouteSubscriber extends RouteSubscriberBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function alterRoutes(RouteCollection $collection) {
+    // Add the requirement to access the link preview.
+    if ($route = $collection->get("entity.node.headless_preview")) {
+      $route->setRequirements([
+        '_preview_link_access_check' => 'TRUE',
+      ]);
+    }
+  }
+
+}


### PR DESCRIPTION
**Motivation**
* The preview button shows up for the anonymous user as well. It should only show up for authenticated user (logged in) who have access to content edit or update or create.
Fixes #[ACMS-1408](https://backlog.acquia.com/browse/ACMS-1408)

**Proposed changes**
* The preview button shows up for the anonymous user as well. It should only show up for authenticated user (logged in) who have access to content edit or update or create.

**Alternatives considered**
* None

**Testing steps**
* Install the acquia_cms_headless starter kit and access the site as anonymous user.
* Notice that the "Preview" link is no longer accessible.

**Merge requirements**
- [ ] _Major change_, _Minor change_, _Bug_, _Enhancement_, and/or _Chore_ label applied
- [ ] Manual testing by a reviewer
