### PR TITLE
ACMS-1453: Update logic to assign all roles to headless user after role refactor.

### DIFF
--- a/modules/acquia_cms_headless/acquia_cms_headless.module
+++ b/modules/acquia_cms_headless/acquia_cms_headless.module
@@ -5,6 +5,24 @@
  * Contains hook implementations for the acquia_cms_headless module.
  */
 
+use Drupal\user\RoleInterface;
+
+/**
+* Implements hook_content_model_role_presave_alter().
+*/
+function acquia_cms_headless_content_model_role_presave_alter(RoleInterface &$role) {
+  $role_id = $role->id();
+  switch ($role->id()) {
+    case 'content_administrator':
+    case 'content_author':
+    case 'content_editor':
+      $user = user_load_by_name('headless');
+      $user->addRole($role_id);
+      $user->save();
+      break;
+  }
+}
+
 /**
  * Implements hook_field_formatter_info_alter().
  */


### PR DESCRIPTION
**Motivation**
Fixes #ACMS-1453

**Proposed changes**
Updated logic to assign all roles to headless user after role refactor.

**Alternatives considered**
NA

**Testing steps**
- Install site with this branch
- Enable below module combination for testing
-- acquia_cms_headless
-- acquia_cms_headless then acquia_cms_starter or any content model module
-- acquia_cms_starter or any content model module then acquia_cms_headless
- Enable pure headless mode 
- Head towards /admin/tour/dashboard
- Click on Headless
- Check Enable headless mode
- Click on save
- Head towards /admin/access/users
- Verify all roles assigned to Headless user

**Merge requirements**
- [ ] _Major change_, _Minor change_, _Bug_, _Enhancement_, and/or _Chore_ label applied
- [ ] Manual testing by a reviewer
