### PR TITLE
ACMS-1496: Drush site:install break on acquia_cms:1.5.2 with settings…

### DIFF
--- a/modules/acquia_cms_common/acquia_cms_common.module
+++ b/modules/acquia_cms_common/acquia_cms_common.module
@@ -13,6 +13,7 @@ use Drupal\acquia_cms_common\Facade\WorkbenchEmailFacade;
 use Drupal\acquia_cms_common\Facade\WorkflowFacade;
 use Drupal\Core\Breadcrumb\Breadcrumb;
 use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\Installer\InstallerKernel;
 use Drupal\Core\Routing\RouteMatchInterface;
 use Drupal\Core\Url;
 use Drupal\imce\Imce;
@@ -416,9 +417,13 @@ function acquia_cms_common_modules_installed($modules, $is_syncing) {
         }
       }
     }
+
+    // Prevent installation of site studio package on module install
+    // during site installation from other modules, this causes issue.
     $configFactory = \Drupal::service('config.factory');
     $config = $configFactory->get('cohesion.settings');
-    if ($config->get('api_key') && $config->get('organization_key')) {
+    $cohesion_configured = $config->get('api_key') && $config->get('organization_key');
+    if (!InstallerKernel::installationAttempted() && $cohesion_configured) {
       $moduleHandler = \Drupal::service('module_handler');
       $acms_modules = [
         'acquia_cms_article',
@@ -478,5 +483,10 @@ function acquia_cms_common_module_implements_alter(array &$implementations, stri
       // hook_modules_uninstalled of Acquia connector.
       unset($implementations['acquia_connector']);
     }
+  }
+  // Prevent installation of site studio package on module install
+  // during site installation from other modules, this causes issue.
+  if ($hook == 'modules_installed' && InstallerKernel::installationAttempted()) {
+    unset($implementations['cohesion_sync']);
   }
 }


### PR DESCRIPTION
… override for SS key.

**Motivation**
<!-- What problem does this solve? Why is it important? What's the context? If this fixes an issue, link to it above. -->
Fixes #[ACMS-1496](https://backlog.acquia.com/browse/ACMS-1496)

**Proposed changes**
<!-- What does this PR change? How does this impact end users? Are manual or automatic updates required? -->
Unset cohesion_sync module implementation for module installed hook.

**Alternatives considered**
<!-- How else could the original issue / use case be addressed? Why did you choose this solution over any others? -->
Use environment variables for site studio keys:
`
export SITESTUDIO_API_KEY=<api-key>
export SITESTUDIO_ORG_KEY=<org-key>
`
**Testing steps**
<!-- How can we replicate the issue and verify that this PR fixes it? -->

**Merge requirements**
- [_Bug_] _Major change_, _Minor change_, _Bug_, _Enhancement_, and/or _Chore_ label applied
- [ ] Manual testing by a reviewer
