### PR TITLE
ACMS-1496: Drush site:install break on acquia_cms:1.5.2 with settings…

### DIFF
--- a/acquia_cms.profile
+++ b/acquia_cms.profile
@@ -203,6 +203,18 @@ function acquia_cms_modules_uninstalled(array $modules) {
 }
 
 /**
+ * Implements hook_module_implements_alter().
+ */
+function acquia_cms_module_implements_alter(array &$implementations) : void {
+
+  // Prevent installation of site studio package on module install
+  // during site installation from other modules, this causes issue.
+  if (InstallerKernel::installationAttempted()) {
+    unset($implementations['cohesion_sync']);
+  }
+}
+
+/**
  * Method that calls another method to capture the installation end time.
  */
 function install_acms_finished() {


### PR DESCRIPTION
… override for SS key.

**Motivation**
<!-- What problem does this solve? Why is it important? What's the context? If this fixes an issue, link to it above. -->
Fixes #[ACMS-1496](https://backlog.acquia.com/browse/ACMS-1496)

**Proposed changes**
<!-- What does this PR change? How does this impact end users? Are manual or automatic updates required? -->
Unset cohesion_sync module implementation for module installed hook.

**Alternatives considered**
<!-- How else could the original issue / use case be addressed? Why did you choose this solution over any others? -->
Use environment variables for site studio keys:
`
export SITESTUDIO_API_KEY=<api-key>
export SITESTUDIO_ORG_KEY=<org-key>
`
**Testing steps**
<!-- How can we replicate the issue and verify that this PR fixes it? -->

**Merge requirements**
- [_Bug_] _Major change_, _Minor change_, _Bug_, _Enhancement_, and/or _Chore_ label applied
- [ ] Manual testing by a reviewer
