### PR TITLE
ACMS-1496: Drush site:install break on acquia_cms:1.5.2 with settings…

### DIFF
--- a/modules/acquia_cms_site_studio/acquia_cms_site_studio.install
+++ b/modules/acquia_cms_site_studio/acquia_cms_site_studio.install
@@ -17,8 +17,11 @@ use Drupal\user\Entity\Role;
  * @throws Exception
  */
 function acquia_cms_site_studio_install() {
-  $site_studio_api_key = getenv('SITESTUDIO_API_KEY');
-  $site_studio_org_key = getenv('SITESTUDIO_ORG_KEY');
+  // If site studio key available in the environment variables
+  // then pick it from there else check for settings overrides.
+  $config = \Drupal::config('cohesion.settings');
+  $site_studio_api_key = getenv('SITESTUDIO_API_KEY') ?? $config->get('api_key');
+  $site_studio_org_key = getenv('SITESTUDIO_ORG_KEY') ?? $config->get('organization_key');
 
   // Set default theme as cohesion.
   set_theme_site_studio_as_default();


### PR DESCRIPTION
… override for SS key.

**Motivation**
<!-- What problem does this solve? Why is it important? What's the context? If this fixes an issue, link to it above. -->
Fixes #[ACMS-1496](https://backlog.acquia.com/browse/ACMS-1496)

**Proposed changes**
<!-- What does this PR change? How does this impact end users? Are manual or automatic updates required? -->
Unset cohesion_sync module implementation for module installed hook.

**Alternatives considered**
<!-- How else could the original issue / use case be addressed? Why did you choose this solution over any others? -->
Use environment variables for site studio keys:
`
export SITESTUDIO_API_KEY=<api-key>
export SITESTUDIO_ORG_KEY=<org-key>
`
**Testing steps**
<!-- How can we replicate the issue and verify that this PR fixes it? -->

**Merge requirements**
- [_Bug_] _Major change_, _Minor change_, _Bug_, _Enhancement_, and/or _Chore_ label applied
- [ ] Manual testing by a reviewer
