### PR TITLE
ACMS-1470: Add Acquia CMS Image and Video dependency in Acquia CMS DAM.

### DIFF
--- a/modules/acquia_cms_dam/acquia_cms_dam.info.yml
+++ b/modules/acquia_cms_dam/acquia_cms_dam.info.yml
@@ -4,6 +4,7 @@ description: 'Provides an Acquia DAM related configuration.'
 type: module
 core_version_requirement: ^9 || ^10
 dependencies:
-  - drupal:acquia_cms_common
+  - drupal:acquia_cms_image
+  - drupal:acquia_cms_video
   - drupal:acquia_dam
   - acquia_dam:acquia_dam_integration_links

--- a/modules/acquia_cms_dam/composer.json
+++ b/modules/acquia_cms_dam/composer.json
@@ -4,7 +4,8 @@
     "description": "Provides an Acquia DAM related configuration.",
     "license": "GPL-2.0-or-later",
     "require": {
-        "drupal/acquia_cms_common": "^1.5",
+        "drupal/acquia_cms_image": "^1.4",
+        "drupal/acquia_cms_video": "^1.4",
         "drupal/acquia_dam": "^1"
     },
     "config": {


### PR DESCRIPTION
**Motivation**
Fixes #ACMS-1470

**Proposed changes**
Require and install ACMS image and video module when installing ACMS DAM

**Alternatives considered**
NA

**Testing steps**
- Checkout this branch
- Execute composer update
- Verify acquia_cms_image and acquia_cms_video modules are downloaded
- Execute drush in acquia_cms_dam -y
- Verify acquia_cms_image, acquia_cms_video modules installed
- Verify site working fine.

**Merge requirements**
- [ ] _Major change_, _Minor change_, _Bug_, _Enhancement_, and/or _Chore_ label applied
- [ ] Manual testing by a reviewer
