### PR TITLE
ACMS-1454: Resolve headless mode switcher for pure headless.

### DIFF
--- a/modules/acquia_cms_headless/modules/acquia_cms_headless_ui/src/Service/PureHeadlessModeInstallHandler.php
+++ b/modules/acquia_cms_headless/modules/acquia_cms_headless_ui/src/Service/PureHeadlessModeInstallHandler.php
@@ -215,6 +215,12 @@ class PureHeadlessModeInstallHandler {
         ->getEditable('views.view.content')
         ->set('display.default.display_options.fields.title.settings.link_to_entity', FALSE)
         ->save();
+
+      $this->configFactory
+        ->getEditable('acquia_cms_headless.settings')
+        ->set('headless_mode', TRUE)
+        ->save();
+
     }
     else {
       // Update 403 and Frontpage values in Site Settings.
@@ -237,6 +243,11 @@ class PureHeadlessModeInstallHandler {
       $this->configFactory
         ->getEditable('views.view.content')
         ->set('display.default.display_options.fields.title.settings.link_to_entity', TRUE)
+        ->save();
+
+      $this->configFactory
+        ->getEditable('acquia_cms_headless.settings')
+        ->set('headless_mode', FALSE)
         ->save();
     }
   }


### PR DESCRIPTION
**Motivation**
<!-- What problem does this solve? Why is it important? What's the context? If this fixes an issue, link to it above. -->
Fixes #ACMS-1454

**Proposed changes**

- Nextjs twice consumer data from tour dashboard should not new nextjs if checkbox is already checked.
- Pure headless mode switcher should be checked if only acquia_cms_headless_ui is installed & enabled.


**Testing steps**

- install headless + nextjs
- Install healdess+demo content
- Enable nextJs starter kit via tour dashboard
- Enable Headless mode from tour dashboard.


