### PR TITLE
ACMS-1389: Content type templates for Article, Person, Place, Event, Page

### DIFF
--- a/hooks/common/post-code-deploy/install_acms.sh
+++ b/hooks/common/post-code-deploy/install_acms.sh
@@ -12,7 +12,7 @@ target_env="$2"
 /usr/local/bin/drush9 @$site.$target_env cr
 
 # Only run update hooks on ode4. ode4 is used to test update path.
-if [ "$target_env" = "ode4" ]; then
+if [ "$target_env" = "ode5" ]; then
     /usr/local/bin/drush9 @$site.$target_env updatedb --no-interaction
 # Install Acquia CMS.
 else
@@ -31,10 +31,6 @@ case $target_env in
     ;;
 
   ode3)
-    /usr/local/bin/drush9 @$site.$target_env pm-enable acquia_cms_starter --yes
-    ;;
-
-  ode5)
     /usr/local/bin/drush9 @$site.$target_env pm-enable acquia_cms_starter --yes
     ;;
 

--- a/hooks/common/post-code-update/install_acms.sh
+++ b/hooks/common/post-code-update/install_acms.sh
@@ -12,7 +12,7 @@ target_env="$2"
 /usr/local/bin/drush9 @$site.$target_env cr
 
 # Only run update hooks on ode4. ode4 is used to test update path.
-if [ "$target_env" = "ode4" ]; then
+if [ "$target_env" = "ode5" ]; then
     /usr/local/bin/drush9 @$site.$target_env updatedb --no-interaction
 # Install Acquia CMS.
 else
@@ -31,10 +31,6 @@ case $target_env in
     ;;
 
   ode3)
-    /usr/local/bin/drush9 @$site.$target_env pm-enable acquia_cms_starter --yes
-    ;;
-
-  ode5)
     /usr/local/bin/drush9 @$site.$target_env pm-enable acquia_cms_starter --yes
     ;;
 

--- a/modules/acquia_cms_article/acquia_cms_article.install
+++ b/modules/acquia_cms_article/acquia_cms_article.install
@@ -82,3 +82,48 @@ function acquia_cms_article_update_8003() {
     }
   }
 }
+
+/**
+ * Implements hook_update_N().
+ *
+ * Update Article display modes.
+ */
+function acquia_cms_article_update_8004() {
+  // Load and update default view mode.
+  $article_image_field = [
+    'field_article_image' => [
+      'type' => 'entity_reference_entity_view',
+      'label' => 'hidden',
+      'settings' => [
+        'view_mode' => 'full',
+        'link' => 'false',
+      ],
+      'third_party_settings' => [],
+      'weight' => 3,
+      'region' => 'content',
+    ],
+  ];
+  $display_modes = [
+    'default',
+    'card',
+    'horizontal_card',
+    'search_results',
+    'teaser',
+  ];
+  $view_modes = [
+    'full',
+    'card',
+    'large_super_landscape',
+    'small',
+    'teaser',
+  ];
+  foreach ($display_modes as $key => $display_mode) {
+    $article_default = \Drupal::configFactory()->getEditable('core.entity_view_display.node.article.' . $display_mode);
+    if ($article_default->get('hidden.field_article_image')) {
+      $article_image_field['field_article_image']['settings']['view_mode'] = $view_modes[$key];
+      $article_default->set('content', array_merge($article_default->get('content'), $article_image_field));
+      $article_default->clear('hidden.field_article_image');
+      $article_default->save();
+    }
+  }
+}

--- a/modules/acquia_cms_article/acquia_cms_article.install
+++ b/modules/acquia_cms_article/acquia_cms_article.install
@@ -111,19 +111,41 @@ function acquia_cms_article_update_8004() {
     'teaser',
   ];
   $view_modes = [
-    'full',
-    'card',
     'large_super_landscape',
-    'small',
+    'small_landscape',
+    'small_landscape',
+    'teaser',
     'teaser',
   ];
+  // Update Image field.
   foreach ($display_modes as $key => $display_mode) {
-    $article_default = \Drupal::configFactory()->getEditable('core.entity_view_display.node.article.' . $display_mode);
-    if ($article_default->get('hidden.field_article_image')) {
+    $article_view_mode = \Drupal::configFactory()->getEditable('core.entity_view_display.node.article.' . $display_mode);
+    if ($article_view_mode->get('hidden.field_article_image')) {
       $article_image_field['field_article_image']['settings']['view_mode'] = $view_modes[$key];
-      $article_default->set('content', array_merge($article_default->get('content'), $article_image_field));
-      $article_default->clear('hidden.field_article_image');
-      $article_default->save();
+      $article_view_mode->set('content', array_merge($article_view_mode->get('content'), $article_image_field));
+      $article_view_mode->clear('hidden.field_article_image');
+      $article_view_mode->save();
     }
+  }
+
+  // Update Display Author field.
+  $field_display_author = [
+    'field_display_author' => [
+      'type' => 'entity_reference_entity_view',
+      'label' => 'hidden',
+      'settings' => [
+        'view_mode' => 'referenced_image',
+        'link' => 'false',
+      ],
+      'third_party_settings' => [],
+      'weight' => 4,
+      'region' => 'content',
+    ],
+  ];
+  $article_view_mode = \Drupal::configFactory()->getEditable('core.entity_view_display.node.article.default');
+  if ($article_view_mode->get('hidden.field_display_author')) {
+    $article_view_mode->set('content', array_merge($article_view_mode->get('content'), $field_display_author));
+    $article_view_mode->clear('hidden.field_display_author');
+    $article_view_mode->save();
   }
 }

--- a/modules/acquia_cms_article/config/optional/core.entity_view_display.node.article.card.yml
+++ b/modules/acquia_cms_article/config/optional/core.entity_view_display.node.article.card.yml
@@ -35,6 +35,11 @@ content:
     third_party_settings: {  }
     weight: 0
     region: content
+  links:
+    settings: {  }
+    third_party_settings: {  }
+    weight: 1
+    region: content
   field_article_image:
     type: entity_reference_entity_view
     label: hidden
@@ -43,11 +48,6 @@ content:
       link: false
     third_party_settings: {  }
     weight: 3
-    region: content
-  links:
-    settings: {  }
-    third_party_settings: {  }
-    weight: 1
     region: content
 hidden:
   field_article_media: true

--- a/modules/acquia_cms_article/config/optional/core.entity_view_display.node.article.card.yml
+++ b/modules/acquia_cms_article/config/optional/core.entity_view_display.node.article.card.yml
@@ -24,24 +24,32 @@ mode: card
 content:
   body:
     type: text_summary_or_trimmed
-    weight: 2
-    region: content
     label: hidden
     settings:
       trim_length: 128
     third_party_settings: {  }
+    weight: 2
+    region: content
   content_moderation_control:
+    settings: {  }
+    third_party_settings: {  }
     weight: 0
     region: content
+  field_article_image:
+    type: entity_reference_entity_view
+    label: hidden
+    settings:
+      view_mode: card
+      link: false
+    third_party_settings: {  }
+    weight: 3
+    region: content
+  links:
     settings: {  }
     third_party_settings: {  }
-  links:
     weight: 1
     region: content
-    settings: {  }
-    third_party_settings: {  }
 hidden:
-  field_article_image: true
   field_article_media: true
   field_article_type: true
   field_categories: true

--- a/modules/acquia_cms_article/config/optional/core.entity_view_display.node.article.card.yml
+++ b/modules/acquia_cms_article/config/optional/core.entity_view_display.node.article.card.yml
@@ -35,19 +35,19 @@ content:
     third_party_settings: {  }
     weight: 0
     region: content
-  links:
-    settings: {  }
-    third_party_settings: {  }
-    weight: 1
-    region: content
   field_article_image:
     type: entity_reference_entity_view
     label: hidden
     settings:
-      view_mode: card
+      view_mode: small_landscape
       link: false
     third_party_settings: {  }
     weight: 3
+    region: content
+  links:
+    settings: {  }
+    third_party_settings: {  }
+    weight: 1
     region: content
 hidden:
   field_article_media: true

--- a/modules/acquia_cms_article/config/optional/core.entity_view_display.node.article.default.yml
+++ b/modules/acquia_cms_article/config/optional/core.entity_view_display.node.article.default.yml
@@ -23,23 +23,31 @@ mode: default
 content:
   body:
     type: text_default
-    weight: 2
-    region: content
     label: hidden
     settings: {  }
     third_party_settings: {  }
+    weight: 2
+    region: content
   content_moderation_control:
+    settings: {  }
+    third_party_settings: {  }
     weight: 0
     region: content
+  field_article_image:
+    type: entity_reference_entity_view
+    label: hidden
+    settings:
+      view_mode: full
+      link: false
+    third_party_settings: {  }
+    weight: 3
+    region: content
+  links:
     settings: {  }
     third_party_settings: {  }
-  links:
     weight: 1
     region: content
-    settings: {  }
-    third_party_settings: {  }
 hidden:
-  field_article_image: true
   field_article_media: true
   field_article_type: true
   field_categories: true

--- a/modules/acquia_cms_article/config/optional/core.entity_view_display.node.article.default.yml
+++ b/modules/acquia_cms_article/config/optional/core.entity_view_display.node.article.default.yml
@@ -33,25 +33,33 @@ content:
     third_party_settings: {  }
     weight: 0
     region: content
+  field_article_image:
+    type: entity_reference_entity_view
+    label: hidden
+    settings:
+      view_mode: large_super_landscape
+      link: false
+    third_party_settings: {  }
+    weight: 3
+    region: content
+  field_display_author:
+    type: entity_reference_entity_view
+    label: hidden
+    settings:
+      view_mode: referenced_image
+      link: false
+    third_party_settings: {  }
+    weight: 4
+    region: content
   links:
     settings: {  }
     third_party_settings: {  }
     weight: 1
     region: content
-  field_article_image:
-    type: entity_reference_entity_view
-    label: hidden
-    settings:
-      view_mode: full
-      link: false
-    third_party_settings: {  }
-    weight: 3
-    region: content
 hidden:
   field_article_media: true
   field_article_type: true
   field_categories: true
-  field_display_author: true
   field_tags: true
   langcode: true
   search_api_excerpt: true

--- a/modules/acquia_cms_article/config/optional/core.entity_view_display.node.article.default.yml
+++ b/modules/acquia_cms_article/config/optional/core.entity_view_display.node.article.default.yml
@@ -33,6 +33,11 @@ content:
     third_party_settings: {  }
     weight: 0
     region: content
+  links:
+    settings: {  }
+    third_party_settings: {  }
+    weight: 1
+    region: content
   field_article_image:
     type: entity_reference_entity_view
     label: hidden
@@ -41,11 +46,6 @@ content:
       link: false
     third_party_settings: {  }
     weight: 3
-    region: content
-  links:
-    settings: {  }
-    third_party_settings: {  }
-    weight: 1
     region: content
 hidden:
   field_article_media: true

--- a/modules/acquia_cms_article/config/optional/core.entity_view_display.node.article.horizontal_card.yml
+++ b/modules/acquia_cms_article/config/optional/core.entity_view_display.node.article.horizontal_card.yml
@@ -35,6 +35,11 @@ content:
     third_party_settings: {  }
     weight: 0
     region: content
+  links:
+    settings: {  }
+    third_party_settings: {  }
+    weight: 1
+    region: content
   field_article_image:
     type: entity_reference_entity_view
     label: hidden
@@ -43,11 +48,6 @@ content:
       link: false
     third_party_settings: {  }
     weight: 3
-    region: content
-  links:
-    settings: {  }
-    third_party_settings: {  }
-    weight: 1
     region: content
 hidden:
   field_article_media: true

--- a/modules/acquia_cms_article/config/optional/core.entity_view_display.node.article.horizontal_card.yml
+++ b/modules/acquia_cms_article/config/optional/core.entity_view_display.node.article.horizontal_card.yml
@@ -35,19 +35,19 @@ content:
     third_party_settings: {  }
     weight: 0
     region: content
-  links:
-    settings: {  }
-    third_party_settings: {  }
-    weight: 1
-    region: content
   field_article_image:
     type: entity_reference_entity_view
     label: hidden
     settings:
-      view_mode: large_super_landscape
+      view_mode: small_landscape
       link: false
     third_party_settings: {  }
     weight: 3
+    region: content
+  links:
+    settings: {  }
+    third_party_settings: {  }
+    weight: 1
     region: content
 hidden:
   field_article_media: true

--- a/modules/acquia_cms_article/config/optional/core.entity_view_display.node.article.horizontal_card.yml
+++ b/modules/acquia_cms_article/config/optional/core.entity_view_display.node.article.horizontal_card.yml
@@ -24,24 +24,32 @@ mode: horizontal_card
 content:
   body:
     type: text_summary_or_trimmed
-    weight: 2
-    region: content
     label: hidden
     settings:
       trim_length: 128
     third_party_settings: {  }
+    weight: 2
+    region: content
   content_moderation_control:
+    settings: {  }
+    third_party_settings: {  }
     weight: 0
     region: content
+  field_article_image:
+    type: entity_reference_entity_view
+    label: hidden
+    settings:
+      view_mode: large_super_landscape
+      link: false
+    third_party_settings: {  }
+    weight: 3
+    region: content
+  links:
     settings: {  }
     third_party_settings: {  }
-  links:
     weight: 1
     region: content
-    settings: {  }
-    third_party_settings: {  }
 hidden:
-  field_article_image: true
   field_article_media: true
   field_article_type: true
   field_categories: true

--- a/modules/acquia_cms_article/config/optional/core.entity_view_display.node.article.search_results.yml
+++ b/modules/acquia_cms_article/config/optional/core.entity_view_display.node.article.search_results.yml
@@ -46,6 +46,11 @@ content:
     third_party_settings: {  }
     weight: 0
     region: content
+  links:
+    settings: {  }
+    third_party_settings: {  }
+    weight: 1
+    region: content
   field_article_image:
     type: entity_reference_entity_view
     label: hidden
@@ -54,11 +59,6 @@ content:
       link: false
     third_party_settings: {  }
     weight: 3
-    region: content
-  links:
-    settings: {  }
-    third_party_settings: {  }
-    weight: 1
     region: content
 hidden:
   field_article_media: true

--- a/modules/acquia_cms_article/config/optional/core.entity_view_display.node.article.search_results.yml
+++ b/modules/acquia_cms_article/config/optional/core.entity_view_display.node.article.search_results.yml
@@ -24,35 +24,43 @@ mode: search_results
 content:
   body:
     type: smart_trim
-    weight: 2
-    region: content
     label: hidden
     settings:
       trim_length: 128
       trim_type: chars
       trim_suffix: ...
-      wrap_class: trimmed
-      more_text: More
-      more_class: more-link
-      summary_handler: trim
       wrap_output: false
+      wrap_class: trimmed
       more_link: false
+      more_class: more-link
+      more_text: More
+      summary_handler: trim
       trim_options:
         text: false
         trim_zero: false
     third_party_settings: {  }
+    weight: 2
+    region: content
   content_moderation_control:
+    settings: {  }
+    third_party_settings: {  }
     weight: 0
     region: content
+  field_article_image:
+    type: entity_reference_entity_view
+    label: hidden
+    settings:
+      view_mode: small
+      link: false
+    third_party_settings: {  }
+    weight: 3
+    region: content
+  links:
     settings: {  }
     third_party_settings: {  }
-  links:
     weight: 1
     region: content
-    settings: {  }
-    third_party_settings: {  }
 hidden:
-  field_article_image: true
   field_article_media: true
   field_article_type: true
   field_categories: true

--- a/modules/acquia_cms_article/config/optional/core.entity_view_display.node.article.search_results.yml
+++ b/modules/acquia_cms_article/config/optional/core.entity_view_display.node.article.search_results.yml
@@ -46,19 +46,19 @@ content:
     third_party_settings: {  }
     weight: 0
     region: content
-  links:
-    settings: {  }
-    third_party_settings: {  }
-    weight: 1
-    region: content
   field_article_image:
     type: entity_reference_entity_view
     label: hidden
     settings:
-      view_mode: small
+      view_mode: teaser
       link: false
     third_party_settings: {  }
     weight: 3
+    region: content
+  links:
+    settings: {  }
+    third_party_settings: {  }
+    weight: 1
     region: content
 hidden:
   field_article_media: true

--- a/modules/acquia_cms_article/config/optional/core.entity_view_display.node.article.teaser.yml
+++ b/modules/acquia_cms_article/config/optional/core.entity_view_display.node.article.teaser.yml
@@ -24,35 +24,43 @@ mode: teaser
 content:
   body:
     type: smart_trim
-    weight: 2
-    region: content
     label: hidden
     settings:
       trim_length: 128
       trim_type: chars
       trim_suffix: ...
-      wrap_class: trimmed
-      more_text: More
-      more_class: more-link
-      summary_handler: trim
       wrap_output: false
+      wrap_class: trimmed
       more_link: false
+      more_class: more-link
+      more_text: More
+      summary_handler: trim
       trim_options:
         text: false
         trim_zero: false
     third_party_settings: {  }
+    weight: 2
+    region: content
   content_moderation_control:
+    settings: {  }
+    third_party_settings: {  }
     weight: 0
     region: content
+  field_article_image:
+    type: entity_reference_entity_view
+    label: hidden
+    settings:
+      view_mode: teaser
+      link: false
+    third_party_settings: {  }
+    weight: 3
+    region: content
+  links:
     settings: {  }
     third_party_settings: {  }
-  links:
     weight: 1
     region: content
-    settings: {  }
-    third_party_settings: {  }
 hidden:
-  field_article_image: true
   field_article_media: true
   field_article_type: true
   field_categories: true

--- a/modules/acquia_cms_article/config/optional/core.entity_view_display.node.article.teaser.yml
+++ b/modules/acquia_cms_article/config/optional/core.entity_view_display.node.article.teaser.yml
@@ -46,6 +46,11 @@ content:
     third_party_settings: {  }
     weight: 0
     region: content
+  links:
+    settings: {  }
+    third_party_settings: {  }
+    weight: 1
+    region: content
   field_article_image:
     type: entity_reference_entity_view
     label: hidden
@@ -54,11 +59,6 @@ content:
       link: false
     third_party_settings: {  }
     weight: 3
-    region: content
-  links:
-    settings: {  }
-    third_party_settings: {  }
-    weight: 1
     region: content
 hidden:
   field_article_media: true

--- a/modules/acquia_cms_article/config/pack_acquia_cms_article/cohesion_templates.cohesion_content_templates.node_article_card.yml
+++ b/modules/acquia_cms_article/config/pack_acquia_cms_article/cohesion_templates.cohesion_content_templates.node_article_card.yml
@@ -3,7 +3,11 @@ langcode: en
 status: true
 dependencies:
   config:
-    - image.style.coh_small_landscape
+    - cohesion_custom_styles.cohesion_custom_style.097f31b2
+    - cohesion_custom_styles.cohesion_custom_style.65dc3072
+    - cohesion_custom_styles.cohesion_custom_style.a13b8c94
+    - cohesion_custom_styles.cohesion_custom_style.bfd0fecd
+    - cohesion_custom_styles.cohesion_custom_style.ed4b7a3d
 label: 'Card (Node, Article)'
 id: node_article_card
 json_values: |
@@ -168,23 +172,20 @@ json_values: |
                       "uid": "container",
                       "title": "Container",
                       "status": {
-                          "collapsed": true,
-                          "collapsedParents": []
+                          "collapsed": false
                       },
                       "uuid": "431a5d30-c620-46b3-8e13-913c553c4391",
                       "parentUid": "container",
                       "children": [
                           {
-                              "type": "item",
-                              "uid": "image",
-                              "title": "Image",
+                              "type": "container",
+                              "uid": "drupal-field",
+                              "title": "Field",
                               "status": {
-                                  "collapsed": true,
-                                  "collapsedParents": [
-                                      "431a5d30-c620-46b3-8e13-913c553c4391"
-                                  ]
+                                  "collapsed": true
                               },
-                              "uuid": "77e230d2-bda7-4869-aea6-3b81ec84542e",
+                              "iconColor": "drupal",
+                              "uuid": "7500c1a8-bc55-47f5-ad50-9969644b5213",
                               "parentUid": "container",
                               "children": []
                           }
@@ -695,78 +696,6 @@ json_values: |
                       }
                   ],
                   "title": "Hide if no data",
-                  "selectorType": "topLevel",
-                  "form": null,
-                  "items": []
-              }
-          },
-          "77e230d2-bda7-4869-aea6-3b81ec84542e": {
-              "settings": {
-                  "formDefinition": [
-                      {
-                          "formKey": "image-settings",
-                          "children": [
-                              {
-                                  "formKey": "image-image",
-                                  "breakpoints": [],
-                                  "activeFields": [
-                                      {
-                                          "name": "image",
-                                          "active": true
-                                      },
-                                      {
-                                          "name": "title",
-                                          "active": true
-                                      },
-                                      {
-                                          "name": "alt",
-                                          "active": true
-                                      },
-                                      {
-                                          "name": "lazyload",
-                                          "active": true
-                                      }
-                                  ]
-                              },
-                              {
-                                  "formKey": "image-size",
-                                  "breakpoints": [
-                                      {
-                                          "name": "xl"
-                                      }
-                                  ],
-                                  "activeFields": [
-                                      {
-                                          "name": "displaySize",
-                                          "active": true
-                                      },
-                                      {
-                                          "name": "imageAlignment",
-                                          "active": true
-                                      }
-                                  ]
-                              },
-                              {
-                                  "formKey": "image-style",
-                                  "breakpoints": [],
-                                  "activeFields": [
-                                      {
-                                          "name": "imageStyle",
-                                          "active": true
-                                      },
-                                      {
-                                          "name": "customStyle",
-                                          "active": true
-                                      },
-                                      {
-                                          "name": "customStyle",
-                                          "active": true
-                                      }
-                                  ]
-                              }
-                          ]
-                      }
-                  ],
                   "selectorType": "topLevel",
                   "form": null,
                   "items": []
@@ -2306,7 +2235,8 @@ json_values: |
                   "form": null,
                   "items": []
               }
-          }
+          },
+          "7500c1a8-bc55-47f5-ad50-9969644b5213": {}
       },
       "model": {
           "c2cb5754-d772-4d73-917a-402d82f060e9": {
@@ -2819,41 +2749,13 @@ json_values: |
                   "hideData": "[node:field_article_image]"
               }
           },
-          "77e230d2-bda7-4869-aea6-3b81ec84542e": {
+          "7500c1a8-bc55-47f5-ad50-9969644b5213": {
               "settings": {
-                  "title": "Image",
-                  "styles": {
-                      "xl": {
-                          "displaySize": "coh-image-responsive",
-                          "imageAlignment": "coh-image-align-left"
-                      }
-                  },
-                  "customStyle": [
-                      {
-                          "customStyle": ""
-                      }
-                  ],
-                  "lazyload": false,
+                  "title": "Field",
                   "settings": {
-                      "lazyload": false,
-                      "styles": {
-                          "xl": {
-                              "displaySize": "coh-image-responsive"
-                          }
-                      },
-                      "imageStyle": "",
-                      "customStyle": [
-                          {
-                              "customStyle": ""
-                          }
-                      ]
+                      "drupalField": ""
                   },
-                  "imageStyle": "coh_small_landscape",
-                  "image": "[node:field_article_image:entity:image:entity:path]",
-                  "attributes": {
-                      "title": "[node:field_article_image:entity:image:entity:name]",
-                      "alt": "[node:field_article_image:entity:image:entity:alt]"
-                  }
+                  "drupalField": "content.field_article_image"
               },
               "context-visibility": {
                   "contextVisibility": {
@@ -2862,7 +2764,7 @@ json_values: |
               },
               "styles": {
                   "settings": {
-                      "element": "img"
+                      "element": "drupal-field"
                   }
               }
           }
@@ -2903,11 +2805,7 @@ json_values: |
           "0005e2e8-54af-4dbb-9967-be838980ce83": {},
           "431a5d30-c620-46b3-8e13-913c553c4391": {},
           "c2cb5754-d772-4d73-917a-402d82f060e9": {},
-          "77e230d2-bda7-4869-aea6-3b81ec84542e": {
-              "settings": {
-                  "image": ""
-              }
-          }
+          "7500c1a8-bc55-47f5-ad50-9969644b5213": {}
       },
       "variableFields": {
           "aa94750d-4ba1-4926-8de5-bb8b55da1e2d": [],
@@ -2934,11 +2832,7 @@ json_values: |
           "0005e2e8-54af-4dbb-9967-be838980ce83": [],
           "431a5d30-c620-46b3-8e13-913c553c4391": [],
           "c2cb5754-d772-4d73-917a-402d82f060e9": [],
-          "77e230d2-bda7-4869-aea6-3b81ec84542e": [
-              "settings.attributes.title",
-              "settings.attributes.alt",
-              "settings.image"
-          ]
+          "7500c1a8-bc55-47f5-ad50-9969644b5213": []
       },
       "meta": {
           "fieldHistory": []

--- a/modules/acquia_cms_article/config/pack_acquia_cms_article/cohesion_templates.cohesion_content_templates.node_article_full.yml
+++ b/modules/acquia_cms_article/config/pack_acquia_cms_article/cohesion_templates.cohesion_content_templates.node_article_full.yml
@@ -3,11 +3,18 @@ langcode: en
 status: true
 dependencies:
   config:
+    - cohesion_custom_styles.cohesion_custom_style.097f31b2
+    - cohesion_custom_styles.cohesion_custom_style.58a35e7a
+    - cohesion_custom_styles.cohesion_custom_style.65dc3072
+    - cohesion_custom_styles.cohesion_custom_style.7ef725fd
+    - cohesion_custom_styles.cohesion_custom_style.a13b8c94
+    - cohesion_custom_styles.cohesion_custom_style.bfd0fecd
+    - cohesion_custom_styles.cohesion_custom_style.ed4b7a3d
+    - cohesion_custom_styles.cohesion_custom_style.ee93d997
+    - cohesion_custom_styles.cohesion_custom_style.f3dc1bea
+    - cohesion_elements.cohesion_component.cpt_breadcrumbs
     - cohesion_templates.cohesion_master_templates.master_template
-    - image.style.coh_large_super_landscape
-    - image.style.coh_medium_super_landscape
-    - image.style.coh_small_landscape
-    - image.style.coh_x_large_super_landscape
+    - cohesion_website_settings.cohesion_color.gray-10
 label: 'Full content (Node, Article)'
 id: node_article_full
 json_values: |
@@ -180,25 +187,20 @@ json_values: |
                               "uid": "column",
                               "title": "Column",
                               "status": {
-                                  "collapsed": true,
-                                  "collapsedParents": []
+                                  "collapsed": false
                               },
                               "uuid": "873b1426-c49a-4008-9bc8-cea6db2123bf",
                               "parentUid": "row-for-columns",
                               "children": [
                                   {
-                                      "type": "item",
-                                      "uid": "picture",
-                                      "title": "Picture",
-                                      "selected": false,
+                                      "type": "container",
+                                      "uid": "drupal-field",
+                                      "title": "Field",
                                       "status": {
-                                          "collapsed": true,
-                                          "isopen": false,
-                                          "collapsedParents": [
-                                              "873b1426-c49a-4008-9bc8-cea6db2123bf"
-                                          ]
+                                          "collapsed": false
                                       },
-                                      "uuid": "65a56bc6-9090-4f4a-b44a-c339e3c182aa",
+                                      "iconColor": "drupal",
+                                      "uuid": "e28ff52e-2a66-4639-b309-3b86bedecbac",
                                       "parentUid": "column",
                                       "children": []
                                   }
@@ -209,8 +211,7 @@ json_values: |
                               "uid": "column",
                               "title": "Column",
                               "status": {
-                                  "collapsed": true,
-                                  "collapsedParents": []
+                                  "collapsed": false
                               },
                               "uuid": "a608c60e-5765-49e9-88cf-0271e8bebf2b",
                               "parentUid": "row-for-columns",
@@ -220,10 +221,7 @@ json_values: |
                                       "uid": "drupal-field",
                                       "title": "Field",
                                       "status": {
-                                          "collapsed": true,
-                                          "collapsedParents": [
-                                              "a608c60e-5765-49e9-88cf-0271e8bebf2b"
-                                          ]
+                                          "collapsed": false
                                       },
                                       "uuid": "32d3d0f7-2fa9-4c29-8d5f-3ef634f3aa0c",
                                       "parentUid": "column",
@@ -2374,91 +2372,6 @@ json_values: |
                   "items": []
               }
           },
-          "65a56bc6-9090-4f4a-b44a-c339e3c182aa": {
-              "settings": {
-                  "formDefinition": [
-                      {
-                          "formKey": "picture-settings",
-                          "children": [
-                              {
-                                  "formKey": "picture-info",
-                                  "breakpoints": [],
-                                  "activeFields": [
-                                      {
-                                          "name": "title",
-                                          "active": true
-                                      },
-                                      {
-                                          "name": "alt",
-                                          "active": true
-                                      },
-                                      {
-                                          "name": "lazyload",
-                                          "active": true
-                                      }
-                                  ]
-                              },
-                              {
-                                  "formKey": "picture-images",
-                                  "breakpoints": [
-                                      {
-                                          "name": "xl"
-                                      },
-                                      {
-                                          "name": "md"
-                                      },
-                                      {
-                                          "name": "sm"
-                                      },
-                                      {
-                                          "name": "ps"
-                                      }
-                                  ],
-                                  "activeFields": [
-                                      {
-                                          "name": "displaySize",
-                                          "active": true
-                                      },
-                                      {
-                                          "name": "imageAlignment",
-                                          "active": true
-                                      },
-                                      {
-                                          "name": "pictureImagesArray",
-                                          "active": true
-                                      },
-                                      {
-                                          "name": "image",
-                                          "active": true
-                                      },
-                                      {
-                                          "name": "imageStyle",
-                                          "active": true
-                                      }
-                                  ]
-                              },
-                              {
-                                  "formKey": "picture-style",
-                                  "breakpoints": [],
-                                  "activeFields": [
-                                      {
-                                          "name": "customStyle",
-                                          "active": true
-                                      },
-                                      {
-                                          "name": "customStyle",
-                                          "active": true
-                                      }
-                                  ]
-                              }
-                          ]
-                      }
-                  ],
-                  "selectorType": "topLevel",
-                  "form": null,
-                  "items": []
-              }
-          },
           "77e7b1ff-d376-449a-a55f-b06501e9dbd8": {
               "settings": {
                   "formDefinition": [
@@ -3484,7 +3397,8 @@ json_values: |
                   "items": [],
                   "form": null
               }
-          }
+          },
+          "e28ff52e-2a66-4639-b309-3b86bedecbac": {}
       },
       "model": {
           "a08fc160-cbd2-409a-a20c-1886a9076721": {
@@ -3941,72 +3855,13 @@ json_values: |
                   "hideData": "[node:field_article_image]"
               }
           },
-          "65a56bc6-9090-4f4a-b44a-c339e3c182aa": {
+          "e28ff52e-2a66-4639-b309-3b86bedecbac": {
               "settings": {
-                  "title": "Picture",
-                  "customStyle": [
-                      {
-                          "customStyle": ""
-                      }
-                  ],
-                  "styles": {
-                      "xl": {
-                          "pictureImagesArray": [
-                              {
-                                  "imageStyle": "coh_x_large_super_landscape",
-                                  "image": "[node:field_article_image:entity:image:entity:path]"
-                              }
-                          ],
-                          "displaySize": "coh-image-responsive"
-                      },
-                      "sm": {
-                          "pictureImagesArray": [
-                              {
-                                  "imageStyle": "coh_medium_super_landscape"
-                              }
-                          ],
-                          "displaySize": "coh-image-responsive"
-                      },
-                      "ps": {
-                          "pictureImagesArray": [
-                              {
-                                  "imageStyle": "coh_small_landscape"
-                              }
-                          ],
-                          "displaySize": "coh-image-responsive"
-                      },
-                      "md": {
-                          "pictureImagesArray": [
-                              {
-                                  "imageStyle": "coh_large_super_landscape"
-                              }
-                          ],
-                          "displaySize": "coh-image-responsive"
-                      }
-                  },
-                  "lazyload": false,
+                  "title": "Field",
                   "settings": {
-                      "lazyload": false,
-                      "styles": {
-                          "xl": {
-                              "displaySize": "coh-image-responsive",
-                              "pictureImagesArray": [
-                                  {
-                                      "imageStyle": ""
-                                  }
-                              ]
-                          }
-                      },
-                      "customStyle": [
-                          {
-                              "customStyle": ""
-                          }
-                      ]
+                      "drupalField": ""
                   },
-                  "attributes": {
-                      "title": "[node:field_article_image:entity:name]",
-                      "alt": "[node:field_article_image:entity:image:alt]"
-                  }
+                  "drupalField": "content.field_article_image"
               },
               "context-visibility": {
                   "contextVisibility": {
@@ -4015,7 +3870,7 @@ json_values: |
               },
               "styles": {
                   "settings": {
-                      "element": "picture"
+                      "element": "drupal-field"
                   }
               }
           },
@@ -4494,19 +4349,6 @@ json_values: |
           "782e6181-4ecf-4ea0-a09a-ba6775d3f048": {},
           "131ebc05-bc00-44d4-bbd9-7a6dcefcce83": {},
           "873b1426-c49a-4008-9bc8-cea6db2123bf": {},
-          "65a56bc6-9090-4f4a-b44a-c339e3c182aa": {
-              "settings": {
-                  "styles": {
-                      "xl": {
-                          "pictureImagesArray": [
-                              {
-                                  "image": ""
-                              }
-                          ]
-                      }
-                  }
-              }
-          },
           "a608c60e-5765-49e9-88cf-0271e8bebf2b": {},
           "b4c72932-3b83-463e-9531-6b8d4e76b17c": {},
           "5f755c02-6b9c-4048-83c2-757ead614280": {},
@@ -4535,7 +4377,8 @@ json_values: |
               }
           },
           "a08fc160-cbd2-409a-a20c-1886a9076721": {},
-          "32d3d0f7-2fa9-4c29-8d5f-3ef634f3aa0c": {}
+          "32d3d0f7-2fa9-4c29-8d5f-3ef634f3aa0c": {},
+          "e28ff52e-2a66-4639-b309-3b86bedecbac": {}
       },
       "variableFields": {
           "87756a05-748a-44ab-87fc-3e71b94fe814": [],
@@ -4562,11 +4405,6 @@ json_values: |
           "873b1426-c49a-4008-9bc8-cea6db2123bf": [
               "hideNoData.hideData"
           ],
-          "65a56bc6-9090-4f4a-b44a-c339e3c182aa": [
-              "settings.styles.xl.pictureImagesArray.0.image",
-              "settings.attributes.title",
-              "settings.attributes.alt"
-          ],
           "a608c60e-5765-49e9-88cf-0271e8bebf2b": [],
           "b4c72932-3b83-463e-9531-6b8d4e76b17c": [],
           "5f755c02-6b9c-4048-83c2-757ead614280": [],
@@ -4590,7 +4428,8 @@ json_values: |
               "settings.linkToPage"
           ],
           "a08fc160-cbd2-409a-a20c-1886a9076721": [],
-          "32d3d0f7-2fa9-4c29-8d5f-3ef634f3aa0c": []
+          "32d3d0f7-2fa9-4c29-8d5f-3ef634f3aa0c": [],
+          "e28ff52e-2a66-4639-b309-3b86bedecbac": []
       },
       "meta": {
           "fieldHistory": []

--- a/modules/acquia_cms_article/config/pack_acquia_cms_article/cohesion_templates.cohesion_content_templates.node_article_full.yml
+++ b/modules/acquia_cms_article/config/pack_acquia_cms_article/cohesion_templates.cohesion_content_templates.node_article_full.yml
@@ -246,10 +246,7 @@ json_values: |
                                       "uid": "container",
                                       "title": "Container",
                                       "status": {
-                                          "collapsed": true,
-                                          "collapsedParents": [
-                                              "a608c60e-5765-49e9-88cf-0271e8bebf2b"
-                                          ]
+                                          "collapsed": false
                                       },
                                       "uuid": "b4c72932-3b83-463e-9531-6b8d4e76b17c",
                                       "parentUid": "column",
@@ -272,10 +269,7 @@ json_values: |
                                                       "uid": "heading",
                                                       "title": "Heading",
                                                       "status": {
-                                                          "collapsed": true,
-                                                          "collapsedParents": [
-                                                              "a608c60e-5765-49e9-88cf-0271e8bebf2b"
-                                                          ]
+                                                          "collapsed": true
                                                       },
                                                       "uuid": "659fbe19-9a26-471d-9be6-d810dfb6b796",
                                                       "parentUid": "container",
@@ -301,10 +295,7 @@ json_values: |
                                                       "uid": "inline-element",
                                                       "title": "Inline element",
                                                       "status": {
-                                                          "collapsed": true,
-                                                          "collapsedParents": [
-                                                              "a608c60e-5765-49e9-88cf-0271e8bebf2b"
-                                                          ]
+                                                          "collapsed": true
                                                       },
                                                       "uuid": "d8963bef-f7a2-4079-9c6f-cd90acdb6fb1",
                                                       "parentUid": "container",
@@ -317,25 +308,19 @@ json_values: |
                                               "uid": "container",
                                               "title": "Container",
                                               "status": {
-                                                  "collapsed": true,
-                                                  "collapsedParents": [
-                                                      "a608c60e-5765-49e9-88cf-0271e8bebf2b"
-                                                  ]
+                                                  "collapsed": false
                                               },
                                               "uuid": "0be0f3bd-df3a-4a44-a9d8-d44379d8fb0d",
                                               "parentUid": "container",
                                               "children": [
                                                   {
-                                                      "type": "item",
-                                                      "uid": "image",
-                                                      "title": "Image",
+                                                      "type": "container",
+                                                      "uid": "drupal-field",
+                                                      "title": "Field",
                                                       "status": {
-                                                          "collapsed": true,
-                                                          "collapsedParents": [
-                                                              "a608c60e-5765-49e9-88cf-0271e8bebf2b"
-                                                          ]
+                                                          "collapsed": true
                                                       },
-                                                      "uuid": "2ee42c4e-2a1f-4c32-ad0a-d8e6b8d0f0ab",
+                                                      "uuid": "6f59058d-5b8f-4588-b4ec-a84e5cf23ad2",
                                                       "parentUid": "container",
                                                       "children": []
                                                   }
@@ -1369,78 +1354,6 @@ json_values: |
                   "selectorType": "topLevel",
                   "items": [],
                   "form": null
-              }
-          },
-          "2ee42c4e-2a1f-4c32-ad0a-d8e6b8d0f0ab": {
-              "settings": {
-                  "formDefinition": [
-                      {
-                          "formKey": "image-settings",
-                          "children": [
-                              {
-                                  "formKey": "image-image",
-                                  "breakpoints": [],
-                                  "activeFields": [
-                                      {
-                                          "name": "image",
-                                          "active": true
-                                      },
-                                      {
-                                          "name": "title",
-                                          "active": true
-                                      },
-                                      {
-                                          "name": "alt",
-                                          "active": true
-                                      },
-                                      {
-                                          "name": "lazyload",
-                                          "active": true
-                                      }
-                                  ]
-                              },
-                              {
-                                  "formKey": "image-size",
-                                  "breakpoints": [
-                                      {
-                                          "name": "xl"
-                                      }
-                                  ],
-                                  "activeFields": [
-                                      {
-                                          "name": "displaySize",
-                                          "active": true
-                                      },
-                                      {
-                                          "name": "imageAlignment",
-                                          "active": true
-                                      }
-                                  ]
-                              },
-                              {
-                                  "formKey": "image-style",
-                                  "breakpoints": [],
-                                  "activeFields": [
-                                      {
-                                          "name": "imageStyle",
-                                          "active": true
-                                      },
-                                      {
-                                          "name": "customStyle",
-                                          "active": true
-                                      },
-                                      {
-                                          "name": "customStyle",
-                                          "active": true
-                                      }
-                                  ]
-                              }
-                          ]
-                      }
-                  ],
-                  "selectorType": "topLevel",
-                  "form": null,
-                  "items": []
               }
           },
           "5f755c02-6b9c-4048-83c2-757ead614280": {
@@ -3398,7 +3311,8 @@ json_values: |
                   "form": null
               }
           },
-          "e28ff52e-2a66-4639-b309-3b86bedecbac": {}
+          "e28ff52e-2a66-4639-b309-3b86bedecbac": {},
+          "6f59058d-5b8f-4588-b4ec-a84e5cf23ad2": {}
       },
       "model": {
           "a08fc160-cbd2-409a-a20c-1886a9076721": {
@@ -4268,41 +4182,13 @@ json_values: |
                   }
               }
           },
-          "2ee42c4e-2a1f-4c32-ad0a-d8e6b8d0f0ab": {
+          "6f59058d-5b8f-4588-b4ec-a84e5cf23ad2": {
               "settings": {
-                  "title": "Image",
-                  "styles": {
-                      "xl": {
-                          "displaySize": "coh-image-responsive",
-                          "imageAlignment": "coh-image-align-left"
-                      }
-                  },
-                  "customStyle": [
-                      {
-                          "customStyle": ""
-                      }
-                  ],
-                  "lazyload": false,
+                  "title": "Field",
                   "settings": {
-                      "lazyload": false,
-                      "styles": {
-                          "xl": {
-                              "displaySize": "coh-image-responsive"
-                          }
-                      },
-                      "imageStyle": "",
-                      "customStyle": [
-                          {
-                              "customStyle": ""
-                          }
-                      ]
+                      "drupalField": ""
                   },
-                  "imageStyle": "x_small_square_320x320_",
-                  "image": "[node:field_display_author:entity:field_person_image:entity:image:entity:path]",
-                  "attributes": {
-                      "title": "[node:field_display_author:entity:title]",
-                      "alt": "[node:field_display_author:entity:title]"
-                  }
+                  "drupalField": "content.field_display_author"
               },
               "context-visibility": {
                   "contextVisibility": {
@@ -4311,7 +4197,7 @@ json_values: |
               },
               "styles": {
                   "settings": {
-                      "element": "img"
+                      "element": "drupal-field"
                   }
               }
           }
@@ -4365,11 +4251,6 @@ json_values: |
                   "linkToPage": "#"
               }
           },
-          "2ee42c4e-2a1f-4c32-ad0a-d8e6b8d0f0ab": {
-              "settings": {
-                  "image": "[media-reference:media:de86764f-580e-495b-a119-8f27b72b0faf]"
-              }
-          },
           "3cd91d96-35ef-4cab-be40-1cfa6a1d58d3": {
               "settings": {
                   "linkText": "James Anderson",
@@ -4378,7 +4259,8 @@ json_values: |
           },
           "a08fc160-cbd2-409a-a20c-1886a9076721": {},
           "32d3d0f7-2fa9-4c29-8d5f-3ef634f3aa0c": {},
-          "e28ff52e-2a66-4639-b309-3b86bedecbac": {}
+          "e28ff52e-2a66-4639-b309-3b86bedecbac": {},
+          "6f59058d-5b8f-4588-b4ec-a84e5cf23ad2": {}
       },
       "variableFields": {
           "87756a05-748a-44ab-87fc-3e71b94fe814": [],
@@ -4418,18 +4300,14 @@ json_values: |
               "settings.linkText",
               "settings.linkToPage"
           ],
-          "2ee42c4e-2a1f-4c32-ad0a-d8e6b8d0f0ab": [
-              "settings.image",
-              "settings.attributes.alt",
-              "settings.attributes.title"
-          ],
           "3cd91d96-35ef-4cab-be40-1cfa6a1d58d3": [
               "settings.linkText",
               "settings.linkToPage"
           ],
           "a08fc160-cbd2-409a-a20c-1886a9076721": [],
           "32d3d0f7-2fa9-4c29-8d5f-3ef634f3aa0c": [],
-          "e28ff52e-2a66-4639-b309-3b86bedecbac": []
+          "e28ff52e-2a66-4639-b309-3b86bedecbac": [],
+          "6f59058d-5b8f-4588-b4ec-a84e5cf23ad2": []
       },
       "meta": {
           "fieldHistory": []

--- a/modules/acquia_cms_article/config/pack_acquia_cms_article/cohesion_templates.cohesion_content_templates.node_article_horizontal_card.yml
+++ b/modules/acquia_cms_article/config/pack_acquia_cms_article/cohesion_templates.cohesion_content_templates.node_article_horizontal_card.yml
@@ -3,7 +3,11 @@ langcode: en
 status: true
 dependencies:
   config:
-    - image.style.coh_small_landscape
+    - cohesion_custom_styles.cohesion_custom_style.097f31b2
+    - cohesion_custom_styles.cohesion_custom_style.65dc3072
+    - cohesion_custom_styles.cohesion_custom_style.a13b8c94
+    - cohesion_custom_styles.cohesion_custom_style.bfd0fecd
+    - cohesion_custom_styles.cohesion_custom_style.ed4b7a3d
 label: 'Horizontal card (Node, Article)'
 id: node_article_horizontal_card
 json_values: |
@@ -196,22 +200,20 @@ json_values: |
                       "uid": "column",
                       "title": "Column",
                       "status": {
-                          "collapsed": true
+                          "collapsed": false
                       },
                       "uuid": "214b7fb6-88c2-4cd5-976b-a57680313050",
                       "parentUid": "row-for-columns",
                       "children": [
                           {
-                              "type": "item",
-                              "uid": "image",
-                              "title": "Image",
+                              "type": "container",
+                              "uid": "drupal-field",
+                              "title": "Field",
                               "status": {
-                                  "collapsed": true,
-                                  "collapsedParents": [
-                                      "214b7fb6-88c2-4cd5-976b-a57680313050"
-                                  ]
+                                  "collapsed": true
                               },
-                              "uuid": "03045370-34da-4513-bac0-4e4218c5742a",
+                              "iconColor": "drupal",
+                              "uuid": "7453ed0c-e2e2-4290-86e5-500a65eff5a7",
                               "parentUid": "column",
                               "children": []
                           }
@@ -544,7 +546,7 @@ json_values: |
                                       },
                                       {
                                           "name": "order",
-                                          "active": true
+                                          "active": false
                                       },
                                       {
                                           "name": "flex-grow",
@@ -563,117 +565,7 @@ json_values: |
                                           "active": true
                                       }
                                   ]
-                              }
-                          ]
-                      }
-                  ],
-                  "items": [],
-                  "form": null
-              },
-              "hideNoData": {
-                  "formDefinition": [
-                      {
-                          "formKey": "tab-hide-data-settings",
-                          "children": [
-                              {
-                                  "formKey": "tab-hide-data-hide",
-                                  "breakpoints": [],
-                                  "activeFields": [
-                                      {
-                                          "name": "hideEnable",
-                                          "active": true
-                                      },
-                                      {
-                                          "name": "hideData",
-                                          "active": true
-                                      }
-                                  ]
-                              }
-                          ]
-                      }
-                  ],
-                  "title": "Hide if no data",
-                  "selectorType": "topLevel",
-                  "form": null,
-                  "items": []
-              }
-          },
-          "03045370-34da-4513-bac0-4e4218c5742a": {
-              "settings": {
-                  "formDefinition": [
-                      {
-                          "formKey": "image-settings",
-                          "children": [
-                              {
-                                  "formKey": "image-image",
-                                  "breakpoints": [],
-                                  "activeFields": [
-                                      {
-                                          "name": "image",
-                                          "active": true
-                                      },
-                                      {
-                                          "name": "title",
-                                          "active": true
-                                      },
-                                      {
-                                          "name": "alt",
-                                          "active": true
-                                      },
-                                      {
-                                          "name": "lazyload",
-                                          "active": true
-                                      }
-                                  ]
                               },
-                              {
-                                  "formKey": "image-size",
-                                  "breakpoints": [
-                                      {
-                                          "name": "xl"
-                                      }
-                                  ],
-                                  "activeFields": [
-                                      {
-                                          "name": "displaySize",
-                                          "active": true
-                                      },
-                                      {
-                                          "name": "imageAlignment",
-                                          "active": true
-                                      }
-                                  ]
-                              },
-                              {
-                                  "formKey": "image-style",
-                                  "breakpoints": [],
-                                  "activeFields": [
-                                      {
-                                          "name": "imageStyle",
-                                          "active": true
-                                      },
-                                      {
-                                          "name": "customStyle",
-                                          "active": true
-                                      },
-                                      {
-                                          "name": "customStyle",
-                                          "active": true
-                                      }
-                                  ]
-                              }
-                          ]
-                      }
-                  ],
-                  "selectorType": "topLevel",
-                  "form": null,
-                  "items": []
-              },
-              "styles": {
-                  "formDefinition": [
-                      {
-                          "formKey": "layout",
-                          "children": [
                               {
                                   "formKey": "height",
                                   "breakpoints": [
@@ -726,9 +618,35 @@ json_values: |
                           ]
                       }
                   ],
-                  "selectorType": "topLevel",
                   "items": [],
                   "form": null
+              },
+              "hideNoData": {
+                  "formDefinition": [
+                      {
+                          "formKey": "tab-hide-data-settings",
+                          "children": [
+                              {
+                                  "formKey": "tab-hide-data-hide",
+                                  "breakpoints": [],
+                                  "activeFields": [
+                                      {
+                                          "name": "hideEnable",
+                                          "active": true
+                                      },
+                                      {
+                                          "name": "hideData",
+                                          "active": true
+                                      }
+                                  ]
+                              }
+                          ]
+                      }
+                  ],
+                  "title": "Hide if no data",
+                  "selectorType": "topLevel",
+                  "form": null,
+                  "items": []
               }
           },
           "cd72122c-7060-4407-9d1a-4908f27d790f": {
@@ -2526,7 +2444,8 @@ json_values: |
                   "form": null,
                   "items": []
               }
-          }
+          },
+          "7453ed0c-e2e2-4290-86e5-500a65eff5a7": {}
       },
       "model": {
           "a7097acc-37f8-43bf-b768-6088fd3c254c": {
@@ -3106,66 +3025,9 @@ json_values: |
                   },
                   "styles": {
                       "xl": {
-                          "flex-item": {
-                              "order": {
-                                  "value": "-1"
-                              }
-                          }
-                      }
-                  }
-              },
-              "hideNoData": {
-                  "hideEnable": true,
-                  "hideData": "[node:field_article_image]"
-              }
-          },
-          "03045370-34da-4513-bac0-4e4218c5742a": {
-              "settings": {
-                  "title": "Image",
-                  "styles": {
-                      "xl": {
-                          "displaySize": "coh-image-responsive",
-                          "imageAlignment": "coh-image-align-left"
-                      }
-                  },
-                  "customStyle": [
-                      {
-                          "customStyle": ""
-                      }
-                  ],
-                  "lazyload": false,
-                  "settings": {
-                      "lazyload": false,
-                      "styles": {
-                          "xl": {
-                              "displaySize": "coh-image-responsive"
-                          }
-                      },
-                      "imageStyle": "",
-                      "customStyle": [
-                          {
-                              "customStyle": ""
-                          }
-                      ]
-                  },
-                  "imageStyle": "coh_small_landscape",
-                  "image": "[node:field_article_image:entity:image:entity:path]",
-                  "attributes": {
-                      "title": "[node:field_article_image:entity:image:entity:name]",
-                      "alt": "[node:field_article_image:entity:image:entity:alt]"
-                  }
-              },
-              "context-visibility": {
-                  "contextVisibility": {
-                      "condition": "ALL"
-                  }
-              },
-              "styles": {
-                  "settings": {
-                      "element": "img"
-                  },
-                  "styles": {
-                      "xl": {
+                          "height": {
+                              "value": "100%"
+                          },
                           "custom-css": [
                               {
                                   "customCssProperty": {
@@ -3175,11 +3037,31 @@ json_values: |
                                       "value": "cover"
                                   }
                               }
-                          ],
-                          "height": {
-                              "value": "100%"
-                          }
+                          ]
                       }
+                  }
+              },
+              "hideNoData": {
+                  "hideEnable": true,
+                  "hideData": "[node:field_article_image]"
+              }
+          },
+          "7453ed0c-e2e2-4290-86e5-500a65eff5a7": {
+              "settings": {
+                  "title": "Field",
+                  "settings": {
+                      "drupalField": ""
+                  },
+                  "drupalField": "content.field_article_image"
+              },
+              "context-visibility": {
+                  "contextVisibility": {
+                      "condition": "ALL"
+                  }
+              },
+              "styles": {
+                  "settings": {
+                      "element": "drupal-field"
                   }
               }
           }
@@ -3189,11 +3071,6 @@ json_values: |
           "cd72122c-7060-4407-9d1a-4908f27d790f": {},
           "214b7fb6-88c2-4cd5-976b-a57680313050": {},
           "8aaaf8e0-2384-450a-bcfb-cebd4e5a2336": {},
-          "03045370-34da-4513-bac0-4e4218c5742a": {
-              "settings": {
-                  "image": ""
-              }
-          },
           "e1e399c9-9e92-481a-8339-60ea5643eada": {
               "settings": {
                   "linkText": "A long article placeholder heading that may wrap over multiple lines."
@@ -3219,18 +3096,14 @@ json_values: |
               }
           },
           "205311b4-d91a-41b8-8c22-acb5115d87dd": {},
-          "467d0cd8-02be-41d4-b24d-3f38ad7bd664": {}
+          "467d0cd8-02be-41d4-b24d-3f38ad7bd664": {},
+          "7453ed0c-e2e2-4290-86e5-500a65eff5a7": {}
       },
       "variableFields": {
           "a7097acc-37f8-43bf-b768-6088fd3c254c": [],
           "cd72122c-7060-4407-9d1a-4908f27d790f": [],
           "214b7fb6-88c2-4cd5-976b-a57680313050": [],
           "8aaaf8e0-2384-450a-bcfb-cebd4e5a2336": [],
-          "03045370-34da-4513-bac0-4e4218c5742a": [
-              "settings.attributes.title",
-              "settings.attributes.alt",
-              "settings.image"
-          ],
           "e1e399c9-9e92-481a-8339-60ea5643eada": [
               "settings.linkText",
               "settings.linkToPage"
@@ -3252,7 +3125,8 @@ json_values: |
               "settings.linkToPage"
           ],
           "205311b4-d91a-41b8-8c22-acb5115d87dd": [],
-          "467d0cd8-02be-41d4-b24d-3f38ad7bd664": []
+          "467d0cd8-02be-41d4-b24d-3f38ad7bd664": [],
+          "7453ed0c-e2e2-4290-86e5-500a65eff5a7": []
       },
       "meta": {
           "fieldHistory": []

--- a/modules/acquia_cms_article/config/pack_acquia_cms_article/cohesion_templates.cohesion_content_templates.node_article_search_results.yml
+++ b/modules/acquia_cms_article/config/pack_acquia_cms_article/cohesion_templates.cohesion_content_templates.node_article_search_results.yml
@@ -3,7 +3,10 @@ langcode: en
 status: true
 dependencies:
   config:
-    - image.style.coh_small_landscape
+    - cohesion_custom_styles.cohesion_custom_style.65dc3072
+    - cohesion_custom_styles.cohesion_custom_style.bfd0fecd
+    - cohesion_custom_styles.cohesion_custom_style.ed4b7a3d
+    - cohesion_custom_styles.cohesion_custom_style.f3dc1bea
 label: 'Search Results (Node, Article)'
 id: node_article_search_results
 json_values: |
@@ -181,24 +184,20 @@ json_values: |
                       "uid": "column",
                       "title": "Column",
                       "status": {
-                          "collapsed": true
+                          "collapsed": false
                       },
                       "uuid": "7937185e-6555-4f94-9885-30774bdf5ce9",
                       "parentUid": "row-for-columns",
                       "children": [
                           {
-                              "type": "item",
-                              "uid": "picture",
-                              "title": "Picture",
-                              "selected": false,
+                              "type": "container",
+                              "uid": "drupal-field",
+                              "title": "Field",
                               "status": {
-                                  "collapsed": true,
-                                  "isopen": false,
-                                  "collapsedParents": [
-                                      "7937185e-6555-4f94-9885-30774bdf5ce9"
-                                  ]
+                                  "collapsed": true
                               },
-                              "uuid": "6de41826-4ad6-4b26-b215-16524c7bd5ea",
+                              "iconColor": "drupal",
+                              "uuid": "601cedd8-9aa4-4772-8c22-6526deaf0d47",
                               "parentUid": "column",
                               "children": []
                           }
@@ -560,85 +559,6 @@ json_values: |
                       }
                   ],
                   "title": "Hide if no data",
-                  "selectorType": "topLevel",
-                  "form": null,
-                  "items": []
-              }
-          },
-          "6de41826-4ad6-4b26-b215-16524c7bd5ea": {
-              "settings": {
-                  "formDefinition": [
-                      {
-                          "formKey": "picture-settings",
-                          "children": [
-                              {
-                                  "formKey": "picture-info",
-                                  "breakpoints": [],
-                                  "activeFields": [
-                                      {
-                                          "name": "title",
-                                          "active": true
-                                      },
-                                      {
-                                          "name": "alt",
-                                          "active": true
-                                      },
-                                      {
-                                          "name": "lazyload",
-                                          "active": true
-                                      }
-                                  ]
-                              },
-                              {
-                                  "formKey": "picture-images",
-                                  "breakpoints": [
-                                      {
-                                          "name": "xl"
-                                      },
-                                      {
-                                          "name": "ps"
-                                      }
-                                  ],
-                                  "activeFields": [
-                                      {
-                                          "name": "displaySize",
-                                          "active": true
-                                      },
-                                      {
-                                          "name": "imageAlignment",
-                                          "active": true
-                                      },
-                                      {
-                                          "name": "pictureImagesArray",
-                                          "active": true
-                                      },
-                                      {
-                                          "name": "image",
-                                          "active": true
-                                      },
-                                      {
-                                          "name": "imageStyle",
-                                          "active": true
-                                      }
-                                  ]
-                              },
-                              {
-                                  "formKey": "picture-style",
-                                  "breakpoints": [],
-                                  "activeFields": [
-                                      {
-                                          "name": "customStyle",
-                                          "active": true
-                                      },
-                                      {
-                                          "name": "customStyle",
-                                          "active": true
-                                      }
-                                  ]
-                              }
-                          ]
-                      }
-                  ],
                   "selectorType": "topLevel",
                   "form": null,
                   "items": []
@@ -2374,7 +2294,8 @@ json_values: |
                   "form": null,
                   "items": []
               }
-          }
+          },
+          "601cedd8-9aa4-4772-8c22-6526deaf0d47": {}
       },
       "model": {
           "77586c33-8dae-499d-8beb-39b6db45e48d": {
@@ -2958,56 +2879,13 @@ json_values: |
                   "hideData": "[node:field_article_image]"
               }
           },
-          "6de41826-4ad6-4b26-b215-16524c7bd5ea": {
+          "601cedd8-9aa4-4772-8c22-6526deaf0d47": {
               "settings": {
-                  "title": "Picture",
-                  "customStyle": [
-                      {
-                          "customStyle": ""
-                      }
-                  ],
-                  "styles": {
-                      "xl": {
-                          "pictureImagesArray": [
-                              {
-                                  "imageStyle": "x_small_square_320x320_",
-                                  "image": "[node:field_article_image:entity:image:entity:path]"
-                              }
-                          ],
-                          "displaySize": "coh-image-responsive"
-                      },
-                      "ps": {
-                          "pictureImagesArray": [
-                              {
-                                  "imageStyle": "coh_small_landscape"
-                              }
-                          ],
-                          "displaySize": "coh-image-responsive"
-                      }
-                  },
-                  "lazyload": false,
+                  "title": "Field",
                   "settings": {
-                      "lazyload": false,
-                      "styles": {
-                          "xl": {
-                              "displaySize": "coh-image-responsive",
-                              "pictureImagesArray": [
-                                  {
-                                      "imageStyle": ""
-                                  }
-                              ]
-                          }
-                      },
-                      "customStyle": [
-                          {
-                              "customStyle": ""
-                          }
-                      ]
+                      "drupalField": ""
                   },
-                  "attributes": {
-                      "title": "[node:field_article_image:entity:image:entity:name]",
-                      "alt": "[node:field_article_image:entity:image:entity:alt]"
-                  }
+                  "drupalField": "content.field_article_image"
               },
               "context-visibility": {
                   "contextVisibility": {
@@ -3016,7 +2894,7 @@ json_values: |
               },
               "styles": {
                   "settings": {
-                      "element": "picture"
+                      "element": "drupal-field"
                   }
               }
           }
@@ -3060,20 +2938,8 @@ json_values: |
                   "linkToPage": "#"
               }
           },
-          "6de41826-4ad6-4b26-b215-16524c7bd5ea": {
-              "settings": {
-                  "styles": {
-                      "xl": {
-                          "pictureImagesArray": [
-                              {
-                                  "image": ""
-                              }
-                          ]
-                      }
-                  }
-              }
-          },
-          "30b6853e-c586-460f-bae0-711a2355750e": []
+          "30b6853e-c586-460f-bae0-711a2355750e": [],
+          "601cedd8-9aa4-4772-8c22-6526deaf0d47": {}
       },
       "variableFields": {
           "77586c33-8dae-499d-8beb-39b6db45e48d": [],
@@ -3100,12 +2966,8 @@ json_values: |
               "settings.linkText",
               "settings.linkToPage"
           ],
-          "6de41826-4ad6-4b26-b215-16524c7bd5ea": [
-              "settings.styles.xl.pictureImagesArray.0.image",
-              "settings.attributes.title",
-              "settings.attributes.alt"
-          ],
-          "30b6853e-c586-460f-bae0-711a2355750e": []
+          "30b6853e-c586-460f-bae0-711a2355750e": [],
+          "601cedd8-9aa4-4772-8c22-6526deaf0d47": []
       },
       "meta": {
           "fieldHistory": []

--- a/modules/acquia_cms_article/config/pack_acquia_cms_article/cohesion_templates.cohesion_content_templates.node_article_teaser.yml
+++ b/modules/acquia_cms_article/config/pack_acquia_cms_article/cohesion_templates.cohesion_content_templates.node_article_teaser.yml
@@ -3,7 +3,10 @@ langcode: en
 status: true
 dependencies:
   config:
-    - image.style.coh_small_landscape
+    - cohesion_custom_styles.cohesion_custom_style.65dc3072
+    - cohesion_custom_styles.cohesion_custom_style.bfd0fecd
+    - cohesion_custom_styles.cohesion_custom_style.ed4b7a3d
+    - cohesion_custom_styles.cohesion_custom_style.f3dc1bea
 label: 'Teaser (Node, Article)'
 id: node_article_teaser
 json_values: |
@@ -181,24 +184,20 @@ json_values: |
                       "uid": "column",
                       "title": "Column",
                       "status": {
-                          "collapsed": true
+                          "collapsed": false
                       },
                       "uuid": "e635a39f-9686-428d-b388-e73b5f5862ef",
                       "parentUid": "row-for-columns",
                       "children": [
                           {
-                              "type": "item",
-                              "uid": "picture",
-                              "title": "Picture",
-                              "selected": false,
+                              "type": "container",
+                              "uid": "drupal-field",
+                              "title": "Field",
                               "status": {
-                                  "collapsed": true,
-                                  "isopen": false,
-                                  "collapsedParents": [
-                                      "e635a39f-9686-428d-b388-e73b5f5862ef"
-                                  ]
+                                  "collapsed": true
                               },
-                              "uuid": "8cc1cc4f-7a0b-4719-b4e5-0bb4523634df",
+                              "iconColor": "drupal",
+                              "uuid": "23501431-8fb1-4c50-aede-5b63f4207284",
                               "parentUid": "column",
                               "children": []
                           }
@@ -560,85 +559,6 @@ json_values: |
                       }
                   ],
                   "title": "Hide if no data",
-                  "selectorType": "topLevel",
-                  "form": null,
-                  "items": []
-              }
-          },
-          "8cc1cc4f-7a0b-4719-b4e5-0bb4523634df": {
-              "settings": {
-                  "formDefinition": [
-                      {
-                          "formKey": "picture-settings",
-                          "children": [
-                              {
-                                  "formKey": "picture-info",
-                                  "breakpoints": [],
-                                  "activeFields": [
-                                      {
-                                          "name": "title",
-                                          "active": true
-                                      },
-                                      {
-                                          "name": "alt",
-                                          "active": true
-                                      },
-                                      {
-                                          "name": "lazyload",
-                                          "active": true
-                                      }
-                                  ]
-                              },
-                              {
-                                  "formKey": "picture-images",
-                                  "breakpoints": [
-                                      {
-                                          "name": "xl"
-                                      },
-                                      {
-                                          "name": "ps"
-                                      }
-                                  ],
-                                  "activeFields": [
-                                      {
-                                          "name": "displaySize",
-                                          "active": true
-                                      },
-                                      {
-                                          "name": "imageAlignment",
-                                          "active": true
-                                      },
-                                      {
-                                          "name": "pictureImagesArray",
-                                          "active": true
-                                      },
-                                      {
-                                          "name": "image",
-                                          "active": true
-                                      },
-                                      {
-                                          "name": "imageStyle",
-                                          "active": true
-                                      }
-                                  ]
-                              },
-                              {
-                                  "formKey": "picture-style",
-                                  "breakpoints": [],
-                                  "activeFields": [
-                                      {
-                                          "name": "customStyle",
-                                          "active": true
-                                      },
-                                      {
-                                          "name": "customStyle",
-                                          "active": true
-                                      }
-                                  ]
-                              }
-                          ]
-                      }
-                  ],
                   "selectorType": "topLevel",
                   "form": null,
                   "items": []
@@ -2303,7 +2223,8 @@ json_values: |
                   "form": null,
                   "items": []
               }
-          }
+          },
+          "23501431-8fb1-4c50-aede-5b63f4207284": {}
       },
       "model": {
           "da724fc2-2f20-4fc6-a332-4aa3da11641e": {
@@ -2866,56 +2787,13 @@ json_values: |
                   "hideData": "[node:field_article_image]"
               }
           },
-          "8cc1cc4f-7a0b-4719-b4e5-0bb4523634df": {
+          "23501431-8fb1-4c50-aede-5b63f4207284": {
               "settings": {
-                  "title": "Picture",
-                  "customStyle": [
-                      {
-                          "customStyle": ""
-                      }
-                  ],
-                  "styles": {
-                      "xl": {
-                          "pictureImagesArray": [
-                              {
-                                  "imageStyle": "x_small_square_320x320_",
-                                  "image": "[node:field_article_image:entity:image:entity:path]"
-                              }
-                          ],
-                          "displaySize": "coh-image-responsive"
-                      },
-                      "ps": {
-                          "pictureImagesArray": [
-                              {
-                                  "imageStyle": "coh_small_landscape"
-                              }
-                          ],
-                          "displaySize": "coh-image-responsive"
-                      }
-                  },
-                  "lazyload": false,
+                  "title": "Field",
                   "settings": {
-                      "lazyload": false,
-                      "styles": {
-                          "xl": {
-                              "displaySize": "coh-image-responsive",
-                              "pictureImagesArray": [
-                                  {
-                                      "imageStyle": ""
-                                  }
-                              ]
-                          }
-                      },
-                      "customStyle": [
-                          {
-                              "customStyle": ""
-                          }
-                      ]
+                      "drupalField": ""
                   },
-                  "attributes": {
-                      "title": "[node:field_article_image:entity:image:entity:name]",
-                      "alt": "[node:field_article_image:entity:image:entity:alt]"
-                  }
+                  "drupalField": "content.field_article_image"
               },
               "context-visibility": {
                   "contextVisibility": {
@@ -2924,7 +2802,7 @@ json_values: |
               },
               "styles": {
                   "settings": {
-                      "element": "picture"
+                      "element": "drupal-field"
                   }
               }
           }
@@ -2933,23 +2811,6 @@ json_values: |
           "da724fc2-2f20-4fc6-a332-4aa3da11641e": {},
           "d1c9183a-7aa4-4c15-a5c3-d72a35dce02e": {},
           "e635a39f-9686-428d-b388-e73b5f5862ef": {},
-          "8cc1cc4f-7a0b-4719-b4e5-0bb4523634df": {
-              "settings": {
-                  "attributes": {
-                      "title": "",
-                      "alt": ""
-                  },
-                  "styles": {
-                      "xl": {
-                          "pictureImagesArray": [
-                              {
-                                  "image": ""
-                              }
-                          ]
-                      }
-                  }
-              }
-          },
           "106e8d49-aa71-48f2-9159-ee8b0c3d1862": {},
           "90533d10-fb6d-4f66-9cd9-366582f6c177": {
               "settings": {
@@ -2978,17 +2839,13 @@ json_values: |
                   "linkText": "James Anderson",
                   "linkToPage": "#"
               }
-          }
+          },
+          "23501431-8fb1-4c50-aede-5b63f4207284": {}
       },
       "variableFields": {
           "da724fc2-2f20-4fc6-a332-4aa3da11641e": [],
           "d1c9183a-7aa4-4c15-a5c3-d72a35dce02e": [],
           "e635a39f-9686-428d-b388-e73b5f5862ef": [],
-          "8cc1cc4f-7a0b-4719-b4e5-0bb4523634df": [
-              "settings.attributes.title",
-              "settings.attributes.alt",
-              "settings.styles.xl.pictureImagesArray.0.image"
-          ],
           "106e8d49-aa71-48f2-9159-ee8b0c3d1862": [],
           "90533d10-fb6d-4f66-9cd9-366582f6c177": [
               "settings.linkText",
@@ -3012,7 +2869,8 @@ json_values: |
           "bd228267-4650-4888-aaa6-8ad62b00c9eb": [
               "settings.linkText",
               "settings.linkToPage"
-          ]
+          ],
+          "23501431-8fb1-4c50-aede-5b63f4207284": []
       },
       "meta": {
           "fieldHistory": []

--- a/modules/acquia_cms_common/acquia_cms_common.install
+++ b/modules/acquia_cms_common/acquia_cms_common.install
@@ -159,3 +159,13 @@ function acquia_cms_common_content_model_role_presave_alter(RoleInterface &$role
     }
   }
 }
+
+/**
+ * Implements hook_update_N().
+ *
+ * Add referenced image view mode.
+ */
+function acquia_cms_common_update_8003() {
+  // Add referenced image view mode.
+  _acquia_cms_common_rewrite_configuration('core.entity_view_mode.node.referenced_image', 'acquia_cms_common');
+}

--- a/modules/acquia_cms_common/config/optional/core.entity_view_mode.node.referenced_image.yml
+++ b/modules/acquia_cms_common/config/optional/core.entity_view_mode.node.referenced_image.yml
@@ -1,0 +1,9 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+id: node.referenced_image
+label: 'Referenced Image'
+targetEntityType: node
+cache: true

--- a/modules/acquia_cms_dam/README.md
+++ b/modules/acquia_cms_dam/README.md
@@ -40,14 +40,14 @@ Require Acquia CMS DAM.
 
 `composer require drupal/acquia_cms_dam`
 
-#Configuration
+# Configuration
 This module need manual Configuration
-Visit `/admin/config/acquia-dam`
-Provide your Acquia DAM Domain & click on Save DAM Configuration
-Login to DAM server and authenticate
-Visit `/user`
-Click on Acquia DAM tab on user profile page.
-Click on Connect to Acquia Dam.
+* Visit `/admin/config/acquia-dam`
+* Provide your Acquia DAM Domain & click on Save DAM Configuration
+* Login to DAM server and authenticate
+* Visit `/user`
+* Click on `Acquia DAM` tab on user profile page.
+* Click on `Connect` under Connect to Acquia Dam.
 
 # Maintainers
 Current maintainers:

--- a/modules/acquia_cms_dam/acquia_cms_dam.info.yml
+++ b/modules/acquia_cms_dam/acquia_cms_dam.info.yml
@@ -4,7 +4,7 @@ description: 'Provides an Acquia DAM related configuration.'
 type: module
 core_version_requirement: ^9 || ^10
 dependencies:
-  - drupal:acquia_cms_image
-  - drupal:acquia_cms_video
-  - drupal:acquia_dam
+  - acquia_cms_image:acquia_cms_image
+  - acquia_cms_video:acquia_cms_video
+  - acquia_dam:acquia_dam
   - acquia_dam:acquia_dam_integration_links

--- a/modules/acquia_cms_dam/acquia_cms_dam.module
+++ b/modules/acquia_cms_dam/acquia_cms_dam.module
@@ -1,0 +1,56 @@
+<?php
+
+/**
+ * @file
+ * Contains hook implementations for ACMS DAM.
+ */
+
+/**
+ * Implements hook_modules_installed().
+ */
+function acquia_cms_dam_modules_installed($modules) {
+  $content_model = [
+    'acquia_cms_article',
+    'acquia_cms_event',
+    'acquia_cms_page',
+    'acquia_cms_person',
+    'acquia_cms_place',
+  ];
+  $moduleHandler = \Drupal::service('module_handler');
+  if (in_array('acquia_cms_dam', $modules) || $content_model = array_intersect($modules, $content_model)) {
+    foreach ($content_model as $module) {
+      if ($moduleHandler->moduleExists($module)) {
+        $node_type = explode('_', $module);
+        // Update content type image field to support Acquia DAM.
+        _acquia_cms_dam_update_content_type_image_field(end($node_type));
+      }
+    }
+    // Flush cache to reflect Acquia CMS DAM configs.
+    drupal_flush_all_caches();
+  }
+}
+
+/**
+ * Helper function to update content type image field config.
+ *
+ * @param string $node_type
+ *   The node type.
+ */
+function _acquia_cms_dam_update_content_type_image_field(string $node_type) {
+  // Update content type image field configuration for DAM integration.
+  if ($node_type) {
+    $field = 'field.field.node.' . $node_type . '.field_' . $node_type . '_image';
+    if ($field_config = \Drupal::configFactory()->getEditable($field)) {
+      if (!array_intersect($field_config->get('dependencies.config'), ['media.type.acquia_dam_image_asset'])) {
+        $field_config->set('dependencies.config', array_merge($field_config->get('dependencies.config'), ['media.type.acquia_dam_image_asset']));
+      }
+      if (!$field_config->get('settings.handler_settings.target_bundles.acquia_dam_image_asset')) {
+        $field_config->set('settings.handler_settings.target_bundles.acquia_dam_image_asset', 'acquia_dam_image_asset');
+      }
+      if (!$field_config->get('settings.handler_settings.sort.direction')) {
+        $field_config->set('settings.handler_settings.sort.direction', 'ASC');
+      }
+      $field_config->save();
+    }
+  }
+}

--- a/modules/acquia_cms_dam/composer.json
+++ b/modules/acquia_cms_dam/composer.json
@@ -1,12 +1,22 @@
 {
     "name": "drupal/acquia_cms_dam",
-    "type": "drupal-module",
     "description": "Provides an Acquia DAM related configuration.",
     "license": "GPL-2.0-or-later",
+    "type": "drupal-module",
     "require": {
         "drupal/acquia_cms_image": "^1.4",
         "drupal/acquia_cms_video": "^1.4",
         "drupal/acquia_dam": "^1"
+    },
+    "repositories": {
+        "drupal": {
+            "type": "composer",
+            "url": "https://packages.drupal.org/8"
+        },
+        "assets": {
+            "type": "composer",
+            "url": "https://asset-packagist.org"
+        }
     },
     "config": {
         "allow-plugins": {
@@ -18,16 +28,6 @@
             "oomphinc/composer-installers-extender": true,
             "phpro/grumphp-shim": true,
             "webdriver-binary/binary-chromedriver": true
-        }
-    },
-    "repositories": {
-        "drupal": {
-            "type": "composer",
-            "url": "https://packages.drupal.org/8"
-        },
-        "assets": {
-            "type": "composer",
-            "url": "https://asset-packagist.org"
         }
     }
 }

--- a/modules/acquia_cms_event/acquia_cms_event.install
+++ b/modules/acquia_cms_event/acquia_cms_event.install
@@ -71,3 +71,61 @@ function acquia_cms_event_update_8002() {
     }
   }
 }
+
+/**
+ * Implements hook_update_N().
+ *
+ * Update Event display modes.
+ */
+function acquia_cms_event_update_8003() {
+  // Load and update default view mode.
+  $event_image_field = [
+    'field_event_image' => [
+      'type' => 'entity_reference_entity_view',
+      'label' => 'hidden',
+      'settings' => [
+        'view_mode' => 'full',
+        'link' => 'false',
+      ],
+      'third_party_settings' => [],
+      'weight' => 2,
+      'region' => 'content',
+    ],
+  ];
+  $display_modes = [
+    'default',
+    'card',
+    'horizontal_card',
+    'search_results',
+    'teaser',
+  ];
+  $view_modes = [
+    'full',
+    'card',
+    'large_super_landscape',
+    'small',
+    'teaser',
+  ];
+  foreach ($display_modes as $key => $display_mode) {
+    $event_default = \Drupal::configFactory()->getEditable('core.entity_view_display.node.event.' . $display_mode);
+    if ($event_default->get('hidden.field_event_image')) {
+      $event_image_field['field_event_image']['settings']['view_mode'] = $view_modes[$key];
+      $event_default->set('content', array_merge($event_default->get('content'), $event_image_field));
+      if ($event_default->get('content.body')) {
+        $event_default->set('content.body.weight', $event_default->get('content.body.weight') + 1);
+      }
+      if ($event_default->get('content.field_event_end')) {
+        $event_default->set('content.field_event_end.weight', $event_default->get('content.field_event_end.weight') + 1);
+      }
+      if ($event_default->get('content.field_event_place')) {
+        $event_default->set('content.field_event_place.weight', $event_default->get('content.field_event_place.weight') + 1);
+      }
+      if ($event_default->get('content.field_event_start')) {
+        $event_default->set('content.field_event_start.weight', $event_default->get('content.field_event_start.weight') + 1);
+      }
+      $event_default->clear('hidden.field_event_image');
+      $event_default->save();
+    }
+  }
+
+}

--- a/modules/acquia_cms_event/acquia_cms_event.install
+++ b/modules/acquia_cms_event/acquia_cms_event.install
@@ -100,32 +100,41 @@ function acquia_cms_event_update_8003() {
     'teaser',
   ];
   $view_modes = [
-    'full',
-    'card',
     'large_super_landscape',
-    'small',
+    'small_landscape',
+    'small_landscape',
+    'teaser',
     'teaser',
   ];
+  // Update Image field.
   foreach ($display_modes as $key => $display_mode) {
-    $event_default = \Drupal::configFactory()->getEditable('core.entity_view_display.node.event.' . $display_mode);
-    if ($event_default->get('hidden.field_event_image')) {
+    $event_view_mode = \Drupal::configFactory()->getEditable('core.entity_view_display.node.event.' . $display_mode);
+    if ($event_view_mode->get('hidden.field_event_image')) {
       $event_image_field['field_event_image']['settings']['view_mode'] = $view_modes[$key];
-      $event_default->set('content', array_merge($event_default->get('content'), $event_image_field));
-      if ($event_default->get('content.body')) {
-        $event_default->set('content.body.weight', $event_default->get('content.body.weight') + 1);
+      $event_view_mode->set('content', array_merge($event_view_mode->get('content'), $event_image_field));
+      if ($event_view_mode->get('content.body')) {
+        $event_view_mode->set('content.body.weight', $event_view_mode->get('content.body.weight') + 1);
       }
-      if ($event_default->get('content.field_event_end')) {
-        $event_default->set('content.field_event_end.weight', $event_default->get('content.field_event_end.weight') + 1);
+      if ($event_view_mode->get('content.field_event_end')) {
+        $event_view_mode->set('content.field_event_end.weight', $event_view_mode->get('content.field_event_end.weight') + 1);
       }
-      if ($event_default->get('content.field_event_place')) {
-        $event_default->set('content.field_event_place.weight', $event_default->get('content.field_event_place.weight') + 1);
+      if ($event_view_mode->get('content.field_event_place')) {
+        $event_view_mode->set('content.field_event_place.weight', $event_view_mode->get('content.field_event_place.weight') + 1);
       }
-      if ($event_default->get('content.field_event_start')) {
-        $event_default->set('content.field_event_start.weight', $event_default->get('content.field_event_start.weight') + 1);
+      if ($event_view_mode->get('content.field_event_start')) {
+        $event_view_mode->set('content.field_event_start.weight', $event_view_mode->get('content.field_event_start.weight') + 1);
       }
-      $event_default->clear('hidden.field_event_image');
-      $event_default->save();
+      $event_view_mode->clear('hidden.field_event_image');
+      $event_view_mode->save();
     }
+  }
+
+  // Update Place field.
+  $event_view_mode = \Drupal::configFactory()->getEditable('core.entity_view_display.node.event.default');
+  if ($event_view_mode->get('content.field_event_place.type') == 'entity_reference_label') {
+    $event_view_mode->set('content.field_event_place.type', 'entity_reference_entity_view');
+    $event_view_mode->set('content.field_event_place.settings.view_mode', 'referenced_image');
+    $event_view_mode->save();
   }
 
 }

--- a/modules/acquia_cms_event/config/optional/core.entity_view_display.node.event.card.yml
+++ b/modules/acquia_cms_event/config/optional/core.entity_view_display.node.event.card.yml
@@ -48,23 +48,6 @@ content:
     third_party_settings: {  }
     weight: 5
     region: content
-  field_event_image:
-    type: entity_reference_entity_view
-    label: hidden
-    settings:
-      view_mode: card
-      link: false
-    third_party_settings: {  }
-    weight: 2
-    region: content
-  field_event_place:
-    type: entity_reference_label
-    label: hidden
-    settings:
-      link: false
-    third_party_settings: {  }
-    weight: 6
-    region: content
   field_event_start:
     type: datetime_default
     label: hidden
@@ -79,10 +62,20 @@ content:
     third_party_settings: {  }
     weight: 1
     region: content
+  field_event_image:
+    type: entity_reference_entity_view
+    label: hidden
+    settings:
+      view_mode: card
+      link: false
+    third_party_settings: {  }
+    weight: 2
+    region: content
 hidden:
   field_categories: true
   field_door_time: true
   field_event_duration: true
+  field_event_place: true
   field_event_type: true
   field_tags: true
   langcode: true

--- a/modules/acquia_cms_event/config/optional/core.entity_view_display.node.event.card.yml
+++ b/modules/acquia_cms_event/config/optional/core.entity_view_display.node.event.card.yml
@@ -48,6 +48,23 @@ content:
     third_party_settings: {  }
     weight: 5
     region: content
+  field_event_image:
+    type: entity_reference_entity_view
+    label: hidden
+    settings:
+      view_mode: small_landscape
+      link: false
+    third_party_settings: {  }
+    weight: 2
+    region: content
+  field_event_place:
+    type: entity_reference_label
+    label: hidden
+    settings:
+      link: false
+    third_party_settings: {  }
+    weight: 6
+    region: content
   field_event_start:
     type: datetime_default
     label: hidden
@@ -62,20 +79,10 @@ content:
     third_party_settings: {  }
     weight: 1
     region: content
-  field_event_image:
-    type: entity_reference_entity_view
-    label: hidden
-    settings:
-      view_mode: card
-      link: false
-    third_party_settings: {  }
-    weight: 2
-    region: content
 hidden:
   field_categories: true
   field_door_time: true
   field_event_duration: true
-  field_event_place: true
   field_event_type: true
   field_tags: true
   langcode: true

--- a/modules/acquia_cms_event/config/optional/core.entity_view_display.node.event.card.yml
+++ b/modules/acquia_cms_event/config/optional/core.entity_view_display.node.event.card.yml
@@ -28,53 +28,61 @@ mode: card
 content:
   body:
     type: text_summary_or_trimmed
-    weight: 2
-    region: content
     label: hidden
     settings:
       trim_length: 128
     third_party_settings: {  }
-  content_moderation_control:
-    weight: 0
+    weight: 3
     region: content
+  content_moderation_control:
     settings: {  }
     third_party_settings: {  }
+    weight: 0
+    region: content
   field_event_end:
     type: datetime_default
-    weight: 4
-    region: content
     label: hidden
     settings:
       timezone_override: ''
       format_type: short
     third_party_settings: {  }
-  field_event_place:
-    type: entity_reference_label
     weight: 5
     region: content
+  field_event_image:
+    type: entity_reference_entity_view
+    label: hidden
+    settings:
+      view_mode: card
+      link: false
+    third_party_settings: {  }
+    weight: 2
+    region: content
+  field_event_place:
+    type: entity_reference_label
     label: hidden
     settings:
       link: false
     third_party_settings: {  }
+    weight: 6
+    region: content
   field_event_start:
     type: datetime_default
-    weight: 3
-    region: content
     label: hidden
     settings:
       timezone_override: ''
       format_type: short
     third_party_settings: {  }
-  links:
-    weight: 1
+    weight: 4
     region: content
+  links:
     settings: {  }
     third_party_settings: {  }
+    weight: 1
+    region: content
 hidden:
   field_categories: true
   field_door_time: true
   field_event_duration: true
-  field_event_image: true
   field_event_type: true
   field_tags: true
   langcode: true

--- a/modules/acquia_cms_event/config/optional/core.entity_view_display.node.event.default.yml
+++ b/modules/acquia_cms_event/config/optional/core.entity_view_display.node.event.default.yml
@@ -30,7 +30,7 @@ content:
     label: hidden
     settings: {  }
     third_party_settings: {  }
-    weight: 3
+    weight: 2
     region: content
   content_moderation_control:
     settings: {  }
@@ -44,15 +44,25 @@ content:
       timezone_override: ''
       format_type: short
     third_party_settings: {  }
-    weight: 6
+    weight: 5
     region: content
-  field_event_place:
-    type: entity_reference_label
+  field_event_image:
+    type: entity_reference_entity_view
     label: hidden
     settings:
+      view_mode: large_super_landscape
       link: false
     third_party_settings: {  }
-    weight: 4
+    weight: 2
+    region: content
+  field_event_place:
+    type: entity_reference_entity_view
+    label: hidden
+    settings:
+      view_mode: referenced_image
+      link: false
+    third_party_settings: {  }
+    weight: 3
     region: content
   field_event_start:
     type: datetime_default
@@ -61,21 +71,12 @@ content:
       timezone_override: ''
       format_type: short
     third_party_settings: {  }
-    weight: 5
+    weight: 4
     region: content
   links:
     settings: {  }
     third_party_settings: {  }
-    weight: 1
-    region: content
-  field_event_image:
-    type: entity_reference_entity_view
-    label: hidden
-    settings:
-      view_mode: full
-      link: false
-    third_party_settings: {  }
-    weight: 2
+    weight: 5
     region: content
 hidden:
   field_categories: true

--- a/modules/acquia_cms_event/config/optional/core.entity_view_display.node.event.default.yml
+++ b/modules/acquia_cms_event/config/optional/core.entity_view_display.node.event.default.yml
@@ -27,52 +27,60 @@ mode: default
 content:
   body:
     type: text_default
-    weight: 1
-    region: content
     label: hidden
     settings: {  }
     third_party_settings: {  }
-  content_moderation_control:
-    weight: 0
+    weight: 2
     region: content
+  content_moderation_control:
     settings: {  }
     third_party_settings: {  }
+    weight: 0
+    region: content
   field_event_end:
     type: datetime_default
-    weight: 4
-    region: content
     label: hidden
     settings:
       timezone_override: ''
       format_type: short
     third_party_settings: {  }
+    weight: 5
+    region: content
+  field_event_image:
+    type: entity_reference_entity_view
+    label: hidden
+    settings:
+      view_mode: full
+      link: false
+    third_party_settings: {  }
+    weight: 1
+    region: content
   field_event_place:
     type: entity_reference_label
-    weight: 2
-    region: content
     label: hidden
     settings:
       link: false
     third_party_settings: {  }
-  field_event_start:
-    type: datetime_default
     weight: 3
     region: content
+  field_event_start:
+    type: datetime_default
     label: hidden
     settings:
       timezone_override: ''
       format_type: short
     third_party_settings: {  }
-  links:
-    weight: 5
+    weight: 4
     region: content
+  links:
     settings: {  }
     third_party_settings: {  }
+    weight: 6
+    region: content
 hidden:
   field_categories: true
   field_door_time: true
   field_event_duration: true
-  field_event_image: true
   field_event_type: true
   field_tags: true
   langcode: true

--- a/modules/acquia_cms_event/config/optional/core.entity_view_display.node.event.default.yml
+++ b/modules/acquia_cms_event/config/optional/core.entity_view_display.node.event.default.yml
@@ -30,7 +30,7 @@ content:
     label: hidden
     settings: {  }
     third_party_settings: {  }
-    weight: 2
+    weight: 3
     region: content
   content_moderation_control:
     settings: {  }
@@ -44,16 +44,7 @@ content:
       timezone_override: ''
       format_type: short
     third_party_settings: {  }
-    weight: 5
-    region: content
-  field_event_image:
-    type: entity_reference_entity_view
-    label: hidden
-    settings:
-      view_mode: full
-      link: false
-    third_party_settings: {  }
-    weight: 1
+    weight: 6
     region: content
   field_event_place:
     type: entity_reference_label
@@ -61,7 +52,7 @@ content:
     settings:
       link: false
     third_party_settings: {  }
-    weight: 3
+    weight: 4
     region: content
   field_event_start:
     type: datetime_default
@@ -70,12 +61,21 @@ content:
       timezone_override: ''
       format_type: short
     third_party_settings: {  }
-    weight: 4
+    weight: 5
     region: content
   links:
     settings: {  }
     third_party_settings: {  }
-    weight: 6
+    weight: 1
+    region: content
+  field_event_image:
+    type: entity_reference_entity_view
+    label: hidden
+    settings:
+      view_mode: full
+      link: false
+    third_party_settings: {  }
+    weight: 2
     region: content
 hidden:
   field_categories: true

--- a/modules/acquia_cms_event/config/optional/core.entity_view_display.node.event.horizontal_card.yml
+++ b/modules/acquia_cms_event/config/optional/core.entity_view_display.node.event.horizontal_card.yml
@@ -32,7 +32,7 @@ content:
     settings:
       trim_length: 300
     third_party_settings: {  }
-    weight: 2
+    weight: 3
     region: content
   content_moderation_control:
     settings: {  }
@@ -46,16 +46,7 @@ content:
       timezone_override: ''
       format_type: short
     third_party_settings: {  }
-    weight: 5
-    region: content
-  field_event_image:
-    type: entity_reference_entity_view
-    label: hidden
-    settings:
-      view_mode: large_super_landscape
-      link: false
-    third_party_settings: {  }
-    weight: 1
+    weight: 6
     region: content
   field_event_place:
     type: entity_reference_label
@@ -63,7 +54,7 @@ content:
     settings:
       link: false
     third_party_settings: {  }
-    weight: 3
+    weight: 4
     region: content
   field_event_start:
     type: datetime_default
@@ -72,12 +63,21 @@ content:
       timezone_override: ''
       format_type: short
     third_party_settings: {  }
-    weight: 4
+    weight: 5
     region: content
   links:
     settings: {  }
     third_party_settings: {  }
-    weight: 6
+    weight: 1
+    region: content
+  field_event_image:
+    type: entity_reference_entity_view
+    label: hidden
+    settings:
+      view_mode: large_super_landscape
+      link: false
+    third_party_settings: {  }
+    weight: 2
     region: content
 hidden:
   field_categories: true

--- a/modules/acquia_cms_event/config/optional/core.entity_view_display.node.event.horizontal_card.yml
+++ b/modules/acquia_cms_event/config/optional/core.entity_view_display.node.event.horizontal_card.yml
@@ -46,7 +46,16 @@ content:
       timezone_override: ''
       format_type: short
     third_party_settings: {  }
-    weight: 6
+    weight: 5
+    region: content
+  field_event_image:
+    type: entity_reference_entity_view
+    label: hidden
+    settings:
+      view_mode: small_landscape
+      link: false
+    third_party_settings: {  }
+    weight: 2
     region: content
   field_event_place:
     type: entity_reference_label
@@ -54,7 +63,7 @@ content:
     settings:
       link: false
     third_party_settings: {  }
-    weight: 4
+    weight: 3
     region: content
   field_event_start:
     type: datetime_default
@@ -63,21 +72,12 @@ content:
       timezone_override: ''
       format_type: short
     third_party_settings: {  }
-    weight: 5
+    weight: 4
     region: content
   links:
     settings: {  }
     third_party_settings: {  }
-    weight: 1
-    region: content
-  field_event_image:
-    type: entity_reference_entity_view
-    label: hidden
-    settings:
-      view_mode: large_super_landscape
-      link: false
-    third_party_settings: {  }
-    weight: 2
+    weight: 5
     region: content
 hidden:
   field_categories: true

--- a/modules/acquia_cms_event/config/optional/core.entity_view_display.node.event.horizontal_card.yml
+++ b/modules/acquia_cms_event/config/optional/core.entity_view_display.node.event.horizontal_card.yml
@@ -28,53 +28,61 @@ mode: horizontal_card
 content:
   body:
     type: text_summary_or_trimmed
-    weight: 2
-    region: content
     label: hidden
     settings:
       trim_length: 300
     third_party_settings: {  }
-  content_moderation_control:
-    weight: 0
+    weight: 2
     region: content
+  content_moderation_control:
     settings: {  }
     third_party_settings: {  }
+    weight: 0
+    region: content
   field_event_end:
     type: datetime_default
-    weight: 4
-    region: content
     label: hidden
     settings:
       timezone_override: ''
       format_type: short
     third_party_settings: {  }
+    weight: 5
+    region: content
+  field_event_image:
+    type: entity_reference_entity_view
+    label: hidden
+    settings:
+      view_mode: large_super_landscape
+      link: false
+    third_party_settings: {  }
+    weight: 1
+    region: content
   field_event_place:
     type: entity_reference_label
-    weight: 2
-    region: content
     label: hidden
     settings:
       link: false
     third_party_settings: {  }
-  field_event_start:
-    type: datetime_default
     weight: 3
     region: content
+  field_event_start:
+    type: datetime_default
     label: hidden
     settings:
       timezone_override: ''
       format_type: short
     third_party_settings: {  }
-  links:
-    weight: 5
+    weight: 4
     region: content
+  links:
     settings: {  }
     third_party_settings: {  }
+    weight: 6
+    region: content
 hidden:
   field_categories: true
   field_door_time: true
   field_event_duration: true
-  field_event_image: true
   field_event_type: true
   field_tags: true
   langcode: true

--- a/modules/acquia_cms_event/config/optional/core.entity_view_display.node.event.search_results.yml
+++ b/modules/acquia_cms_event/config/optional/core.entity_view_display.node.event.search_results.yml
@@ -49,19 +49,19 @@ content:
     third_party_settings: {  }
     weight: 0
     region: content
-  links:
-    settings: {  }
-    third_party_settings: {  }
-    weight: 1
-    region: content
   field_event_image:
     type: entity_reference_entity_view
     label: hidden
     settings:
-      view_mode: small
+      view_mode: teaser
       link: false
     third_party_settings: {  }
     weight: 2
+    region: content
+  links:
+    settings: {  }
+    third_party_settings: {  }
+    weight: 1
     region: content
 hidden:
   field_categories: true

--- a/modules/acquia_cms_event/config/optional/core.entity_view_display.node.event.search_results.yml
+++ b/modules/acquia_cms_event/config/optional/core.entity_view_display.node.event.search_results.yml
@@ -27,39 +27,47 @@ mode: search_results
 content:
   body:
     type: smart_trim
-    weight: 2
-    region: content
     label: hidden
     settings:
       trim_length: 128
       trim_type: chars
       trim_suffix: ...
-      wrap_class: trimmed
-      more_text: More
-      more_class: more-link
-      summary_handler: trim
       wrap_output: false
+      wrap_class: trimmed
       more_link: false
+      more_class: more-link
+      more_text: More
+      summary_handler: trim
       trim_options:
         text: false
         trim_zero: false
     third_party_settings: {  }
+    weight: 3
+    region: content
   content_moderation_control:
+    settings: {  }
+    third_party_settings: {  }
     weight: 0
     region: content
+  field_event_image:
+    type: entity_reference_entity_view
+    label: hidden
+    settings:
+      view_mode: small
+      link: false
+    third_party_settings: {  }
+    weight: 2
+    region: content
+  links:
     settings: {  }
     third_party_settings: {  }
-  links:
     weight: 1
     region: content
-    settings: {  }
-    third_party_settings: {  }
 hidden:
   field_categories: true
   field_door_time: true
   field_event_duration: true
   field_event_end: true
-  field_event_image: true
   field_event_place: true
   field_event_start: true
   field_event_type: true

--- a/modules/acquia_cms_event/config/optional/core.entity_view_display.node.event.search_results.yml
+++ b/modules/acquia_cms_event/config/optional/core.entity_view_display.node.event.search_results.yml
@@ -49,6 +49,11 @@ content:
     third_party_settings: {  }
     weight: 0
     region: content
+  links:
+    settings: {  }
+    third_party_settings: {  }
+    weight: 1
+    region: content
   field_event_image:
     type: entity_reference_entity_view
     label: hidden
@@ -57,11 +62,6 @@ content:
       link: false
     third_party_settings: {  }
     weight: 2
-    region: content
-  links:
-    settings: {  }
-    third_party_settings: {  }
-    weight: 1
     region: content
 hidden:
   field_categories: true

--- a/modules/acquia_cms_event/config/optional/core.entity_view_display.node.event.teaser.yml
+++ b/modules/acquia_cms_event/config/optional/core.entity_view_display.node.event.teaser.yml
@@ -49,6 +49,11 @@ content:
     third_party_settings: {  }
     weight: 0
     region: content
+  links:
+    settings: {  }
+    third_party_settings: {  }
+    weight: 1
+    region: content
   field_event_image:
     type: entity_reference_entity_view
     label: hidden
@@ -57,11 +62,6 @@ content:
       link: false
     third_party_settings: {  }
     weight: 2
-    region: content
-  links:
-    settings: {  }
-    third_party_settings: {  }
-    weight: 1
     region: content
 hidden:
   field_categories: true

--- a/modules/acquia_cms_event/config/optional/core.entity_view_display.node.event.teaser.yml
+++ b/modules/acquia_cms_event/config/optional/core.entity_view_display.node.event.teaser.yml
@@ -27,39 +27,47 @@ mode: teaser
 content:
   body:
     type: smart_trim
-    weight: 2
-    region: content
     label: hidden
     settings:
       trim_length: 128
       trim_type: chars
       trim_suffix: ...
-      wrap_class: trimmed
-      more_text: More
-      more_class: more-link
-      summary_handler: trim
       wrap_output: false
+      wrap_class: trimmed
       more_link: false
+      more_class: more-link
+      more_text: More
+      summary_handler: trim
       trim_options:
         text: false
         trim_zero: false
     third_party_settings: {  }
+    weight: 3
+    region: content
   content_moderation_control:
+    settings: {  }
+    third_party_settings: {  }
     weight: 0
     region: content
+  field_event_image:
+    type: entity_reference_entity_view
+    label: hidden
+    settings:
+      view_mode: teaser
+      link: false
+    third_party_settings: {  }
+    weight: 2
+    region: content
+  links:
     settings: {  }
     third_party_settings: {  }
-  links:
     weight: 1
     region: content
-    settings: {  }
-    third_party_settings: {  }
 hidden:
   field_categories: true
   field_door_time: true
   field_event_duration: true
   field_event_end: true
-  field_event_image: true
   field_event_place: true
   field_event_start: true
   field_event_type: true

--- a/modules/acquia_cms_event/config/pack_acquia_cms_event/cohesion_templates.cohesion_content_templates.node_event_card.yml
+++ b/modules/acquia_cms_event/config/pack_acquia_cms_event/cohesion_templates.cohesion_content_templates.node_event_card.yml
@@ -3,7 +3,13 @@ langcode: en
 status: true
 dependencies:
   config:
-    - image.style.coh_small_landscape
+    - cohesion_custom_styles.cohesion_custom_style.097f31b2
+    - cohesion_custom_styles.cohesion_custom_style.0f2c7187
+    - cohesion_custom_styles.cohesion_custom_style.65dc3072
+    - cohesion_custom_styles.cohesion_custom_style.96e94044
+    - cohesion_custom_styles.cohesion_custom_style.a13b8c94
+    - cohesion_custom_styles.cohesion_custom_style.bfd0fecd
+    - cohesion_custom_styles.cohesion_custom_style.ed4b7a3d
 label: 'Card (Node, Event)'
 id: node_event_card
 json_values: |
@@ -24,7 +30,7 @@ json_values: |
                       "uid": "container",
                       "title": "Container",
                       "status": {
-                          "collapsed": true
+                          "collapsed": false
                       },
                       "uuid": "fb3bac17-ac64-48df-834e-d9e2d9829523",
                       "parentUid": "container",
@@ -181,22 +187,20 @@ json_values: |
                       "uid": "container",
                       "title": "Container",
                       "status": {
-                          "collapsed": true
+                          "collapsed": false
                       },
                       "uuid": "1ddde32b-40bd-43ce-a883-9286f67be9fc",
                       "parentUid": "container",
                       "children": [
                           {
-                              "type": "item",
-                              "uid": "image",
-                              "title": "Image",
+                              "type": "container",
+                              "uid": "drupal-field",
+                              "title": "Field",
                               "status": {
-                                  "collapsed": true,
-                                  "collapsedParents": [
-                                      "1ddde32b-40bd-43ce-a883-9286f67be9fc"
-                                  ]
+                                  "collapsed": true
                               },
-                              "uuid": "6b689bc6-bcae-41c5-be9d-1cfc4ed69b19",
+                              "iconColor": "drupal",
+                              "uuid": "bdf5250d-6c1a-4776-87d1-16eb9b3a2de8",
                               "parentUid": "container",
                               "children": []
                           }
@@ -707,78 +711,6 @@ json_values: |
                       }
                   ],
                   "title": "Hide if no data",
-                  "selectorType": "topLevel",
-                  "form": null,
-                  "items": []
-              }
-          },
-          "6b689bc6-bcae-41c5-be9d-1cfc4ed69b19": {
-              "settings": {
-                  "formDefinition": [
-                      {
-                          "formKey": "image-settings",
-                          "children": [
-                              {
-                                  "formKey": "image-image",
-                                  "breakpoints": [],
-                                  "activeFields": [
-                                      {
-                                          "name": "image",
-                                          "active": true
-                                      },
-                                      {
-                                          "name": "title",
-                                          "active": true
-                                      },
-                                      {
-                                          "name": "alt",
-                                          "active": true
-                                      },
-                                      {
-                                          "name": "lazyload",
-                                          "active": true
-                                      }
-                                  ]
-                              },
-                              {
-                                  "formKey": "image-size",
-                                  "breakpoints": [
-                                      {
-                                          "name": "xl"
-                                      }
-                                  ],
-                                  "activeFields": [
-                                      {
-                                          "name": "displaySize",
-                                          "active": true
-                                      },
-                                      {
-                                          "name": "imageAlignment",
-                                          "active": true
-                                      }
-                                  ]
-                              },
-                              {
-                                  "formKey": "image-style",
-                                  "breakpoints": [],
-                                  "activeFields": [
-                                      {
-                                          "name": "imageStyle",
-                                          "active": true
-                                      },
-                                      {
-                                          "name": "customStyle",
-                                          "active": true
-                                      },
-                                      {
-                                          "name": "customStyle",
-                                          "active": true
-                                      }
-                                  ]
-                              }
-                          ]
-                      }
-                  ],
                   "selectorType": "topLevel",
                   "form": null,
                   "items": []
@@ -2392,7 +2324,8 @@ json_values: |
                   "form": null,
                   "items": []
               }
-          }
+          },
+          "bdf5250d-6c1a-4776-87d1-16eb9b3a2de8": {}
       },
       "model": {
           "584777da-a2a9-4af0-8ed1-68262c332198": {
@@ -2936,41 +2869,13 @@ json_values: |
                   "hideData": "[node:field_event_image]"
               }
           },
-          "6b689bc6-bcae-41c5-be9d-1cfc4ed69b19": {
+          "bdf5250d-6c1a-4776-87d1-16eb9b3a2de8": {
               "settings": {
-                  "title": "Image",
-                  "styles": {
-                      "xl": {
-                          "displaySize": "coh-image-responsive",
-                          "imageAlignment": "coh-image-align-left"
-                      }
-                  },
-                  "customStyle": [
-                      {
-                          "customStyle": ""
-                      }
-                  ],
-                  "lazyload": false,
+                  "title": "Field",
                   "settings": {
-                      "lazyload": false,
-                      "styles": {
-                          "xl": {
-                              "displaySize": "coh-image-responsive"
-                          }
-                      },
-                      "imageStyle": "",
-                      "customStyle": [
-                          {
-                              "customStyle": ""
-                          }
-                      ]
+                      "drupalField": ""
                   },
-                  "imageStyle": "coh_small_landscape",
-                  "image": "[node:field_event_image:entity:image:entity:path]",
-                  "attributes": {
-                      "title": "[node:field_event_image:entity:image:entity:title]",
-                      "alt": "[node:field_event_image:entity:image:alt]"
-                  }
+                  "drupalField": "content.field_event_image"
               },
               "context-visibility": {
                   "contextVisibility": {
@@ -2979,7 +2884,7 @@ json_values: |
               },
               "styles": {
                   "settings": {
-                      "element": "img"
+                      "element": "drupal-field"
                   }
               }
           }
@@ -3032,11 +2937,7 @@ json_values: |
           },
           "584777da-a2a9-4af0-8ed1-68262c332198": {},
           "1ddde32b-40bd-43ce-a883-9286f67be9fc": {},
-          "6b689bc6-bcae-41c5-be9d-1cfc4ed69b19": {
-              "settings": {
-                  "image": ""
-              }
-          }
+          "bdf5250d-6c1a-4776-87d1-16eb9b3a2de8": {}
       },
       "variableFields": {
           "0f6716d8-4092-4e52-bc4e-fa6f94f36685": [],
@@ -3067,11 +2968,7 @@ json_values: |
           ],
           "584777da-a2a9-4af0-8ed1-68262c332198": [],
           "1ddde32b-40bd-43ce-a883-9286f67be9fc": [],
-          "6b689bc6-bcae-41c5-be9d-1cfc4ed69b19": [
-              "settings.attributes.title",
-              "settings.attributes.alt",
-              "settings.image"
-          ]
+          "bdf5250d-6c1a-4776-87d1-16eb9b3a2de8": []
       },
       "meta": {
           "fieldHistory": []

--- a/modules/acquia_cms_event/config/pack_acquia_cms_event/cohesion_templates.cohesion_content_templates.node_event_full.yml
+++ b/modules/acquia_cms_event/config/pack_acquia_cms_event/cohesion_templates.cohesion_content_templates.node_event_full.yml
@@ -3,11 +3,21 @@ langcode: en
 status: true
 dependencies:
   config:
+    - cohesion_custom_styles.cohesion_custom_style.097f31b2
+    - cohesion_custom_styles.cohesion_custom_style.0f2c7187
+    - cohesion_custom_styles.cohesion_custom_style.45861218
+    - cohesion_custom_styles.cohesion_custom_style.58a35e7a
+    - cohesion_custom_styles.cohesion_custom_style.65dc3072
+    - cohesion_custom_styles.cohesion_custom_style.7ef725fd
+    - cohesion_custom_styles.cohesion_custom_style.96e94044
+    - cohesion_custom_styles.cohesion_custom_style.a13b8c94
+    - cohesion_custom_styles.cohesion_custom_style.bfd0fecd
+    - cohesion_custom_styles.cohesion_custom_style.ed4b7a3d
+    - cohesion_custom_styles.cohesion_custom_style.ee93d997
+    - cohesion_elements.cohesion_component.cpt_breadcrumbs
     - cohesion_templates.cohesion_master_templates.master_template
-    - image.style.coh_large_super_landscape
-    - image.style.coh_medium_super_landscape
+    - cohesion_website_settings.cohesion_color.gray-10
     - image.style.coh_small_landscape
-    - image.style.coh_x_large_super_landscape
 label: 'Full content (Node, Event)'
 id: node_event_full
 json_values: |
@@ -40,7 +50,7 @@ json_values: |
                       "uid": "row-for-columns",
                       "title": "Row for columns",
                       "status": {
-                          "collapsed": true
+                          "collapsed": false
                       },
                       "uuid": "47d8afbc-9ed9-48e6-9e41-cf9548134510",
                       "parentUid": "container",
@@ -195,27 +205,20 @@ json_values: |
                               "uid": "column",
                               "title": "Column",
                               "status": {
-                                  "collapsed": true,
-                                  "collapsedParents": [
-                                      "47d8afbc-9ed9-48e6-9e41-cf9548134510"
-                                  ]
+                                  "collapsed": false
                               },
                               "uuid": "90f589d7-a755-44b9-a08a-1afe7bbed81d",
                               "parentUid": "row-for-columns",
                               "children": [
                                   {
-                                      "type": "item",
-                                      "uid": "picture",
-                                      "title": "Picture",
-                                      "selected": false,
+                                      "type": "container",
+                                      "uid": "drupal-field",
+                                      "title": "Field",
                                       "status": {
-                                          "collapsed": true,
-                                          "isopen": false,
-                                          "collapsedParents": [
-                                              "47d8afbc-9ed9-48e6-9e41-cf9548134510"
-                                          ]
+                                          "collapsed": true
                                       },
-                                      "uuid": "79e7a391-3a26-4297-9a2c-30d0d2df74f1",
+                                      "iconColor": "drupal",
+                                      "uuid": "bd301e82-60b6-4bce-8fdd-dc097152536c",
                                       "parentUid": "column",
                                       "children": []
                                   }
@@ -228,7 +231,7 @@ json_values: |
                       "uid": "row-for-columns",
                       "title": "Row for columns",
                       "status": {
-                          "collapsed": true
+                          "collapsed": false
                       },
                       "uuid": "8bfc5a1e-ae51-4a48-b5d6-6a3ebe174503",
                       "parentUid": "container",
@@ -3825,91 +3828,6 @@ json_values: |
                   "items": []
               }
           },
-          "79e7a391-3a26-4297-9a2c-30d0d2df74f1": {
-              "settings": {
-                  "formDefinition": [
-                      {
-                          "formKey": "picture-settings",
-                          "children": [
-                              {
-                                  "formKey": "picture-info",
-                                  "breakpoints": [],
-                                  "activeFields": [
-                                      {
-                                          "name": "title",
-                                          "active": true
-                                      },
-                                      {
-                                          "name": "alt",
-                                          "active": true
-                                      },
-                                      {
-                                          "name": "lazyload",
-                                          "active": true
-                                      }
-                                  ]
-                              },
-                              {
-                                  "formKey": "picture-images",
-                                  "breakpoints": [
-                                      {
-                                          "name": "xl"
-                                      },
-                                      {
-                                          "name": "md"
-                                      },
-                                      {
-                                          "name": "sm"
-                                      },
-                                      {
-                                          "name": "ps"
-                                      }
-                                  ],
-                                  "activeFields": [
-                                      {
-                                          "name": "displaySize",
-                                          "active": true
-                                      },
-                                      {
-                                          "name": "imageAlignment",
-                                          "active": true
-                                      },
-                                      {
-                                          "name": "pictureImagesArray",
-                                          "active": true
-                                      },
-                                      {
-                                          "name": "image",
-                                          "active": true
-                                      },
-                                      {
-                                          "name": "imageStyle",
-                                          "active": true
-                                      }
-                                  ]
-                              },
-                              {
-                                  "formKey": "picture-style",
-                                  "breakpoints": [],
-                                  "activeFields": [
-                                      {
-                                          "name": "customStyle",
-                                          "active": true
-                                      },
-                                      {
-                                          "name": "customStyle",
-                                          "active": true
-                                      }
-                                  ]
-                              }
-                          ]
-                      }
-                  ],
-                  "selectorType": "topLevel",
-                  "form": null,
-                  "items": []
-              }
-          },
           "4693beae-0836-4a8e-8010-60dfd656c71b": {
               "settings": {
                   "formDefinition": [
@@ -5103,7 +5021,8 @@ json_values: |
                   "items": [],
                   "form": null
               }
-          }
+          },
+          "bd301e82-60b6-4bce-8fdd-dc097152536c": {}
       },
       "model": {
           "168d7c8d-0ee9-45c1-a2f3-414a62b02f48": {
@@ -5616,72 +5535,13 @@ json_values: |
                   "hideData": "[node:field_event_image]"
               }
           },
-          "79e7a391-3a26-4297-9a2c-30d0d2df74f1": {
+          "bd301e82-60b6-4bce-8fdd-dc097152536c": {
               "settings": {
-                  "title": "Picture",
-                  "customStyle": [
-                      {
-                          "customStyle": ""
-                      }
-                  ],
-                  "styles": {
-                      "xl": {
-                          "pictureImagesArray": [
-                              {
-                                  "imageStyle": "coh_x_large_super_landscape",
-                                  "image": "[node:field_event_image:entity:image:entity:path]"
-                              }
-                          ],
-                          "displaySize": "coh-image-responsive"
-                      },
-                      "md": {
-                          "pictureImagesArray": [
-                              {
-                                  "imageStyle": "coh_large_super_landscape"
-                              }
-                          ],
-                          "displaySize": "coh-image-responsive"
-                      },
-                      "sm": {
-                          "pictureImagesArray": [
-                              {
-                                  "imageStyle": "coh_medium_super_landscape"
-                              }
-                          ],
-                          "displaySize": "coh-image-responsive"
-                      },
-                      "ps": {
-                          "pictureImagesArray": [
-                              {
-                                  "imageStyle": "coh_small_landscape"
-                              }
-                          ],
-                          "displaySize": "coh-image-responsive"
-                      }
-                  },
-                  "lazyload": false,
+                  "title": "Field",
                   "settings": {
-                      "lazyload": false,
-                      "styles": {
-                          "xl": {
-                              "displaySize": "coh-image-responsive",
-                              "pictureImagesArray": [
-                                  {
-                                      "imageStyle": ""
-                                  }
-                              ]
-                          }
-                      },
-                      "customStyle": [
-                          {
-                              "customStyle": ""
-                          }
-                      ]
+                      "drupalField": ""
                   },
-                  "attributes": {
-                      "title": "[node:field_event_image:entity:name]",
-                      "alt": "[node:field_event_image:entity:image:alt]"
-                  }
+                  "drupalField": "content.field_event_image"
               },
               "context-visibility": {
                   "contextVisibility": {
@@ -5690,7 +5550,7 @@ json_values: |
               },
               "styles": {
                   "settings": {
-                      "element": "picture"
+                      "element": "drupal-field"
                   }
               }
           },
@@ -6731,19 +6591,6 @@ json_values: |
               }
           },
           "90f589d7-a755-44b9-a08a-1afe7bbed81d": {},
-          "79e7a391-3a26-4297-9a2c-30d0d2df74f1": {
-              "settings": {
-                  "styles": {
-                      "xl": {
-                          "pictureImagesArray": [
-                              {
-                                  "image": ""
-                              }
-                          ]
-                      }
-                  }
-              }
-          },
           "1bcba3f7-dd3a-4498-96b1-1bf1fd6d62ec": {},
           "13999c6f-7276-49ae-8dbf-85a40b09a8b3": {},
           "19812813-c342-44b5-9f68-b123c2bbd2a9": {
@@ -6833,7 +6680,8 @@ json_values: |
               }
           },
           "6c8bd15c-3f05-4e3f-8278-32c689624eee": {},
-          "b94fb4e1-7080-4f13-baab-8f3e8808a74c": {}
+          "b94fb4e1-7080-4f13-baab-8f3e8808a74c": {},
+          "bd301e82-60b6-4bce-8fdd-dc097152536c": {}
       },
       "variableFields": {
           "a4e18250-0fff-41a9-9c42-19c5615b07bc": [],
@@ -6843,11 +6691,6 @@ json_values: |
               "settings.content"
           ],
           "90f589d7-a755-44b9-a08a-1afe7bbed81d": [],
-          "79e7a391-3a26-4297-9a2c-30d0d2df74f1": [
-              "settings.attributes.title",
-              "settings.attributes.alt",
-              "settings.styles.xl.pictureImagesArray.0.image"
-          ],
           "1bcba3f7-dd3a-4498-96b1-1bf1fd6d62ec": [],
           "13999c6f-7276-49ae-8dbf-85a40b09a8b3": [],
           "19812813-c342-44b5-9f68-b123c2bbd2a9": [
@@ -6935,7 +6778,8 @@ json_values: |
           ],
           "b94fb4e1-7080-4f13-baab-8f3e8808a74c": [
               "settings.content"
-          ]
+          ],
+          "bd301e82-60b6-4bce-8fdd-dc097152536c": []
       },
       "meta": {
           "fieldHistory": []

--- a/modules/acquia_cms_event/config/pack_acquia_cms_event/cohesion_templates.cohesion_content_templates.node_event_full.yml
+++ b/modules/acquia_cms_event/config/pack_acquia_cms_event/cohesion_templates.cohesion_content_templates.node_event_full.yml
@@ -17,7 +17,6 @@ dependencies:
     - cohesion_elements.cohesion_component.cpt_breadcrumbs
     - cohesion_templates.cohesion_master_templates.master_template
     - cohesion_website_settings.cohesion_color.gray-10
-    - image.style.coh_small_landscape
 label: 'Full content (Node, Event)'
 id: node_event_full
 json_values: |
@@ -205,7 +204,7 @@ json_values: |
                               "uid": "column",
                               "title": "Column",
                               "status": {
-                                  "collapsed": false
+                                  "collapsed": true
                               },
                               "uuid": "90f589d7-a755-44b9-a08a-1afe7bbed81d",
                               "parentUid": "row-for-columns",
@@ -231,7 +230,7 @@ json_values: |
                       "uid": "row-for-columns",
                       "title": "Row for columns",
                       "status": {
-                          "collapsed": false
+                          "collapsed": true
                       },
                       "uuid": "8bfc5a1e-ae51-4a48-b5d6-6a3ebe174503",
                       "parentUid": "container",
@@ -241,10 +240,7 @@ json_values: |
                               "uid": "column",
                               "title": "Column",
                               "status": {
-                                  "collapsed": true,
-                                  "collapsedParents": [
-                                      "8bfc5a1e-ae51-4a48-b5d6-6a3ebe174503"
-                                  ]
+                                  "collapsed": true
                               },
                               "uuid": "1bcba3f7-dd3a-4498-96b1-1bf1fd6d62ec",
                               "parentUid": "row-for-columns",
@@ -270,10 +266,7 @@ json_values: |
                               "uid": "column",
                               "title": "Column",
                               "status": {
-                                  "collapsed": true,
-                                  "collapsedParents": [
-                                      "8bfc5a1e-ae51-4a48-b5d6-6a3ebe174503"
-                                  ]
+                                  "collapsed": true
                               },
                               "uuid": "13999c6f-7276-49ae-8dbf-85a40b09a8b3",
                               "parentUid": "row-for-columns",
@@ -283,10 +276,7 @@ json_values: |
                                       "uid": "container",
                                       "title": "Container",
                                       "status": {
-                                          "collapsed": false,
-                                          "collapsedParents": [
-                                              "8bfc5a1e-ae51-4a48-b5d6-6a3ebe174503"
-                                          ]
+                                          "collapsed": true
                                       },
                                       "uuid": "522207da-97dd-406c-ba55-4eab0084ea64",
                                       "parentUid": "column",
@@ -296,10 +286,7 @@ json_values: |
                                               "uid": "list-container",
                                               "title": "List container",
                                               "status": {
-                                                  "collapsed": false,
-                                                  "collapsedParents": [
-                                                      "8bfc5a1e-ae51-4a48-b5d6-6a3ebe174503"
-                                                  ]
+                                                  "collapsed": true
                                               },
                                               "uuid": "33f10a5d-49f1-4d67-a851-3d50a19f8bd4",
                                               "parentUid": "container",
@@ -309,10 +296,7 @@ json_values: |
                                                       "uid": "list-item",
                                                       "title": "List item",
                                                       "status": {
-                                                          "collapsed": true,
-                                                          "collapsedParents": [
-                                                              "8bfc5a1e-ae51-4a48-b5d6-6a3ebe174503"
-                                                          ]
+                                                          "collapsed": true
                                                       },
                                                       "uuid": "09401368-6ea6-4fa6-adb0-a44874b04a57",
                                                       "parentUid": "list-container",
@@ -380,10 +364,7 @@ json_values: |
                                                       "uid": "list-item",
                                                       "title": "List item",
                                                       "status": {
-                                                          "collapsed": false,
-                                                          "collapsedParents": [
-                                                              "8bfc5a1e-ae51-4a48-b5d6-6a3ebe174503"
-                                                          ]
+                                                          "collapsed": false
                                                       },
                                                       "uuid": "f4da97b4-b8a0-454f-a787-06154bb061db",
                                                       "parentUid": "list-container",
@@ -393,10 +374,7 @@ json_values: |
                                                               "uid": "heading",
                                                               "title": "Heading",
                                                               "status": {
-                                                                  "collapsed": true,
-                                                                  "collapsedParents": [
-                                                                      "8bfc5a1e-ae51-4a48-b5d6-6a3ebe174503"
-                                                                  ]
+                                                                  "collapsed": true
                                                               },
                                                               "uuid": "c5e1e4db-165d-4cda-aa6d-4dcd0acdccb4",
                                                               "parentUid": "list-item",
@@ -407,10 +385,7 @@ json_values: |
                                                               "uid": "inline-element",
                                                               "title": "Inline element",
                                                               "status": {
-                                                                  "collapsed": true,
-                                                                  "collapsedParents": [
-                                                                      "8bfc5a1e-ae51-4a48-b5d6-6a3ebe174503"
-                                                                  ]
+                                                                  "collapsed": true
                                                               },
                                                               "uuid": "d0773f7a-a667-4d58-9200-76191166c299",
                                                               "parentUid": "list-item",
@@ -421,10 +396,7 @@ json_values: |
                                                               "uid": "inline-element",
                                                               "title": "Inline element",
                                                               "status": {
-                                                                  "collapsed": true,
-                                                                  "collapsedParents": [
-                                                                      "8bfc5a1e-ae51-4a48-b5d6-6a3ebe174503"
-                                                                  ]
+                                                                  "collapsed": true
                                                               },
                                                               "uuid": "d2d7e11a-9c64-4fea-aba7-a01d0d9ceb29",
                                                               "parentUid": "list-item",
@@ -437,10 +409,7 @@ json_values: |
                                                       "uid": "list-item",
                                                       "title": "List item",
                                                       "status": {
-                                                          "collapsed": false,
-                                                          "collapsedParents": [
-                                                              "8bfc5a1e-ae51-4a48-b5d6-6a3ebe174503"
-                                                          ]
+                                                          "collapsed": false
                                                       },
                                                       "uuid": "389cb3ab-d515-4ea5-afb3-7214bb0391cf",
                                                       "parentUid": "list-container",
@@ -450,10 +419,7 @@ json_values: |
                                                               "uid": "heading",
                                                               "title": "Heading",
                                                               "status": {
-                                                                  "collapsed": true,
-                                                                  "collapsedParents": [
-                                                                      "8bfc5a1e-ae51-4a48-b5d6-6a3ebe174503"
-                                                                  ]
+                                                                  "collapsed": true
                                                               },
                                                               "uuid": "bbd36cd4-cf94-455c-9929-3b08801eb5b8",
                                                               "parentUid": "list-item",
@@ -464,10 +430,7 @@ json_values: |
                                                               "uid": "inline-element",
                                                               "title": "Inline element",
                                                               "status": {
-                                                                  "collapsed": true,
-                                                                  "collapsedParents": [
-                                                                      "8bfc5a1e-ae51-4a48-b5d6-6a3ebe174503"
-                                                                  ]
+                                                                  "collapsed": true
                                                               },
                                                               "uuid": "9b556903-634f-46e9-981d-c63a67d1b88d",
                                                               "parentUid": "list-item",
@@ -478,10 +441,7 @@ json_values: |
                                                               "uid": "inline-element",
                                                               "title": "Inline element",
                                                               "status": {
-                                                                  "collapsed": true,
-                                                                  "collapsedParents": [
-                                                                      "8bfc5a1e-ae51-4a48-b5d6-6a3ebe174503"
-                                                                  ]
+                                                                  "collapsed": true
                                                               },
                                                               "uuid": "99284bbb-47a8-4a68-bbaf-6ebb390bb70e",
                                                               "parentUid": "list-item",
@@ -494,10 +454,7 @@ json_values: |
                                                       "uid": "list-item",
                                                       "title": "List item",
                                                       "status": {
-                                                          "collapsed": true,
-                                                          "collapsedParents": [
-                                                              "8bfc5a1e-ae51-4a48-b5d6-6a3ebe174503"
-                                                          ]
+                                                          "collapsed": true
                                                       },
                                                       "uuid": "6c8bd15c-3f05-4e3f-8278-32c689624eee",
                                                       "parentUid": "list-container",
@@ -537,10 +494,7 @@ json_values: |
                                                       "uid": "list-item",
                                                       "title": "List item",
                                                       "status": {
-                                                          "collapsed": true,
-                                                          "collapsedParents": [
-                                                              "8bfc5a1e-ae51-4a48-b5d6-6a3ebe174503"
-                                                          ]
+                                                          "collapsed": true
                                                       },
                                                       "uuid": "a50e8033-ea18-4d50-9c46-c63eadec095c",
                                                       "parentUid": "list-container",
@@ -580,10 +534,7 @@ json_values: |
                                                       "uid": "list-item",
                                                       "title": "List item",
                                                       "status": {
-                                                          "collapsed": true,
-                                                          "collapsedParents": [
-                                                              "8bfc5a1e-ae51-4a48-b5d6-6a3ebe174503"
-                                                          ]
+                                                          "collapsed": true
                                                       },
                                                       "uuid": "e47724db-30bb-45ee-927b-0c2b4f0f5311",
                                                       "parentUid": "list-container",
@@ -609,16 +560,13 @@ json_values: |
                                       ]
                                   },
                                   {
-                                      "type": "item",
-                                      "uid": "image",
-                                      "title": "Image",
+                                      "type": "container",
+                                      "uid": "drupal-field",
+                                      "title": "Field",
                                       "status": {
-                                          "collapsed": true,
-                                          "collapsedParents": [
-                                              "8bfc5a1e-ae51-4a48-b5d6-6a3ebe174503"
-                                          ]
+                                          "collapsed": true
                                       },
-                                      "uuid": "19812813-c342-44b5-9f68-b123c2bbd2a9",
+                                      "uuid": "17181b4e-80be-4550-b50e-cb9937f96894",
                                       "parentUid": "column",
                                       "children": []
                                   }
@@ -931,105 +879,6 @@ json_values: |
                       }
                   ],
                   "title": "Settings",
-                  "selectorType": "topLevel",
-                  "form": null,
-                  "items": []
-              }
-          },
-          "19812813-c342-44b5-9f68-b123c2bbd2a9": {
-              "settings": {
-                  "formDefinition": [
-                      {
-                          "formKey": "image-settings",
-                          "children": [
-                              {
-                                  "formKey": "image-image",
-                                  "breakpoints": [],
-                                  "activeFields": [
-                                      {
-                                          "name": "image",
-                                          "active": true
-                                      },
-                                      {
-                                          "name": "title",
-                                          "active": true
-                                      },
-                                      {
-                                          "name": "alt",
-                                          "active": true
-                                      },
-                                      {
-                                          "name": "lazyload",
-                                          "active": true
-                                      }
-                                  ]
-                              },
-                              {
-                                  "formKey": "image-size",
-                                  "breakpoints": [
-                                      {
-                                          "name": "xl"
-                                      }
-                                  ],
-                                  "activeFields": [
-                                      {
-                                          "name": "displaySize",
-                                          "active": true
-                                      },
-                                      {
-                                          "name": "imageAlignment",
-                                          "active": true
-                                      }
-                                  ]
-                              },
-                              {
-                                  "formKey": "image-style",
-                                  "breakpoints": [],
-                                  "activeFields": [
-                                      {
-                                          "name": "imageStyle",
-                                          "active": true
-                                      },
-                                      {
-                                          "name": "customStyle",
-                                          "active": true
-                                      },
-                                      {
-                                          "name": "customStyle",
-                                          "active": true
-                                      }
-                                  ]
-                              }
-                          ]
-                      }
-                  ],
-                  "selectorType": "topLevel",
-                  "form": null,
-                  "items": []
-              },
-              "hideNoData": {
-                  "formDefinition": [
-                      {
-                          "formKey": "tab-hide-data-settings",
-                          "children": [
-                              {
-                                  "formKey": "tab-hide-data-hide",
-                                  "breakpoints": [],
-                                  "activeFields": [
-                                      {
-                                          "name": "hideEnable",
-                                          "active": true
-                                      },
-                                      {
-                                          "name": "hideData",
-                                          "active": true
-                                      }
-                                  ]
-                              }
-                          ]
-                      }
-                  ],
-                  "title": "Hide if no data",
                   "selectorType": "topLevel",
                   "form": null,
                   "items": []
@@ -5022,7 +4871,8 @@ json_values: |
                   "form": null
               }
           },
-          "bd301e82-60b6-4bce-8fdd-dc097152536c": {}
+          "bd301e82-60b6-4bce-8fdd-dc097152536c": {},
+          "17181b4e-80be-4550-b50e-cb9937f96894": {}
       },
       "model": {
           "168d7c8d-0ee9-45c1-a2f3-414a62b02f48": {
@@ -6529,41 +6379,13 @@ json_values: |
                   }
               }
           },
-          "19812813-c342-44b5-9f68-b123c2bbd2a9": {
+          "17181b4e-80be-4550-b50e-cb9937f96894": {
               "settings": {
-                  "title": "Image - Location image",
-                  "styles": {
-                      "xl": {
-                          "displaySize": "coh-image-responsive",
-                          "imageAlignment": "coh-image-align-left"
-                      }
-                  },
-                  "customStyle": [
-                      {
-                          "customStyle": ""
-                      }
-                  ],
-                  "lazyload": false,
+                  "title": "Field",
                   "settings": {
-                      "lazyload": false,
-                      "styles": {
-                          "xl": {
-                              "displaySize": "coh-image-responsive"
-                          }
-                      },
-                      "imageStyle": "",
-                      "customStyle": [
-                          {
-                              "customStyle": ""
-                          }
-                      ]
+                      "drupalField": ""
                   },
-                  "imageStyle": "coh_small_landscape",
-                  "image": "[node:field_event_place:entity:field_place_image:entity:image:entity:path]",
-                  "attributes": {
-                      "title": "[node:field_event_place:entity:field_place_image:entity:image:entity:title]",
-                      "alt": "[node:field_event_place:entity:field_place_image:entity:image:entity:alt]"
-                  }
+                  "drupalField": "content.field_event_place"
               },
               "context-visibility": {
                   "contextVisibility": {
@@ -6572,12 +6394,8 @@ json_values: |
               },
               "styles": {
                   "settings": {
-                      "element": "img"
+                      "element": "drupal-field"
                   }
-              },
-              "hideNoData": {
-                  "hideEnable": true,
-                  "hideData": "[node:field_event_place]"
               }
           }
       },
@@ -6593,11 +6411,6 @@ json_values: |
           "90f589d7-a755-44b9-a08a-1afe7bbed81d": {},
           "1bcba3f7-dd3a-4498-96b1-1bf1fd6d62ec": {},
           "13999c6f-7276-49ae-8dbf-85a40b09a8b3": {},
-          "19812813-c342-44b5-9f68-b123c2bbd2a9": {
-              "settings": {
-                  "image": ""
-              }
-          },
           "522207da-97dd-406c-ba55-4eab0084ea64": {},
           "79b80f32-185f-482e-b369-84d93c6fb3ae": {},
           "03704263-4e27-4afd-8531-c370e383e36d": {},
@@ -6681,7 +6494,8 @@ json_values: |
           },
           "6c8bd15c-3f05-4e3f-8278-32c689624eee": {},
           "b94fb4e1-7080-4f13-baab-8f3e8808a74c": {},
-          "bd301e82-60b6-4bce-8fdd-dc097152536c": {}
+          "bd301e82-60b6-4bce-8fdd-dc097152536c": {},
+          "17181b4e-80be-4550-b50e-cb9937f96894": {}
       },
       "variableFields": {
           "a4e18250-0fff-41a9-9c42-19c5615b07bc": [],
@@ -6693,12 +6507,6 @@ json_values: |
           "90f589d7-a755-44b9-a08a-1afe7bbed81d": [],
           "1bcba3f7-dd3a-4498-96b1-1bf1fd6d62ec": [],
           "13999c6f-7276-49ae-8dbf-85a40b09a8b3": [],
-          "19812813-c342-44b5-9f68-b123c2bbd2a9": [
-              "settings.attributes.title",
-              "settings.attributes.alt",
-              "settings.image",
-              "hideNoData.hideData"
-          ],
           "522207da-97dd-406c-ba55-4eab0084ea64": [],
           "79b80f32-185f-482e-b369-84d93c6fb3ae": [],
           "03704263-4e27-4afd-8531-c370e383e36d": [],
@@ -6779,7 +6587,8 @@ json_values: |
           "b94fb4e1-7080-4f13-baab-8f3e8808a74c": [
               "settings.content"
           ],
-          "bd301e82-60b6-4bce-8fdd-dc097152536c": []
+          "bd301e82-60b6-4bce-8fdd-dc097152536c": [],
+          "17181b4e-80be-4550-b50e-cb9937f96894": []
       },
       "meta": {
           "fieldHistory": []

--- a/modules/acquia_cms_event/config/pack_acquia_cms_event/cohesion_templates.cohesion_content_templates.node_event_horizontal_card.yml
+++ b/modules/acquia_cms_event/config/pack_acquia_cms_event/cohesion_templates.cohesion_content_templates.node_event_horizontal_card.yml
@@ -3,7 +3,13 @@ langcode: en
 status: true
 dependencies:
   config:
-    - image.style.coh_small_landscape
+    - cohesion_custom_styles.cohesion_custom_style.097f31b2
+    - cohesion_custom_styles.cohesion_custom_style.0f2c7187
+    - cohesion_custom_styles.cohesion_custom_style.65dc3072
+    - cohesion_custom_styles.cohesion_custom_style.96e94044
+    - cohesion_custom_styles.cohesion_custom_style.a13b8c94
+    - cohesion_custom_styles.cohesion_custom_style.bfd0fecd
+    - cohesion_custom_styles.cohesion_custom_style.ed4b7a3d
 label: 'Horizontal card (Node, Event)'
 id: node_event_horizontal_card
 json_values: |
@@ -196,22 +202,20 @@ json_values: |
                       "uid": "column",
                       "title": "Column",
                       "status": {
-                          "collapsed": true
+                          "collapsed": false
                       },
                       "uuid": "21e6170c-9059-41bf-9b11-4a7ccc8ff467",
                       "parentUid": "row-for-columns",
                       "children": [
                           {
-                              "type": "item",
-                              "uid": "image",
-                              "title": "Image",
+                              "type": "container",
+                              "uid": "drupal-field",
+                              "title": "Field",
                               "status": {
-                                  "collapsed": true,
-                                  "collapsedParents": [
-                                      "21e6170c-9059-41bf-9b11-4a7ccc8ff467"
-                                  ]
+                                  "collapsed": true
                               },
-                              "uuid": "44895abc-e1b0-4711-9f62-73e1e6107bab",
+                              "iconColor": "drupal",
+                              "uuid": "bfad45c9-e754-4724-926c-2e6d25a957e7",
                               "parentUid": "column",
                               "children": []
                           }
@@ -498,7 +502,7 @@ json_values: |
                                       },
                                       {
                                           "name": "order",
-                                          "active": true
+                                          "active": false
                                       },
                                       {
                                           "name": "flex-grow",
@@ -517,117 +521,7 @@ json_values: |
                                           "active": true
                                       }
                                   ]
-                              }
-                          ]
-                      }
-                  ],
-                  "items": [],
-                  "form": null
-              },
-              "hideNoData": {
-                  "formDefinition": [
-                      {
-                          "formKey": "tab-hide-data-settings",
-                          "children": [
-                              {
-                                  "formKey": "tab-hide-data-hide",
-                                  "breakpoints": [],
-                                  "activeFields": [
-                                      {
-                                          "name": "hideEnable",
-                                          "active": true
-                                      },
-                                      {
-                                          "name": "hideData",
-                                          "active": true
-                                      }
-                                  ]
-                              }
-                          ]
-                      }
-                  ],
-                  "title": "Hide if no data",
-                  "selectorType": "topLevel",
-                  "form": null,
-                  "items": []
-              }
-          },
-          "44895abc-e1b0-4711-9f62-73e1e6107bab": {
-              "settings": {
-                  "formDefinition": [
-                      {
-                          "formKey": "image-settings",
-                          "children": [
-                              {
-                                  "formKey": "image-image",
-                                  "breakpoints": [],
-                                  "activeFields": [
-                                      {
-                                          "name": "image",
-                                          "active": true
-                                      },
-                                      {
-                                          "name": "title",
-                                          "active": true
-                                      },
-                                      {
-                                          "name": "alt",
-                                          "active": true
-                                      },
-                                      {
-                                          "name": "lazyload",
-                                          "active": true
-                                      }
-                                  ]
                               },
-                              {
-                                  "formKey": "image-size",
-                                  "breakpoints": [
-                                      {
-                                          "name": "xl"
-                                      }
-                                  ],
-                                  "activeFields": [
-                                      {
-                                          "name": "displaySize",
-                                          "active": true
-                                      },
-                                      {
-                                          "name": "imageAlignment",
-                                          "active": true
-                                      }
-                                  ]
-                              },
-                              {
-                                  "formKey": "image-style",
-                                  "breakpoints": [],
-                                  "activeFields": [
-                                      {
-                                          "name": "imageStyle",
-                                          "active": true
-                                      },
-                                      {
-                                          "name": "customStyle",
-                                          "active": true
-                                      },
-                                      {
-                                          "name": "customStyle",
-                                          "active": true
-                                      }
-                                  ]
-                              }
-                          ]
-                      }
-                  ],
-                  "selectorType": "topLevel",
-                  "form": null,
-                  "items": []
-              },
-              "styles": {
-                  "formDefinition": [
-                      {
-                          "formKey": "layout",
-                          "children": [
                               {
                                   "formKey": "height",
                                   "breakpoints": [
@@ -680,9 +574,35 @@ json_values: |
                           ]
                       }
                   ],
-                  "selectorType": "topLevel",
                   "items": [],
                   "form": null
+              },
+              "hideNoData": {
+                  "formDefinition": [
+                      {
+                          "formKey": "tab-hide-data-settings",
+                          "children": [
+                              {
+                                  "formKey": "tab-hide-data-hide",
+                                  "breakpoints": [],
+                                  "activeFields": [
+                                      {
+                                          "name": "hideEnable",
+                                          "active": true
+                                      },
+                                      {
+                                          "name": "hideData",
+                                          "active": true
+                                      }
+                                  ]
+                              }
+                          ]
+                      }
+                  ],
+                  "title": "Hide if no data",
+                  "selectorType": "topLevel",
+                  "form": null,
+                  "items": []
               }
           },
           "5ffa3455-0569-48aa-a9e4-96b42c1ecb89": {
@@ -2456,7 +2376,8 @@ json_values: |
                   ],
                   "form": null
               }
-          }
+          },
+          "bfad45c9-e754-4724-926c-2e6d25a957e7": {}
       },
       "model": {
           "360c4518-e440-403b-bed5-eb9cb00ba735": {
@@ -3032,66 +2953,6 @@ json_values: |
                   },
                   "styles": {
                       "xl": {
-                          "flex-item": {
-                              "order": {
-                                  "value": "-1"
-                              }
-                          }
-                      }
-                  }
-              },
-              "hideNoData": {
-                  "hideEnable": true,
-                  "hideData": "[node:field_event_image]"
-              }
-          },
-          "44895abc-e1b0-4711-9f62-73e1e6107bab": {
-              "settings": {
-                  "title": "Image",
-                  "styles": {
-                      "xl": {
-                          "displaySize": "coh-image-responsive",
-                          "imageAlignment": "coh-image-align-left"
-                      }
-                  },
-                  "customStyle": [
-                      {
-                          "customStyle": ""
-                      }
-                  ],
-                  "lazyload": false,
-                  "settings": {
-                      "lazyload": false,
-                      "styles": {
-                          "xl": {
-                              "displaySize": "coh-image-responsive"
-                          }
-                      },
-                      "imageStyle": "",
-                      "customStyle": [
-                          {
-                              "customStyle": ""
-                          }
-                      ]
-                  },
-                  "imageStyle": "coh_small_landscape",
-                  "image": "[node:field_event_image:entity:image:entity:path]",
-                  "attributes": {
-                      "title": "[node:field_event_image:entity:image:entity:title]",
-                      "alt": "[node:field_event_image:entity:image:entity:alt]"
-                  }
-              },
-              "context-visibility": {
-                  "contextVisibility": {
-                      "condition": "ALL"
-                  }
-              },
-              "styles": {
-                  "settings": {
-                      "element": "img"
-                  },
-                  "styles": {
-                      "xl": {
                           "custom-css": [
                               {
                                   "customCssProperty": {
@@ -3107,17 +2968,35 @@ json_values: |
                           }
                       }
                   }
+              },
+              "hideNoData": {
+                  "hideEnable": true,
+                  "hideData": "[node:field_event_image]"
+              }
+          },
+          "bfad45c9-e754-4724-926c-2e6d25a957e7": {
+              "settings": {
+                  "title": "Field",
+                  "settings": {
+                      "drupalField": ""
+                  },
+                  "drupalField": "content.field_event_image"
+              },
+              "context-visibility": {
+                  "contextVisibility": {
+                      "condition": "ALL"
+                  }
+              },
+              "styles": {
+                  "settings": {
+                      "element": "drupal-field"
+                  }
               }
           }
       },
       "previewModel": {
           "5ffa3455-0569-48aa-a9e4-96b42c1ecb89": {},
           "21e6170c-9059-41bf-9b11-4a7ccc8ff467": {},
-          "44895abc-e1b0-4711-9f62-73e1e6107bab": {
-              "settings": {
-                  "image": ""
-              }
-          },
           "3b5cb31d-2d39-4c51-9c07-f5a007690980": {
               "settings": {
                   "linkText": "A long event placeholder heading that may wrap over multiple lines."
@@ -3149,16 +3028,12 @@ json_values: |
               "settings": {
                   "linkText": "London"
               }
-          }
+          },
+          "bfad45c9-e754-4724-926c-2e6d25a957e7": {}
       },
       "variableFields": {
           "5ffa3455-0569-48aa-a9e4-96b42c1ecb89": [],
           "21e6170c-9059-41bf-9b11-4a7ccc8ff467": [],
-          "44895abc-e1b0-4711-9f62-73e1e6107bab": [
-              "settings.attributes.title",
-              "settings.attributes.alt",
-              "settings.image"
-          ],
           "3b5cb31d-2d39-4c51-9c07-f5a007690980": [
               "settings.linkText",
               "settings.linkToPage"
@@ -3185,7 +3060,8 @@ json_values: |
           "568bbe5f-bd8e-401a-98bb-d5e25c0b66fd": [
               "settings.linkText",
               "settings.linkToPage"
-          ]
+          ],
+          "bfad45c9-e754-4724-926c-2e6d25a957e7": []
       },
       "meta": {
           "fieldHistory": []

--- a/modules/acquia_cms_event/config/pack_acquia_cms_event/cohesion_templates.cohesion_content_templates.node_event_search_results.yml
+++ b/modules/acquia_cms_event/config/pack_acquia_cms_event/cohesion_templates.cohesion_content_templates.node_event_search_results.yml
@@ -3,7 +3,12 @@ langcode: en
 status: true
 dependencies:
   config:
-    - image.style.coh_small_landscape
+    - cohesion_custom_styles.cohesion_custom_style.0f2c7187
+    - cohesion_custom_styles.cohesion_custom_style.65dc3072
+    - cohesion_custom_styles.cohesion_custom_style.96e94044
+    - cohesion_custom_styles.cohesion_custom_style.bfd0fecd
+    - cohesion_custom_styles.cohesion_custom_style.ed4b7a3d
+    - cohesion_custom_styles.cohesion_custom_style.f3dc1bea
 label: 'Search Results (Node, Event)'
 id: node_event_search_results
 json_values: |
@@ -195,24 +200,20 @@ json_values: |
                       "uid": "column",
                       "title": "Column",
                       "status": {
-                          "collapsed": true
+                          "collapsed": false
                       },
                       "uuid": "65917a4b-d697-4b1d-a5ec-2c6c4eaa34eb",
                       "parentUid": "row-for-columns",
                       "children": [
                           {
-                              "type": "item",
-                              "uid": "picture",
-                              "title": "Picture",
-                              "selected": false,
+                              "type": "container",
+                              "uid": "drupal-field",
+                              "title": "Field",
                               "status": {
-                                  "collapsed": true,
-                                  "isopen": false,
-                                  "collapsedParents": [
-                                      "65917a4b-d697-4b1d-a5ec-2c6c4eaa34eb"
-                                  ]
+                                  "collapsed": true
                               },
-                              "uuid": "2852366d-0808-4597-9525-902c82bd51f3",
+                              "iconColor": "drupal",
+                              "uuid": "8289732b-f6c9-486b-a6b4-8c244298d8e7",
                               "parentUid": "column",
                               "children": []
                           }
@@ -574,85 +575,6 @@ json_values: |
                       }
                   ],
                   "title": "Hide if no data",
-                  "selectorType": "topLevel",
-                  "form": null,
-                  "items": []
-              }
-          },
-          "2852366d-0808-4597-9525-902c82bd51f3": {
-              "settings": {
-                  "formDefinition": [
-                      {
-                          "formKey": "picture-settings",
-                          "children": [
-                              {
-                                  "formKey": "picture-info",
-                                  "breakpoints": [],
-                                  "activeFields": [
-                                      {
-                                          "name": "title",
-                                          "active": true
-                                      },
-                                      {
-                                          "name": "alt",
-                                          "active": true
-                                      },
-                                      {
-                                          "name": "lazyload",
-                                          "active": true
-                                      }
-                                  ]
-                              },
-                              {
-                                  "formKey": "picture-images",
-                                  "breakpoints": [
-                                      {
-                                          "name": "xl"
-                                      },
-                                      {
-                                          "name": "ps"
-                                      }
-                                  ],
-                                  "activeFields": [
-                                      {
-                                          "name": "displaySize",
-                                          "active": true
-                                      },
-                                      {
-                                          "name": "imageAlignment",
-                                          "active": true
-                                      },
-                                      {
-                                          "name": "pictureImagesArray",
-                                          "active": true
-                                      },
-                                      {
-                                          "name": "image",
-                                          "active": true
-                                      },
-                                      {
-                                          "name": "imageStyle",
-                                          "active": true
-                                      }
-                                  ]
-                              },
-                              {
-                                  "formKey": "picture-style",
-                                  "breakpoints": [],
-                                  "activeFields": [
-                                      {
-                                          "name": "customStyle",
-                                          "active": true
-                                      },
-                                      {
-                                          "name": "customStyle",
-                                          "active": true
-                                      }
-                                  ]
-                              }
-                          ]
-                      }
-                  ],
                   "selectorType": "topLevel",
                   "form": null,
                   "items": []
@@ -2447,7 +2369,8 @@ json_values: |
                   ],
                   "form": null
               }
-          }
+          },
+          "8289732b-f6c9-486b-a6b4-8c244298d8e7": {}
       },
       "model": {
           "30dc932a-8c04-4015-8497-e754bd293851": {
@@ -3051,56 +2974,13 @@ json_values: |
                   "hideData": "[node:field_event_image]"
               }
           },
-          "2852366d-0808-4597-9525-902c82bd51f3": {
+          "8289732b-f6c9-486b-a6b4-8c244298d8e7": {
               "settings": {
-                  "title": "Picture",
-                  "customStyle": [
-                      {
-                          "customStyle": ""
-                      }
-                  ],
-                  "styles": {
-                      "xl": {
-                          "pictureImagesArray": [
-                              {
-                                  "imageStyle": "x_small_square_320x320_",
-                                  "image": "[node:field_event_image:entity:image:entity:path]"
-                              }
-                          ],
-                          "displaySize": "coh-image-responsive"
-                      },
-                      "ps": {
-                          "pictureImagesArray": [
-                              {
-                                  "imageStyle": "coh_small_landscape"
-                              }
-                          ],
-                          "displaySize": "coh-image-responsive"
-                      }
-                  },
-                  "lazyload": false,
+                  "title": "Field",
                   "settings": {
-                      "lazyload": false,
-                      "styles": {
-                          "xl": {
-                              "displaySize": "coh-image-responsive",
-                              "pictureImagesArray": [
-                                  {
-                                      "imageStyle": ""
-                                  }
-                              ]
-                          }
-                      },
-                      "customStyle": [
-                          {
-                              "customStyle": ""
-                          }
-                      ]
+                      "drupalField": ""
                   },
-                  "attributes": {
-                      "title": "[node:field_event_image:entity:image:entity:title]",
-                      "alt": "[node:field_event_image:entity:image:alt]"
-                  }
+                  "drupalField": "content.field_event_image"
               },
               "context-visibility": {
                   "contextVisibility": {
@@ -3109,7 +2989,7 @@ json_values: |
               },
               "styles": {
                   "settings": {
-                      "element": "picture"
+                      "element": "drupal-field"
                   }
               }
           }
@@ -3117,19 +2997,6 @@ json_values: |
       "previewModel": {
           "fd0efb0e-3229-4f2e-8864-80ccbed4bdfe": {},
           "65917a4b-d697-4b1d-a5ec-2c6c4eaa34eb": {},
-          "2852366d-0808-4597-9525-902c82bd51f3": {
-              "settings": {
-                  "styles": {
-                      "xl": {
-                          "pictureImagesArray": [
-                              {
-                                  "image": ""
-                              }
-                          ]
-                      }
-                  }
-              }
-          },
           "1285a02b-c5c6-41ca-b62c-c6e6ded8b71d": {},
           "621eb487-8365-4e0f-af56-946caf552dd3": {},
           "5936403b-501b-4d0d-b088-0804b0618453": {
@@ -3164,16 +3031,12 @@ json_values: |
               }
           },
           "30dc932a-8c04-4015-8497-e754bd293851": {},
-          "14e027ff-c73e-4c9c-a79c-97278e60c9ba": []
+          "14e027ff-c73e-4c9c-a79c-97278e60c9ba": [],
+          "8289732b-f6c9-486b-a6b4-8c244298d8e7": {}
       },
       "variableFields": {
           "fd0efb0e-3229-4f2e-8864-80ccbed4bdfe": [],
           "65917a4b-d697-4b1d-a5ec-2c6c4eaa34eb": [],
-          "2852366d-0808-4597-9525-902c82bd51f3": [
-              "settings.styles.xl.pictureImagesArray.0.image",
-              "settings.attributes.title",
-              "settings.attributes.alt"
-          ],
           "1285a02b-c5c6-41ca-b62c-c6e6ded8b71d": [],
           "621eb487-8365-4e0f-af56-946caf552dd3": [],
           "5936403b-501b-4d0d-b088-0804b0618453": [
@@ -3200,7 +3063,8 @@ json_values: |
               "settings.linkToPage"
           ],
           "30dc932a-8c04-4015-8497-e754bd293851": [],
-          "14e027ff-c73e-4c9c-a79c-97278e60c9ba": []
+          "14e027ff-c73e-4c9c-a79c-97278e60c9ba": [],
+          "8289732b-f6c9-486b-a6b4-8c244298d8e7": []
       },
       "meta": {
           "fieldHistory": []

--- a/modules/acquia_cms_event/config/pack_acquia_cms_event/cohesion_templates.cohesion_content_templates.node_event_teaser.yml
+++ b/modules/acquia_cms_event/config/pack_acquia_cms_event/cohesion_templates.cohesion_content_templates.node_event_teaser.yml
@@ -3,7 +3,12 @@ langcode: en
 status: true
 dependencies:
   config:
-    - image.style.coh_small_landscape
+    - cohesion_custom_styles.cohesion_custom_style.0f2c7187
+    - cohesion_custom_styles.cohesion_custom_style.65dc3072
+    - cohesion_custom_styles.cohesion_custom_style.96e94044
+    - cohesion_custom_styles.cohesion_custom_style.bfd0fecd
+    - cohesion_custom_styles.cohesion_custom_style.ed4b7a3d
+    - cohesion_custom_styles.cohesion_custom_style.f3dc1bea
 label: 'Teaser (Node, Event)'
 id: node_event_teaser
 json_values: |
@@ -195,24 +200,19 @@ json_values: |
                       "uid": "column",
                       "title": "Column",
                       "status": {
-                          "collapsed": true
+                          "collapsed": false
                       },
                       "uuid": "fa8e6607-05e6-4d6d-8d83-dac6ff390f3b",
                       "parentUid": "row-for-columns",
                       "children": [
                           {
-                              "type": "item",
-                              "uid": "picture",
-                              "title": "Picture",
-                              "selected": false,
+                              "type": "container",
+                              "uid": "drupal-field",
+                              "title": "Field",
                               "status": {
-                                  "collapsed": true,
-                                  "isopen": false,
-                                  "collapsedParents": [
-                                      "fa8e6607-05e6-4d6d-8d83-dac6ff390f3b"
-                                  ]
+                                  "collapsed": true
                               },
-                              "uuid": "efa0f639-a4bd-490c-a283-9e57d9808b69",
+                              "uuid": "afea843a-e842-4adf-8dc1-75e37ce58787",
                               "parentUid": "column",
                               "children": []
                           }
@@ -574,85 +574,6 @@ json_values: |
                       }
                   ],
                   "title": "Hide if no data",
-                  "selectorType": "topLevel",
-                  "form": null,
-                  "items": []
-              }
-          },
-          "efa0f639-a4bd-490c-a283-9e57d9808b69": {
-              "settings": {
-                  "formDefinition": [
-                      {
-                          "formKey": "picture-settings",
-                          "children": [
-                              {
-                                  "formKey": "picture-info",
-                                  "breakpoints": [],
-                                  "activeFields": [
-                                      {
-                                          "name": "title",
-                                          "active": true
-                                      },
-                                      {
-                                          "name": "alt",
-                                          "active": true
-                                      },
-                                      {
-                                          "name": "lazyload",
-                                          "active": true
-                                      }
-                                  ]
-                              },
-                              {
-                                  "formKey": "picture-images",
-                                  "breakpoints": [
-                                      {
-                                          "name": "xl"
-                                      },
-                                      {
-                                          "name": "ps"
-                                      }
-                                  ],
-                                  "activeFields": [
-                                      {
-                                          "name": "displaySize",
-                                          "active": true
-                                      },
-                                      {
-                                          "name": "imageAlignment",
-                                          "active": true
-                                      },
-                                      {
-                                          "name": "pictureImagesArray",
-                                          "active": true
-                                      },
-                                      {
-                                          "name": "image",
-                                          "active": true
-                                      },
-                                      {
-                                          "name": "imageStyle",
-                                          "active": true
-                                      }
-                                  ]
-                              },
-                              {
-                                  "formKey": "picture-style",
-                                  "breakpoints": [],
-                                  "activeFields": [
-                                      {
-                                          "name": "customStyle",
-                                          "active": true
-                                      },
-                                      {
-                                          "name": "customStyle",
-                                          "active": true
-                                      }
-                                  ]
-                              }
-                          ]
-                      }
-                  ],
                   "selectorType": "topLevel",
                   "form": null,
                   "items": []
@@ -2400,7 +2321,8 @@ json_values: |
                   "form": null,
                   "items": []
               }
-          }
+          },
+          "afea843a-e842-4adf-8dc1-75e37ce58787": {}
       },
       "model": {
           "fdbd43f4-619c-4ea8-86bd-c58b7bebfdf6": {
@@ -3000,56 +2922,13 @@ json_values: |
                   "hideData": "[node:field_event_image]"
               }
           },
-          "efa0f639-a4bd-490c-a283-9e57d9808b69": {
+          "afea843a-e842-4adf-8dc1-75e37ce58787": {
               "settings": {
-                  "title": "Picture",
-                  "customStyle": [
-                      {
-                          "customStyle": ""
-                      }
-                  ],
-                  "styles": {
-                      "xl": {
-                          "pictureImagesArray": [
-                              {
-                                  "imageStyle": "x_small_square_320x320_",
-                                  "image": "[node:field_event_image:entity:image:entity:path]"
-                              }
-                          ],
-                          "displaySize": "coh-image-responsive"
-                      },
-                      "ps": {
-                          "pictureImagesArray": [
-                              {
-                                  "imageStyle": "coh_small_landscape"
-                              }
-                          ],
-                          "displaySize": "coh-image-responsive"
-                      }
-                  },
-                  "lazyload": false,
+                  "title": "Field",
                   "settings": {
-                      "lazyload": false,
-                      "styles": {
-                          "xl": {
-                              "displaySize": "coh-image-responsive",
-                              "pictureImagesArray": [
-                                  {
-                                      "imageStyle": ""
-                                  }
-                              ]
-                          }
-                      },
-                      "customStyle": [
-                          {
-                              "customStyle": ""
-                          }
-                      ]
+                      "drupalField": ""
                   },
-                  "attributes": {
-                      "title": "[node:field_event_image:entity:image:entity:title]",
-                      "alt": "[node:field_event_image:entity:image:alt]"
-                  }
+                  "drupalField": "content.field_event_image"
               },
               "context-visibility": {
                   "contextVisibility": {
@@ -3058,7 +2937,7 @@ json_values: |
               },
               "styles": {
                   "settings": {
-                      "element": "picture"
+                      "element": "drupal-field"
                   }
               }
           }
@@ -3066,19 +2945,6 @@ json_values: |
       "previewModel": {
           "eb77c7d0-7df1-4dbb-8d0e-09fe1de75f0f": {},
           "fa8e6607-05e6-4d6d-8d83-dac6ff390f3b": {},
-          "efa0f639-a4bd-490c-a283-9e57d9808b69": {
-              "settings": {
-                  "styles": {
-                      "xl": {
-                          "pictureImagesArray": [
-                              {
-                                  "image": ""
-                              }
-                          ]
-                      }
-                  }
-              }
-          },
           "b8a1ffcd-503c-4def-8d66-273508467297": {},
           "4f93d284-103f-44d9-9e4c-f2b96a09810c": {
               "settings": {
@@ -3113,16 +2979,12 @@ json_values: |
                   "linkToPage": "#"
               }
           },
-          "fdbd43f4-619c-4ea8-86bd-c58b7bebfdf6": {}
+          "fdbd43f4-619c-4ea8-86bd-c58b7bebfdf6": {},
+          "afea843a-e842-4adf-8dc1-75e37ce58787": {}
       },
       "variableFields": {
           "eb77c7d0-7df1-4dbb-8d0e-09fe1de75f0f": [],
           "fa8e6607-05e6-4d6d-8d83-dac6ff390f3b": [],
-          "efa0f639-a4bd-490c-a283-9e57d9808b69": [
-              "settings.attributes.title",
-              "settings.attributes.alt",
-              "settings.styles.xl.pictureImagesArray.0.image"
-          ],
           "b8a1ffcd-503c-4def-8d66-273508467297": [],
           "4f93d284-103f-44d9-9e4c-f2b96a09810c": [
               "settings.linkText",
@@ -3149,7 +3011,8 @@ json_values: |
               "settings.linkText",
               "settings.linkToPage"
           ],
-          "fdbd43f4-619c-4ea8-86bd-c58b7bebfdf6": []
+          "fdbd43f4-619c-4ea8-86bd-c58b7bebfdf6": [],
+          "afea843a-e842-4adf-8dc1-75e37ce58787": []
       },
       "meta": {
           "fieldHistory": []

--- a/modules/acquia_cms_page/acquia_cms_page.install
+++ b/modules/acquia_cms_page/acquia_cms_page.install
@@ -134,15 +134,15 @@ function acquia_cms_page_update_8003() {
     'teaser',
   ];
   foreach ($display_modes as $key => $display_mode) {
-    $page_default = \Drupal::configFactory()->getEditable('core.entity_view_display.node.page.' . $display_mode);
-    if ($page_default->get('hidden.field_page_image')) {
+    $page_view_mode = \Drupal::configFactory()->getEditable('core.entity_view_display.node.page.' . $display_mode);
+    if ($page_view_mode->get('hidden.field_page_image')) {
       $page_image_field['field_page_image']['settings']['view_mode'] = $view_modes[$key];
-      $page_default->set('content', array_merge($page_default->get('content'), $page_image_field));
-      if ($page_default->get('content.body')) {
-        $page_default->set('content.body.weight', $page_default->get('content.body.weight') + 1);
+      $page_view_mode->set('content', array_merge($page_view_mode->get('content'), $page_image_field));
+      if ($page_view_mode->get('content.body')) {
+        $page_view_mode->set('content.body.weight', $page_view_mode->get('content.body.weight') + 1);
       }
-      $page_default->clear('hidden.field_page_image');
-      $page_default->save();
+      $page_view_mode->clear('hidden.field_page_image');
+      $page_view_mode->save();
     }
   }
 

--- a/modules/acquia_cms_page/acquia_cms_page.install
+++ b/modules/acquia_cms_page/acquia_cms_page.install
@@ -98,3 +98,52 @@ function acquia_cms_page_update_8002() {
     }
   }
 }
+
+/**
+ * Implements hook_update_N().
+ *
+ * Update Page display modes.
+ */
+function acquia_cms_page_update_8003() {
+  // Load and update default view mode.
+  $page_image_field = [
+    'field_page_image' => [
+      'type' => 'entity_reference_entity_view',
+      'label' => 'hidden',
+      'settings' => [
+        'view_mode' => 'full',
+        'link' => 'false',
+      ],
+      'third_party_settings' => [],
+      'weight' => 2,
+      'region' => 'content',
+    ],
+  ];
+  $display_modes = [
+    'default',
+    'card',
+    'horizontal_card',
+    'search_results',
+    'teaser',
+  ];
+  $view_modes = [
+    'full',
+    'card',
+    'large_super_landscape',
+    'small',
+    'teaser',
+  ];
+  foreach ($display_modes as $key => $display_mode) {
+    $page_default = \Drupal::configFactory()->getEditable('core.entity_view_display.node.page.' . $display_mode);
+    if ($page_default->get('hidden.field_page_image')) {
+      $page_image_field['field_page_image']['settings']['view_mode'] = $view_modes[$key];
+      $page_default->set('content', array_merge($page_default->get('content'), $page_image_field));
+      if ($page_default->get('content.body')) {
+        $page_default->set('content.body.weight', $page_default->get('content.body.weight') + 1);
+      }
+      $page_default->clear('hidden.field_page_image');
+      $page_default->save();
+    }
+  }
+
+}

--- a/modules/acquia_cms_page/config/optional/core.entity_view_display.node.page.card.yml
+++ b/modules/acquia_cms_page/config/optional/core.entity_view_display.node.page.card.yml
@@ -32,6 +32,11 @@ content:
     third_party_settings: {  }
     weight: 0
     region: content
+  links:
+    settings: {  }
+    third_party_settings: {  }
+    weight: 1
+    region: content
   field_page_image:
     type: entity_reference_entity_view
     label: hidden
@@ -41,14 +46,8 @@ content:
     third_party_settings: {  }
     weight: 2
     region: content
-  links:
-    settings: {  }
-    third_party_settings: {  }
-    weight: 1
-    region: content
 hidden:
   field_categories: true
-  field_layout_canvas: true
   field_tags: true
   langcode: true
   search_api_excerpt: true

--- a/modules/acquia_cms_page/config/optional/core.entity_view_display.node.page.card.yml
+++ b/modules/acquia_cms_page/config/optional/core.entity_view_display.node.page.card.yml
@@ -32,19 +32,19 @@ content:
     third_party_settings: {  }
     weight: 0
     region: content
-  links:
-    settings: {  }
-    third_party_settings: {  }
-    weight: 1
-    region: content
   field_page_image:
     type: entity_reference_entity_view
     label: hidden
     settings:
-      view_mode: card
+      view_mode: small_landscape
       link: false
     third_party_settings: {  }
     weight: 2
+    region: content
+  links:
+    settings: {  }
+    third_party_settings: {  }
+    weight: 1
     region: content
 hidden:
   field_categories: true

--- a/modules/acquia_cms_page/config/optional/core.entity_view_display.node.page.card.yml
+++ b/modules/acquia_cms_page/config/optional/core.entity_view_display.node.page.card.yml
@@ -8,12 +8,12 @@ dependencies:
     - field.field.node.page.field_page_image
     - field.field.node.page.field_tags
     - node.type.page
-  enforced:
-    module:
-      - acquia_cms_page
   module:
     - text
     - user
+  enforced:
+    module:
+      - acquia_cms_page
 id: node.page.card
 targetEntityType: node
 bundle: page
@@ -21,26 +21,34 @@ mode: card
 content:
   body:
     type: text_trimmed
-    weight: 2
-    region: content
     label: hidden
     settings:
       trim_length: 600
     third_party_settings: {  }
+    weight: 3
+    region: content
   content_moderation_control:
+    settings: {  }
+    third_party_settings: {  }
     weight: 0
     region: content
+  field_page_image:
+    type: entity_reference_entity_view
+    label: hidden
+    settings:
+      view_mode: card
+      link: false
+    third_party_settings: {  }
+    weight: 2
+    region: content
+  links:
     settings: {  }
     third_party_settings: {  }
-  links:
     weight: 1
     region: content
-    settings: {  }
-    third_party_settings: {  }
 hidden:
   field_categories: true
   field_layout_canvas: true
-  field_page_image: true
   field_tags: true
   langcode: true
   search_api_excerpt: true

--- a/modules/acquia_cms_page/config/optional/core.entity_view_display.node.page.default.yml
+++ b/modules/acquia_cms_page/config/optional/core.entity_view_display.node.page.default.yml
@@ -26,7 +26,7 @@ content:
     type: entity_reference_entity_view
     label: hidden
     settings:
-      view_mode: full
+      view_mode: large_super_landscape
       link: false
     third_party_settings: {  }
     weight: 2

--- a/modules/acquia_cms_page/config/optional/core.entity_view_display.node.page.default.yml
+++ b/modules/acquia_cms_page/config/optional/core.entity_view_display.node.page.default.yml
@@ -7,30 +7,38 @@ dependencies:
     - field.field.node.page.field_page_image
     - field.field.node.page.field_tags
     - node.type.page
+  module:
+    - user
   enforced:
     module:
       - acquia_cms_page
-  module:
-    - user
 id: node.page.default
 targetEntityType: node
 bundle: page
 mode: default
 content:
   content_moderation_control:
+    settings: {  }
+    third_party_settings: {  }
     weight: 0
     region: content
+  field_page_image:
+    type: entity_reference_entity_view
+    label: hidden
+    settings:
+      view_mode: full
+      link: false
+    third_party_settings: {  }
+    weight: 2
+    region: content
+  links:
     settings: {  }
     third_party_settings: {  }
-  links:
     weight: 1
     region: content
-    settings: {  }
-    third_party_settings: {  }
 hidden:
   body: true
   field_categories: true
-  field_page_image: true
   field_tags: true
   langcode: true
   search_api_excerpt: true

--- a/modules/acquia_cms_page/config/optional/core.entity_view_display.node.page.horizontal_card.yml
+++ b/modules/acquia_cms_page/config/optional/core.entity_view_display.node.page.horizontal_card.yml
@@ -36,7 +36,7 @@ content:
     type: entity_reference_entity_view
     label: hidden
     settings:
-      view_mode: large_super_landscape
+      view_mode: small_landscape
       link: false
     third_party_settings: {  }
     weight: 2

--- a/modules/acquia_cms_page/config/optional/core.entity_view_display.node.page.horizontal_card.yml
+++ b/modules/acquia_cms_page/config/optional/core.entity_view_display.node.page.horizontal_card.yml
@@ -8,12 +8,12 @@ dependencies:
     - field.field.node.page.field_page_image
     - field.field.node.page.field_tags
     - node.type.page
-  enforced:
-    module:
-      - acquia_cms_page
   module:
     - text
     - user
+  enforced:
+    module:
+      - acquia_cms_page
 id: node.page.horizontal_card
 targetEntityType: node
 bundle: page
@@ -21,25 +21,33 @@ mode: horizontal_card
 content:
   body:
     type: text_summary_or_trimmed
-    weight: 3
-    region: content
     label: hidden
     settings:
       trim_length: 600
     third_party_settings: {  }
+    weight: 4
+    region: content
   content_moderation_control:
+    settings: {  }
+    third_party_settings: {  }
     weight: 0
     region: content
+  field_page_image:
+    type: entity_reference_entity_view
+    label: hidden
+    settings:
+      view_mode: large_super_landscape
+      link: false
+    third_party_settings: {  }
+    weight: 3
+    region: content
+  links:
     settings: {  }
     third_party_settings: {  }
-  links:
     weight: 1
     region: content
-    settings: {  }
-    third_party_settings: {  }
 hidden:
   field_categories: true
-  field_page_image: true
   field_tags: true
   langcode: true
   search_api_excerpt: true

--- a/modules/acquia_cms_page/config/optional/core.entity_view_display.node.page.horizontal_card.yml
+++ b/modules/acquia_cms_page/config/optional/core.entity_view_display.node.page.horizontal_card.yml
@@ -25,7 +25,7 @@ content:
     settings:
       trim_length: 600
     third_party_settings: {  }
-    weight: 4
+    weight: 3
     region: content
   content_moderation_control:
     settings: {  }
@@ -39,7 +39,7 @@ content:
       view_mode: large_super_landscape
       link: false
     third_party_settings: {  }
-    weight: 3
+    weight: 2
     region: content
   links:
     settings: {  }

--- a/modules/acquia_cms_page/config/optional/core.entity_view_display.node.page.search_index.yml
+++ b/modules/acquia_cms_page/config/optional/core.entity_view_display.node.page.search_index.yml
@@ -8,30 +8,29 @@ dependencies:
     - field.field.node.page.field_page_image
     - field.field.node.page.field_tags
     - node.type.page
+  module:
+    - user
   enforced:
     module:
       - acquia_cms_page
-  module:
-    - user
 id: node.page.search_index
 targetEntityType: node
 bundle: page
 mode: search_index
 content:
   content_moderation_control:
+    settings: {  }
+    third_party_settings: {  }
     weight: 0
     region: content
+  links:
     settings: {  }
     third_party_settings: {  }
-  links:
     weight: 1
     region: content
-    settings: {  }
-    third_party_settings: {  }
 hidden:
   body: true
   field_categories: true
-  field_layout_canvas: true
   field_page_image: true
   field_tags: true
   langcode: true

--- a/modules/acquia_cms_page/config/optional/core.entity_view_display.node.page.search_results.yml
+++ b/modules/acquia_cms_page/config/optional/core.entity_view_display.node.page.search_results.yml
@@ -43,19 +43,19 @@ content:
     third_party_settings: {  }
     weight: 0
     region: content
-  links:
-    settings: {  }
-    third_party_settings: {  }
-    weight: 1
-    region: content
   field_page_image:
     type: entity_reference_entity_view
     label: hidden
     settings:
-      view_mode: small
+      view_mode: teaser
       link: false
     third_party_settings: {  }
     weight: 2
+    region: content
+  links:
+    settings: {  }
+    third_party_settings: {  }
+    weight: 1
     region: content
 hidden:
   field_categories: true

--- a/modules/acquia_cms_page/config/optional/core.entity_view_display.node.page.search_results.yml
+++ b/modules/acquia_cms_page/config/optional/core.entity_view_display.node.page.search_results.yml
@@ -8,12 +8,12 @@ dependencies:
     - field.field.node.page.field_page_image
     - field.field.node.page.field_tags
     - node.type.page
-  enforced:
-    module:
-      - acquia_cms_page
   module:
     - smart_trim
     - user
+  enforced:
+    module:
+      - acquia_cms_page
 id: node.page.search_results
 targetEntityType: node
 bundle: page
@@ -21,37 +21,45 @@ mode: search_results
 content:
   body:
     type: smart_trim
-    weight: 2
-    region: content
     label: hidden
     settings:
       trim_length: 128
       trim_type: chars
       trim_suffix: ...
-      wrap_class: trimmed
-      more_text: More
-      more_class: more-link
-      summary_handler: trim
       wrap_output: false
+      wrap_class: trimmed
       more_link: false
+      more_class: more-link
+      more_text: More
+      summary_handler: trim
       trim_options:
         text: false
         trim_zero: false
     third_party_settings: {  }
+    weight: 3
+    region: content
   content_moderation_control:
+    settings: {  }
+    third_party_settings: {  }
     weight: 0
     region: content
+  field_page_image:
+    type: entity_reference_entity_view
+    label: hidden
+    settings:
+      view_mode: small
+      link: false
+    third_party_settings: {  }
+    weight: 2
+    region: content
+  links:
     settings: {  }
     third_party_settings: {  }
-  links:
     weight: 1
     region: content
-    settings: {  }
-    third_party_settings: {  }
 hidden:
   field_categories: true
   field_layout_canvas: true
-  field_page_image: true
   field_tags: true
   langcode: true
   search_api_excerpt: true

--- a/modules/acquia_cms_page/config/optional/core.entity_view_display.node.page.search_results.yml
+++ b/modules/acquia_cms_page/config/optional/core.entity_view_display.node.page.search_results.yml
@@ -43,6 +43,11 @@ content:
     third_party_settings: {  }
     weight: 0
     region: content
+  links:
+    settings: {  }
+    third_party_settings: {  }
+    weight: 1
+    region: content
   field_page_image:
     type: entity_reference_entity_view
     label: hidden
@@ -52,14 +57,8 @@ content:
     third_party_settings: {  }
     weight: 2
     region: content
-  links:
-    settings: {  }
-    third_party_settings: {  }
-    weight: 1
-    region: content
 hidden:
   field_categories: true
-  field_layout_canvas: true
   field_tags: true
   langcode: true
   search_api_excerpt: true

--- a/modules/acquia_cms_page/config/optional/core.entity_view_display.node.page.teaser.yml
+++ b/modules/acquia_cms_page/config/optional/core.entity_view_display.node.page.teaser.yml
@@ -8,12 +8,12 @@ dependencies:
     - field.field.node.page.field_page_image
     - field.field.node.page.field_tags
     - node.type.page
-  enforced:
-    module:
-      - acquia_cms_page
   module:
     - smart_trim
     - user
+  enforced:
+    module:
+      - acquia_cms_page
 id: node.page.teaser
 targetEntityType: node
 bundle: page
@@ -21,37 +21,45 @@ mode: teaser
 content:
   body:
     type: smart_trim
-    weight: 2
-    region: content
     label: hidden
     settings:
       trim_length: 128
       trim_type: chars
       trim_suffix: ...
-      wrap_class: trimmed
-      more_text: More
-      more_class: more-link
-      summary_handler: trim
       wrap_output: false
+      wrap_class: trimmed
       more_link: false
+      more_class: more-link
+      more_text: More
+      summary_handler: trim
       trim_options:
         text: false
         trim_zero: false
     third_party_settings: {  }
+    weight: 3
+    region: content
   content_moderation_control:
+    settings: {  }
+    third_party_settings: {  }
     weight: 0
     region: content
+  field_page_image:
+    type: entity_reference_entity_view
+    label: hidden
+    settings:
+      view_mode: teaser
+      link: false
+    third_party_settings: {  }
+    weight: 2
+    region: content
+  links:
     settings: {  }
     third_party_settings: {  }
-  links:
     weight: 1
     region: content
-    settings: {  }
-    third_party_settings: {  }
 hidden:
   field_categories: true
   field_layout_canvas: true
-  field_page_image: true
   field_tags: true
   langcode: true
   search_api_excerpt: true

--- a/modules/acquia_cms_page/config/optional/core.entity_view_display.node.page.teaser.yml
+++ b/modules/acquia_cms_page/config/optional/core.entity_view_display.node.page.teaser.yml
@@ -43,6 +43,11 @@ content:
     third_party_settings: {  }
     weight: 0
     region: content
+  links:
+    settings: {  }
+    third_party_settings: {  }
+    weight: 1
+    region: content
   field_page_image:
     type: entity_reference_entity_view
     label: hidden
@@ -52,14 +57,8 @@ content:
     third_party_settings: {  }
     weight: 2
     region: content
-  links:
-    settings: {  }
-    third_party_settings: {  }
-    weight: 1
-    region: content
 hidden:
   field_categories: true
-  field_layout_canvas: true
   field_tags: true
   langcode: true
   search_api_excerpt: true

--- a/modules/acquia_cms_page/config/pack_acquia_cms_page/cohesion_templates.cohesion_content_templates.node_page_card.yml
+++ b/modules/acquia_cms_page/config/pack_acquia_cms_page/cohesion_templates.cohesion_content_templates.node_page_card.yml
@@ -3,7 +3,8 @@ langcode: en
 status: true
 dependencies:
   config:
-    - image.style.coh_small_landscape
+    - cohesion_custom_styles.cohesion_custom_style.097f31b2
+    - cohesion_custom_styles.cohesion_custom_style.a13b8c94
 label: 'Card (Node, Page)'
 id: node_page_card
 json_values: |
@@ -80,23 +81,20 @@ json_values: |
                       "uid": "container",
                       "title": "Container",
                       "status": {
-                          "collapsed": true,
-                          "collapsedParents": []
+                          "collapsed": false
                       },
                       "uuid": "32581850-c4fc-40b8-a64a-f99380e3f56c",
                       "parentUid": "container",
                       "children": [
                           {
-                              "type": "item",
-                              "uid": "image",
-                              "title": "Image",
+                              "type": "container",
+                              "uid": "drupal-field",
+                              "title": "Field",
                               "status": {
-                                  "collapsed": true,
-                                  "collapsedParents": [
-                                      "32581850-c4fc-40b8-a64a-f99380e3f56c"
-                                  ]
+                                  "collapsed": true
                               },
-                              "uuid": "cf85bf76-a24e-42f2-8753-eb429f9c0fb1",
+                              "iconColor": "drupal",
+                              "uuid": "f629f877-a25b-4109-a386-266f6692c157",
                               "parentUid": "container",
                               "children": []
                           }
@@ -607,78 +605,6 @@ json_values: |
                       }
                   ],
                   "title": "Hide if no data",
-                  "selectorType": "topLevel",
-                  "form": null,
-                  "items": []
-              }
-          },
-          "cf85bf76-a24e-42f2-8753-eb429f9c0fb1": {
-              "settings": {
-                  "formDefinition": [
-                      {
-                          "formKey": "image-settings",
-                          "children": [
-                              {
-                                  "formKey": "image-image",
-                                  "breakpoints": [],
-                                  "activeFields": [
-                                      {
-                                          "name": "image",
-                                          "active": true
-                                      },
-                                      {
-                                          "name": "title",
-                                          "active": true
-                                      },
-                                      {
-                                          "name": "alt",
-                                          "active": true
-                                      },
-                                      {
-                                          "name": "lazyload",
-                                          "active": true
-                                      }
-                                  ]
-                              },
-                              {
-                                  "formKey": "image-size",
-                                  "breakpoints": [
-                                      {
-                                          "name": "xl"
-                                      }
-                                  ],
-                                  "activeFields": [
-                                      {
-                                          "name": "displaySize",
-                                          "active": true
-                                      },
-                                      {
-                                          "name": "imageAlignment",
-                                          "active": true
-                                      }
-                                  ]
-                              },
-                              {
-                                  "formKey": "image-style",
-                                  "breakpoints": [],
-                                  "activeFields": [
-                                      {
-                                          "name": "imageStyle",
-                                          "active": true
-                                      },
-                                      {
-                                          "name": "customStyle",
-                                          "active": true
-                                      },
-                                      {
-                                          "name": "customStyle",
-                                          "active": true
-                                      }
-                                  ]
-                              }
-                          ]
-                      }
-                  ],
                   "selectorType": "topLevel",
                   "form": null,
                   "items": []
@@ -1307,7 +1233,8 @@ json_values: |
                   "form": null,
                   "items": []
               }
-          }
+          },
+          "f629f877-a25b-4109-a386-266f6692c157": {}
       },
       "model": {
           "032e8885-0753-42c0-a9bf-e533b892febc": {
@@ -1562,41 +1489,13 @@ json_values: |
                   "hideData": "[node:field_page_image]"
               }
           },
-          "cf85bf76-a24e-42f2-8753-eb429f9c0fb1": {
+          "f629f877-a25b-4109-a386-266f6692c157": {
               "settings": {
-                  "title": "Image",
-                  "styles": {
-                      "xl": {
-                          "displaySize": "coh-image-responsive",
-                          "imageAlignment": "coh-image-align-left"
-                      }
-                  },
-                  "customStyle": [
-                      {
-                          "customStyle": ""
-                      }
-                  ],
-                  "lazyload": false,
+                  "title": "Field",
                   "settings": {
-                      "lazyload": false,
-                      "styles": {
-                          "xl": {
-                              "displaySize": "coh-image-responsive"
-                          }
-                      },
-                      "imageStyle": "",
-                      "customStyle": [
-                          {
-                              "customStyle": ""
-                          }
-                      ]
+                      "drupalField": ""
                   },
-                  "imageStyle": "coh_small_landscape",
-                  "image": "[node:field_page_image:entity:image:entity:path]",
-                  "attributes": {
-                      "title": "[node:field_page_image:entity:image:entity:name]",
-                      "alt": "[node:field_page_image:entity:image:alt]"
-                  }
+                  "drupalField": "content.field_page_image"
               },
               "context-visibility": {
                   "contextVisibility": {
@@ -1605,7 +1504,7 @@ json_values: |
               },
               "styles": {
                   "settings": {
-                      "element": "img"
+                      "element": "drupal-field"
                   }
               }
           }
@@ -1620,12 +1519,8 @@ json_values: |
                   "linkText": "Title of the page"
               }
           },
-          "cf85bf76-a24e-42f2-8753-eb429f9c0fb1": {
-              "settings": {
-                  "image": ""
-              }
-          },
-          "e9bb4398-565c-4515-abe3-878171391410": {}
+          "e9bb4398-565c-4515-abe3-878171391410": {},
+          "f629f877-a25b-4109-a386-266f6692c157": {}
       },
       "variableFields": {
           "032e8885-0753-42c0-a9bf-e533b892febc": [],
@@ -1636,12 +1531,8 @@ json_values: |
               "settings.linkText",
               "settings.linkToPage"
           ],
-          "cf85bf76-a24e-42f2-8753-eb429f9c0fb1": [
-              "settings.attributes.title",
-              "settings.attributes.alt",
-              "settings.image"
-          ],
-          "e9bb4398-565c-4515-abe3-878171391410": []
+          "e9bb4398-565c-4515-abe3-878171391410": [],
+          "f629f877-a25b-4109-a386-266f6692c157": []
       },
       "meta": {
           "fieldHistory": []

--- a/modules/acquia_cms_page/config/pack_acquia_cms_page/cohesion_templates.cohesion_content_templates.node_page_horizontal_card.yml
+++ b/modules/acquia_cms_page/config/pack_acquia_cms_page/cohesion_templates.cohesion_content_templates.node_page_horizontal_card.yml
@@ -3,7 +3,8 @@ langcode: en
 status: true
 dependencies:
   config:
-    - image.style.coh_small_landscape
+    - cohesion_custom_styles.cohesion_custom_style.097f31b2
+    - cohesion_custom_styles.cohesion_custom_style.a13b8c94
 label: 'Horizontal card (Node, Page)'
 id: node_page_horizontal_card
 json_values: |
@@ -94,22 +95,20 @@ json_values: |
                       "uid": "column",
                       "title": "Column",
                       "status": {
-                          "collapsed": true
+                          "collapsed": false
                       },
                       "uuid": "d064ac0c-529f-4efc-acb6-9ea6b6ae53d9",
                       "parentUid": "row-for-columns",
                       "children": [
                           {
-                              "type": "item",
-                              "uid": "image",
-                              "title": "Image",
+                              "type": "container",
+                              "uid": "drupal-field",
+                              "title": "Field",
                               "status": {
-                                  "collapsed": true,
-                                  "collapsedParents": [
-                                      "d064ac0c-529f-4efc-acb6-9ea6b6ae53d9"
-                                  ]
+                                  "collapsed": true
                               },
-                              "uuid": "7f902258-1702-4879-b5e5-217b5053c044",
+                              "iconColor": "drupal",
+                              "uuid": "8e22a905-8cdd-4111-8376-1a6abf3b1005",
                               "parentUid": "column",
                               "children": []
                           }
@@ -442,7 +441,7 @@ json_values: |
                                       },
                                       {
                                           "name": "order",
-                                          "active": true
+                                          "active": false
                                       },
                                       {
                                           "name": "flex-grow",
@@ -461,117 +460,7 @@ json_values: |
                                           "active": true
                                       }
                                   ]
-                              }
-                          ]
-                      }
-                  ],
-                  "items": [],
-                  "form": null
-              },
-              "hideNoData": {
-                  "formDefinition": [
-                      {
-                          "formKey": "tab-hide-data-settings",
-                          "children": [
-                              {
-                                  "formKey": "tab-hide-data-hide",
-                                  "breakpoints": [],
-                                  "activeFields": [
-                                      {
-                                          "name": "hideEnable",
-                                          "active": true
-                                      },
-                                      {
-                                          "name": "hideData",
-                                          "active": true
-                                      }
-                                  ]
-                              }
-                          ]
-                      }
-                  ],
-                  "title": "Hide if no data",
-                  "selectorType": "topLevel",
-                  "form": null,
-                  "items": []
-              }
-          },
-          "7f902258-1702-4879-b5e5-217b5053c044": {
-              "settings": {
-                  "formDefinition": [
-                      {
-                          "formKey": "image-settings",
-                          "children": [
-                              {
-                                  "formKey": "image-image",
-                                  "breakpoints": [],
-                                  "activeFields": [
-                                      {
-                                          "name": "image",
-                                          "active": true
-                                      },
-                                      {
-                                          "name": "title",
-                                          "active": true
-                                      },
-                                      {
-                                          "name": "alt",
-                                          "active": true
-                                      },
-                                      {
-                                          "name": "lazyload",
-                                          "active": true
-                                      }
-                                  ]
                               },
-                              {
-                                  "formKey": "image-size",
-                                  "breakpoints": [
-                                      {
-                                          "name": "xl"
-                                      }
-                                  ],
-                                  "activeFields": [
-                                      {
-                                          "name": "displaySize",
-                                          "active": true
-                                      },
-                                      {
-                                          "name": "imageAlignment",
-                                          "active": true
-                                      }
-                                  ]
-                              },
-                              {
-                                  "formKey": "image-style",
-                                  "breakpoints": [],
-                                  "activeFields": [
-                                      {
-                                          "name": "imageStyle",
-                                          "active": true
-                                      },
-                                      {
-                                          "name": "customStyle",
-                                          "active": true
-                                      },
-                                      {
-                                          "name": "customStyle",
-                                          "active": true
-                                      }
-                                  ]
-                              }
-                          ]
-                      }
-                  ],
-                  "selectorType": "topLevel",
-                  "form": null,
-                  "items": []
-              },
-              "styles": {
-                  "formDefinition": [
-                      {
-                          "formKey": "layout",
-                          "children": [
                               {
                                   "formKey": "height",
                                   "breakpoints": [
@@ -624,9 +513,35 @@ json_values: |
                           ]
                       }
                   ],
-                  "selectorType": "topLevel",
                   "items": [],
                   "form": null
+              },
+              "hideNoData": {
+                  "formDefinition": [
+                      {
+                          "formKey": "tab-hide-data-settings",
+                          "children": [
+                              {
+                                  "formKey": "tab-hide-data-hide",
+                                  "breakpoints": [],
+                                  "activeFields": [
+                                      {
+                                          "name": "hideEnable",
+                                          "active": true
+                                      },
+                                      {
+                                          "name": "hideData",
+                                          "active": true
+                                      }
+                                  ]
+                              }
+                          ]
+                      }
+                  ],
+                  "title": "Hide if no data",
+                  "selectorType": "topLevel",
+                  "form": null,
+                  "items": []
               }
           },
           "32896179-c898-407e-959c-80cdea97da3d": {
@@ -1466,7 +1381,8 @@ json_values: |
                   "form": null,
                   "items": []
               }
-          }
+          },
+          "8e22a905-8cdd-4111-8376-1a6abf3b1005": {}
       },
       "model": {
           "f6ec3928-969c-4485-ba59-d94bd4603aae": {
@@ -1770,66 +1686,6 @@ json_values: |
                   },
                   "styles": {
                       "xl": {
-                          "flex-item": {
-                              "order": {
-                                  "value": "-1"
-                              }
-                          }
-                      }
-                  }
-              },
-              "hideNoData": {
-                  "hideEnable": true,
-                  "hideData": "[node:field_page_image]"
-              }
-          },
-          "7f902258-1702-4879-b5e5-217b5053c044": {
-              "settings": {
-                  "title": "Image",
-                  "styles": {
-                      "xl": {
-                          "displaySize": "coh-image-responsive",
-                          "imageAlignment": null
-                      }
-                  },
-                  "customStyle": [
-                      {
-                          "customStyle": ""
-                      }
-                  ],
-                  "lazyload": false,
-                  "settings": {
-                      "lazyload": false,
-                      "styles": {
-                          "xl": {
-                              "displaySize": "coh-image-responsive"
-                          }
-                      },
-                      "imageStyle": "",
-                      "customStyle": [
-                          {
-                              "customStyle": ""
-                          }
-                      ]
-                  },
-                  "imageStyle": "coh_small_landscape",
-                  "image": "[node:field_page_image:entity:image:entity:path]",
-                  "attributes": {
-                      "title": "[node:field_page_image:entity:image:entity:name]",
-                      "alt": "[node:field_page_image:entity:image:alt]"
-                  }
-              },
-              "context-visibility": {
-                  "contextVisibility": {
-                      "condition": "ALL"
-                  }
-              },
-              "styles": {
-                  "settings": {
-                      "element": "img"
-                  },
-                  "styles": {
-                      "xl": {
                           "custom-css": [
                               {
                                   "customCssProperty": {
@@ -1845,6 +1701,29 @@ json_values: |
                           }
                       }
                   }
+              },
+              "hideNoData": {
+                  "hideEnable": true,
+                  "hideData": "[node:field_page_image]"
+              }
+          },
+          "8e22a905-8cdd-4111-8376-1a6abf3b1005": {
+              "settings": {
+                  "title": "Field",
+                  "settings": {
+                      "drupalField": ""
+                  },
+                  "drupalField": "content.field_page_image"
+              },
+              "context-visibility": {
+                  "contextVisibility": {
+                      "condition": "ALL"
+                  }
+              },
+              "styles": {
+                  "settings": {
+                      "element": "drupal-field"
+                  }
               }
           }
       },
@@ -1859,12 +1738,8 @@ json_values: |
           },
           "b674acf0-ffed-4944-9e1c-e42d5dbf6b67": {},
           "f6ec3928-969c-4485-ba59-d94bd4603aae": {},
-          "7f902258-1702-4879-b5e5-217b5053c044": {
-              "settings": {
-                  "image": ""
-              }
-          },
-          "683f0ebb-ef5a-4340-8269-6687b47c3e88": {}
+          "683f0ebb-ef5a-4340-8269-6687b47c3e88": {},
+          "8e22a905-8cdd-4111-8376-1a6abf3b1005": {}
       },
       "variableFields": {
           "32896179-c898-407e-959c-80cdea97da3d": [],
@@ -1876,12 +1751,8 @@ json_values: |
           ],
           "b674acf0-ffed-4944-9e1c-e42d5dbf6b67": [],
           "f6ec3928-969c-4485-ba59-d94bd4603aae": [],
-          "7f902258-1702-4879-b5e5-217b5053c044": [
-              "settings.attributes.title",
-              "settings.attributes.alt",
-              "settings.image"
-          ],
-          "683f0ebb-ef5a-4340-8269-6687b47c3e88": []
+          "683f0ebb-ef5a-4340-8269-6687b47c3e88": [],
+          "8e22a905-8cdd-4111-8376-1a6abf3b1005": []
       },
       "meta": {
           "fieldHistory": []

--- a/modules/acquia_cms_page/config/pack_acquia_cms_page/cohesion_templates.cohesion_content_templates.node_page_search_results.yml
+++ b/modules/acquia_cms_page/config/pack_acquia_cms_page/cohesion_templates.cohesion_content_templates.node_page_search_results.yml
@@ -3,7 +3,9 @@ langcode: en
 status: true
 dependencies:
   config:
-    - image.style.coh_small_landscape
+    - cohesion_custom_styles.cohesion_custom_style.bfd0fecd
+    - cohesion_custom_styles.cohesion_custom_style.ed4b7a3d
+    - cohesion_custom_styles.cohesion_custom_style.f3dc1bea
 label: 'Search Results (Node, Page)'
 id: node_page_search_results
 json_values: |
@@ -123,24 +125,19 @@ json_values: |
                       "uid": "column",
                       "title": "Column",
                       "status": {
-                          "collapsed": true
+                          "collapsed": false
                       },
                       "uuid": "3c26563f-9de5-4e47-bdc0-5e18bb0d648a",
                       "parentUid": "row-for-columns",
                       "children": [
                           {
-                              "type": "item",
-                              "uid": "picture",
-                              "title": "Picture",
-                              "selected": false,
+                              "type": "container",
+                              "uid": "drupal-field",
+                              "title": "Field",
                               "status": {
-                                  "collapsed": true,
-                                  "isopen": false,
-                                  "collapsedParents": [
-                                      "3c26563f-9de5-4e47-bdc0-5e18bb0d648a"
-                                  ]
+                                  "collapsed": true
                               },
-                              "uuid": "1e25da42-59ea-4c3b-9607-57d51c2eed12",
+                              "uuid": "861fd501-8c72-493b-8a4a-3fb3bd77b165",
                               "parentUid": "column",
                               "children": []
                           }
@@ -502,85 +499,6 @@ json_values: |
                       }
                   ],
                   "title": "Hide if no data",
-                  "selectorType": "topLevel",
-                  "form": null,
-                  "items": []
-              }
-          },
-          "1e25da42-59ea-4c3b-9607-57d51c2eed12": {
-              "settings": {
-                  "formDefinition": [
-                      {
-                          "formKey": "picture-settings",
-                          "children": [
-                              {
-                                  "formKey": "picture-info",
-                                  "breakpoints": [],
-                                  "activeFields": [
-                                      {
-                                          "name": "title",
-                                          "active": true
-                                      },
-                                      {
-                                          "name": "alt",
-                                          "active": true
-                                      },
-                                      {
-                                          "name": "lazyload",
-                                          "active": true
-                                      }
-                                  ]
-                              },
-                              {
-                                  "formKey": "picture-images",
-                                  "breakpoints": [
-                                      {
-                                          "name": "xl"
-                                      },
-                                      {
-                                          "name": "ps"
-                                      }
-                                  ],
-                                  "activeFields": [
-                                      {
-                                          "name": "displaySize",
-                                          "active": true
-                                      },
-                                      {
-                                          "name": "imageAlignment",
-                                          "active": true
-                                      },
-                                      {
-                                          "name": "pictureImagesArray",
-                                          "active": true
-                                      },
-                                      {
-                                          "name": "image",
-                                          "active": true
-                                      },
-                                      {
-                                          "name": "imageStyle",
-                                          "active": true
-                                      }
-                                  ]
-                              },
-                              {
-                                  "formKey": "picture-style",
-                                  "breakpoints": [],
-                                  "activeFields": [
-                                      {
-                                          "name": "customStyle",
-                                          "active": true
-                                      },
-                                      {
-                                          "name": "customStyle",
-                                          "active": true
-                                      }
-                                  ]
-                              }
-                          ]
-                      }
-                  ],
                   "selectorType": "topLevel",
                   "form": null,
                   "items": []
@@ -1573,7 +1491,8 @@ json_values: |
                   "form": null,
                   "items": []
               }
-          }
+          },
+          "861fd501-8c72-493b-8a4a-3fb3bd77b165": {}
       },
       "model": {
           "077408ab-eb6d-4c6e-b906-4158a537633f": {
@@ -1977,56 +1896,13 @@ json_values: |
                   "hideData": "[node:field_page_image]"
               }
           },
-          "1e25da42-59ea-4c3b-9607-57d51c2eed12": {
+          "861fd501-8c72-493b-8a4a-3fb3bd77b165": {
               "settings": {
-                  "title": "Picture",
-                  "customStyle": [
-                      {
-                          "customStyle": ""
-                      }
-                  ],
-                  "styles": {
-                      "xl": {
-                          "pictureImagesArray": [
-                              {
-                                  "imageStyle": "x_small_square_320x320_",
-                                  "image": "[node:field_page_image:entity:image:entity:path]"
-                              }
-                          ],
-                          "displaySize": "coh-image-responsive"
-                      },
-                      "ps": {
-                          "pictureImagesArray": [
-                              {
-                                  "imageStyle": "coh_small_landscape"
-                              }
-                          ],
-                          "displaySize": "coh-image-responsive"
-                      }
-                  },
-                  "lazyload": false,
+                  "title": "Field",
                   "settings": {
-                      "lazyload": false,
-                      "styles": {
-                          "xl": {
-                              "displaySize": "coh-image-responsive",
-                              "pictureImagesArray": [
-                                  {
-                                      "imageStyle": ""
-                                  }
-                              ]
-                          }
-                      },
-                      "customStyle": [
-                          {
-                              "customStyle": ""
-                          }
-                      ]
+                      "drupalField": ""
                   },
-                  "attributes": {
-                      "title": "[node:field_page_image:entity:image:entity:name]",
-                      "alt": "[node:field_page_image:entity:image:alt]"
-                  }
+                  "drupalField": "content.field_page_image"
               },
               "context-visibility": {
                   "contextVisibility": {
@@ -2035,7 +1911,7 @@ json_values: |
               },
               "styles": {
                   "settings": {
-                      "element": "picture"
+                      "element": "drupal-field"
                   }
               }
           }
@@ -2045,19 +1921,6 @@ json_values: |
           "077408ab-eb6d-4c6e-b906-4158a537633f": {},
           "7f47653a-bdf6-496f-97ef-4e409fc6679f": {},
           "3c26563f-9de5-4e47-bdc0-5e18bb0d648a": {},
-          "1e25da42-59ea-4c3b-9607-57d51c2eed12": {
-              "settings": {
-                  "styles": {
-                      "xl": {
-                          "pictureImagesArray": [
-                              {
-                                  "image": ""
-                              }
-                          ]
-                      }
-                  }
-              }
-          },
           "122e35cc-902e-4bc4-a30e-d204a627c154": {},
           "0b4f7f3f-1175-49db-8374-edaf85796f94": {
               "settings": {
@@ -2071,18 +1934,14 @@ json_values: |
               "settings": {
                   "content": "Jan 27, 2021"
               }
-          }
+          },
+          "861fd501-8c72-493b-8a4a-3fb3bd77b165": {}
       },
       "variableFields": {
           "6724674f-ba97-4b07-883d-a546b7dc3f4e": [],
           "077408ab-eb6d-4c6e-b906-4158a537633f": [],
           "7f47653a-bdf6-496f-97ef-4e409fc6679f": [],
           "3c26563f-9de5-4e47-bdc0-5e18bb0d648a": [],
-          "1e25da42-59ea-4c3b-9607-57d51c2eed12": [
-              "settings.styles.xl.pictureImagesArray.0.image",
-              "settings.attributes.title",
-              "settings.attributes.alt"
-          ],
           "122e35cc-902e-4bc4-a30e-d204a627c154": [],
           "0b4f7f3f-1175-49db-8374-edaf85796f94": [
               "settings.linkText",
@@ -2093,7 +1952,8 @@ json_values: |
           "8394962f-e5b9-4cf4-a73f-3cca17fe4af2": [
               "settings.content",
               "markup.attributes.0.value"
-          ]
+          ],
+          "861fd501-8c72-493b-8a4a-3fb3bd77b165": []
       },
       "meta": {
           "fieldHistory": []

--- a/modules/acquia_cms_page/config/pack_acquia_cms_page/cohesion_templates.cohesion_content_templates.node_page_teaser.yml
+++ b/modules/acquia_cms_page/config/pack_acquia_cms_page/cohesion_templates.cohesion_content_templates.node_page_teaser.yml
@@ -3,7 +3,9 @@ langcode: en
 status: true
 dependencies:
   config:
-    - image.style.coh_small_landscape
+    - cohesion_custom_styles.cohesion_custom_style.bfd0fecd
+    - cohesion_custom_styles.cohesion_custom_style.ed4b7a3d
+    - cohesion_custom_styles.cohesion_custom_style.f3dc1bea
 label: 'Teaser (Node, Page)'
 id: node_page_teaser
 json_values: |
@@ -123,24 +125,19 @@ json_values: |
                       "uid": "column",
                       "title": "Column",
                       "status": {
-                          "collapsed": true
+                          "collapsed": false
                       },
                       "uuid": "ac9a8d55-cef5-4310-b2fb-c75cc1d1ae5a",
                       "parentUid": "row-for-columns",
                       "children": [
                           {
-                              "type": "item",
-                              "uid": "picture",
-                              "title": "Picture",
-                              "selected": false,
+                              "type": "container",
+                              "uid": "drupal-field",
+                              "title": "Field",
                               "status": {
-                                  "collapsed": true,
-                                  "isopen": false,
-                                  "collapsedParents": [
-                                      "ac9a8d55-cef5-4310-b2fb-c75cc1d1ae5a"
-                                  ]
+                                  "collapsed": true
                               },
-                              "uuid": "56ee8f09-28ed-411f-a1e5-a34b2a4c2d5a",
+                              "uuid": "374a5b01-9fcf-46c0-b4ac-7708343970c9",
                               "parentUid": "column",
                               "children": []
                           }
@@ -502,85 +499,6 @@ json_values: |
                       }
                   ],
                   "title": "Hide if no data",
-                  "selectorType": "topLevel",
-                  "form": null,
-                  "items": []
-              }
-          },
-          "56ee8f09-28ed-411f-a1e5-a34b2a4c2d5a": {
-              "settings": {
-                  "formDefinition": [
-                      {
-                          "formKey": "picture-settings",
-                          "children": [
-                              {
-                                  "formKey": "picture-info",
-                                  "breakpoints": [],
-                                  "activeFields": [
-                                      {
-                                          "name": "title",
-                                          "active": true
-                                      },
-                                      {
-                                          "name": "alt",
-                                          "active": true
-                                      },
-                                      {
-                                          "name": "lazyload",
-                                          "active": true
-                                      }
-                                  ]
-                              },
-                              {
-                                  "formKey": "picture-images",
-                                  "breakpoints": [
-                                      {
-                                          "name": "xl"
-                                      },
-                                      {
-                                          "name": "ps"
-                                      }
-                                  ],
-                                  "activeFields": [
-                                      {
-                                          "name": "displaySize",
-                                          "active": true
-                                      },
-                                      {
-                                          "name": "imageAlignment",
-                                          "active": true
-                                      },
-                                      {
-                                          "name": "pictureImagesArray",
-                                          "active": true
-                                      },
-                                      {
-                                          "name": "image",
-                                          "active": true
-                                      },
-                                      {
-                                          "name": "imageStyle",
-                                          "active": true
-                                      }
-                                  ]
-                              },
-                              {
-                                  "formKey": "picture-style",
-                                  "breakpoints": [],
-                                  "activeFields": [
-                                      {
-                                          "name": "customStyle",
-                                          "active": true
-                                      },
-                                      {
-                                          "name": "customStyle",
-                                          "active": true
-                                      }
-                                  ]
-                              }
-                          ]
-                      }
-                  ],
                   "selectorType": "topLevel",
                   "form": null,
                   "items": []
@@ -1536,7 +1454,8 @@ json_values: |
                   ],
                   "form": null
               }
-          }
+          },
+          "374a5b01-9fcf-46c0-b4ac-7708343970c9": {}
       },
       "model": {
           "987da72b-6198-4924-bbce-005eba970773": {
@@ -1919,56 +1838,13 @@ json_values: |
                   "hideData": "[node:field_page_image]"
               }
           },
-          "56ee8f09-28ed-411f-a1e5-a34b2a4c2d5a": {
+          "374a5b01-9fcf-46c0-b4ac-7708343970c9": {
               "settings": {
-                  "title": "Picture",
-                  "customStyle": [
-                      {
-                          "customStyle": ""
-                      }
-                  ],
-                  "styles": {
-                      "xl": {
-                          "pictureImagesArray": [
-                              {
-                                  "imageStyle": "x_small_square_320x320_",
-                                  "image": "[node:field_page_image:entity:image:entity:path]"
-                              }
-                          ],
-                          "displaySize": "coh-image-responsive"
-                      },
-                      "ps": {
-                          "pictureImagesArray": [
-                              {
-                                  "imageStyle": "coh_small_landscape"
-                              }
-                          ],
-                          "displaySize": "coh-image-responsive"
-                      }
-                  },
-                  "lazyload": false,
+                  "title": "Field",
                   "settings": {
-                      "lazyload": false,
-                      "styles": {
-                          "xl": {
-                              "displaySize": "coh-image-responsive",
-                              "pictureImagesArray": [
-                                  {
-                                      "imageStyle": ""
-                                  }
-                              ]
-                          }
-                      },
-                      "customStyle": [
-                          {
-                              "customStyle": ""
-                          }
-                      ]
+                      "drupalField": ""
                   },
-                  "attributes": {
-                      "title": "[node:field_page_image:entity:image:entity:name]",
-                      "alt": "[node:field_page_image:entity:image:alt]"
-                  }
+                  "drupalField": "content.field_page_image"
               },
               "context-visibility": {
                   "contextVisibility": {
@@ -1977,7 +1853,7 @@ json_values: |
               },
               "styles": {
                   "settings": {
-                      "element": "picture"
+                      "element": "drupal-field"
                   }
               }
           }
@@ -1985,23 +1861,6 @@ json_values: |
       "previewModel": {
           "1802fcb6-947a-4020-83ab-744870e6aacc": {},
           "ac9a8d55-cef5-4310-b2fb-c75cc1d1ae5a": {},
-          "56ee8f09-28ed-411f-a1e5-a34b2a4c2d5a": {
-              "settings": {
-                  "attributes": {
-                      "title": "",
-                      "alt": ""
-                  },
-                  "styles": {
-                      "xl": {
-                          "pictureImagesArray": [
-                              {
-                                  "image": ""
-                              }
-                          ]
-                      }
-                  }
-              }
-          },
           "7fde348c-292a-43ac-834a-0c37d8bb3b22": {},
           "26b95fb3-ac5f-44b9-b704-dab3000ae1e8": {
               "settings": {
@@ -2016,16 +1875,12 @@ json_values: |
                   "content": "Jan 27, 2021"
               }
           },
-          "987da72b-6198-4924-bbce-005eba970773": {}
+          "987da72b-6198-4924-bbce-005eba970773": {},
+          "374a5b01-9fcf-46c0-b4ac-7708343970c9": {}
       },
       "variableFields": {
           "1802fcb6-947a-4020-83ab-744870e6aacc": [],
           "ac9a8d55-cef5-4310-b2fb-c75cc1d1ae5a": [],
-          "56ee8f09-28ed-411f-a1e5-a34b2a4c2d5a": [
-              "settings.attributes.title",
-              "settings.attributes.alt",
-              "settings.styles.xl.pictureImagesArray.0.image"
-          ],
           "7fde348c-292a-43ac-834a-0c37d8bb3b22": [],
           "26b95fb3-ac5f-44b9-b704-dab3000ae1e8": [
               "settings.linkText",
@@ -2037,7 +1892,8 @@ json_values: |
               "settings.content",
               "markup.attributes.0.value"
           ],
-          "987da72b-6198-4924-bbce-005eba970773": []
+          "987da72b-6198-4924-bbce-005eba970773": [],
+          "374a5b01-9fcf-46c0-b4ac-7708343970c9": []
       },
       "meta": {
           "fieldHistory": []

--- a/modules/acquia_cms_person/acquia_cms_person.install
+++ b/modules/acquia_cms_person/acquia_cms_person.install
@@ -59,3 +59,35 @@ function acquia_cms_person_update_8001() {
     }
   }
 }
+
+/**
+ * Implements hook_update_N().
+ *
+ * Update Person display modes.
+ */
+function acquia_cms_person_update_8002() {
+  // Load and update default view mode.
+  $display_modes = [
+    'default',
+    'card',
+    'horizontal_card',
+    'search_results',
+    'teaser',
+  ];
+  $view_modes = [
+    'full',
+    'card',
+    'large_super_landscape',
+    'small',
+    'teaser',
+  ];
+  foreach ($display_modes as $key => $display_mode) {
+    $person_default = \Drupal::configFactory()->getEditable('core.entity_view_display.node.person.' . $display_mode);
+    if ($person_default->get('content.field_person_image.type') == 'entity_reference_label') {
+      $person_default->set('content.field_person_image.type', 'entity_reference_entity_view');
+      $person_default->set('content.field_person_image.settings.view_mode', $view_modes[$key]);
+      $person_default->save();
+    }
+  }
+
+}

--- a/modules/acquia_cms_person/acquia_cms_person.install
+++ b/modules/acquia_cms_person/acquia_cms_person.install
@@ -74,20 +74,17 @@ function acquia_cms_person_update_8002() {
     'search_results',
     'teaser',
   ];
-  $view_modes = [
-    'full',
-    'card',
-    'large_super_landscape',
-    'small',
-    'teaser',
-  ];
-  foreach ($display_modes as $key => $display_mode) {
-    $person_default = \Drupal::configFactory()->getEditable('core.entity_view_display.node.person.' . $display_mode);
-    if ($person_default->get('content.field_person_image.type') == 'entity_reference_label') {
-      $person_default->set('content.field_person_image.type', 'entity_reference_entity_view');
-      $person_default->set('content.field_person_image.settings.view_mode', $view_modes[$key]);
-      $person_default->save();
+  // Update Image field.
+  foreach ($display_modes as $display_mode) {
+    $person_view_mode = \Drupal::configFactory()->getEditable('core.entity_view_display.node.person.' . $display_mode);
+    if ($person_view_mode->get('content.field_person_image.type') == 'entity_reference_label') {
+      $person_view_mode->set('content.field_person_image.type', 'entity_reference_entity_view');
+      $person_view_mode->set('content.field_person_image.settings.view_mode', 'x_small_square');
+      $person_view_mode->save();
     }
   }
+
+  // Add referenced image view mode.
+  _acquia_cms_common_rewrite_configuration('core.entity_view_display.node.person.referenced_image', 'acquia_cms_person');
 
 }

--- a/modules/acquia_cms_person/config/optional/core.entity_view_display.node.person.card.yml
+++ b/modules/acquia_cms_person/config/optional/core.entity_view_display.node.person.card.yml
@@ -13,12 +13,12 @@ dependencies:
     - field.field.node.person.field_place
     - field.field.node.person.field_tags
     - node.type.person
-  enforced:
-    module:
-      - acquia_cms_person
   module:
     - text
     - user
+  enforced:
+    module:
+      - acquia_cms_person
 id: node.person.card
 targetEntityType: node
 bundle: person
@@ -26,28 +26,29 @@ mode: card
 content:
   body:
     type: text_summary_or_trimmed
-    weight: 1
-    region: content
     label: hidden
     settings:
       trim_length: 128
     third_party_settings: {  }
+    weight: 1
+    region: content
   field_person_image:
-    type: entity_reference_label
+    type: entity_reference_entity_view
+    label: hidden
+    settings:
+      view_mode: card
+      link: false
+    third_party_settings: {  }
     weight: 0
     region: content
-    label: hidden
-    settings:
-      link: false
-    third_party_settings: {  }
   field_person_type:
     type: entity_reference_label
-    weight: 2
-    region: content
     label: hidden
     settings:
       link: false
     third_party_settings: {  }
+    weight: 2
+    region: content
 hidden:
   content_moderation_control: true
   field_categories: true

--- a/modules/acquia_cms_person/config/optional/core.entity_view_display.node.person.default.yml
+++ b/modules/acquia_cms_person/config/optional/core.entity_view_display.node.person.default.yml
@@ -12,13 +12,13 @@ dependencies:
     - field.field.node.person.field_place
     - field.field.node.person.field_tags
     - node.type.person
-  enforced:
-    module:
-      - acquia_cms_person
   module:
     - telephone
     - text
     - user
+  enforced:
+    module:
+      - acquia_cms_person
 id: node.person.default
 targetEntityType: node
 bundle: person
@@ -26,68 +26,69 @@ mode: default
 content:
   body:
     type: text_default
+    label: hidden
+    settings: {  }
+    third_party_settings: {  }
     weight: 3
     region: content
-    label: hidden
+  content_moderation_control:
     settings: {  }
     third_party_settings: {  }
-  content_moderation_control:
     weight: 7
     region: content
-    settings: {  }
-    third_party_settings: {  }
   field_email:
     type: basic_string
-    weight: 6
-    region: content
     label: hidden
     settings: {  }
     third_party_settings: {  }
+    weight: 6
+    region: content
   field_job_title:
     type: string
-    weight: 0
-    region: content
     label: hidden
     settings:
       link_to_entity: false
     third_party_settings: {  }
-  field_person_image:
-    type: entity_reference_label
-    weight: 2
+    weight: 0
     region: content
+  field_person_image:
+    type: entity_reference_entity_view
     label: hidden
     settings:
+      view_mode: full
       link: true
     third_party_settings: {  }
+    weight: 2
+    region: content
   field_person_telephone:
     type: telephone_link
-    weight: 1
-    region: content
     label: hidden
     settings:
       title: ''
     third_party_settings: {  }
+    weight: 1
+    region: content
   field_person_type:
     type: entity_reference_label
-    weight: 5
-    region: content
     label: hidden
     settings:
       link: false
     third_party_settings: {  }
+    weight: 5
+    region: content
   field_place:
     type: entity_reference_label
-    weight: 4
-    region: content
     label: hidden
     settings:
       link: true
     third_party_settings: {  }
-  links:
-    weight: 8
+    weight: 4
     region: content
+  links:
     settings: {  }
     third_party_settings: {  }
+    weight: 8
+    region: content
 hidden:
   field_categories: true
   field_tags: true

--- a/modules/acquia_cms_person/config/optional/core.entity_view_display.node.person.default.yml
+++ b/modules/acquia_cms_person/config/optional/core.entity_view_display.node.person.default.yml
@@ -55,7 +55,7 @@ content:
     type: entity_reference_entity_view
     label: hidden
     settings:
-      view_mode: full
+      view_mode: x_small_square
       link: false
     third_party_settings: {  }
     weight: 2

--- a/modules/acquia_cms_person/config/optional/core.entity_view_display.node.person.default.yml
+++ b/modules/acquia_cms_person/config/optional/core.entity_view_display.node.person.default.yml
@@ -56,7 +56,7 @@ content:
     label: hidden
     settings:
       view_mode: full
-      link: true
+      link: false
     third_party_settings: {  }
     weight: 2
     region: content

--- a/modules/acquia_cms_person/config/optional/core.entity_view_display.node.person.horizontal_card.yml
+++ b/modules/acquia_cms_person/config/optional/core.entity_view_display.node.person.horizontal_card.yml
@@ -13,13 +13,13 @@ dependencies:
     - field.field.node.person.field_place
     - field.field.node.person.field_tags
     - node.type.person
-  enforced:
-    module:
-      - acquia_cms_person
   module:
     - telephone
     - text
     - user
+  enforced:
+    module:
+      - acquia_cms_person
 id: node.person.horizontal_card
 targetEntityType: node
 bundle: person
@@ -27,68 +27,69 @@ mode: horizontal_card
 content:
   body:
     type: text_default
+    label: hidden
+    settings: {  }
+    third_party_settings: {  }
     weight: 3
     region: content
-    label: hidden
+  content_moderation_control:
     settings: {  }
     third_party_settings: {  }
-  content_moderation_control:
     weight: 7
     region: content
-    settings: {  }
-    third_party_settings: {  }
   field_email:
     type: basic_string
-    weight: 6
-    region: content
     label: hidden
     settings: {  }
     third_party_settings: {  }
+    weight: 6
+    region: content
   field_job_title:
     type: string
-    weight: 0
-    region: content
     label: hidden
     settings:
       link_to_entity: false
     third_party_settings: {  }
-  field_person_image:
-    type: entity_reference_label
-    weight: 2
+    weight: 0
     region: content
+  field_person_image:
+    type: entity_reference_entity_view
     label: hidden
     settings:
+      view_mode: large_super_landscape
       link: true
     third_party_settings: {  }
+    weight: 2
+    region: content
   field_person_telephone:
     type: telephone_link
-    weight: 1
-    region: content
     label: hidden
     settings:
       title: ''
     third_party_settings: {  }
+    weight: 1
+    region: content
   field_person_type:
     type: entity_reference_label
-    weight: 5
-    region: content
     label: hidden
     settings:
       link: false
     third_party_settings: {  }
+    weight: 5
+    region: content
   field_place:
     type: entity_reference_label
-    weight: 4
-    region: content
     label: hidden
     settings:
       link: true
     third_party_settings: {  }
-  links:
-    weight: 8
+    weight: 4
     region: content
+  links:
     settings: {  }
     third_party_settings: {  }
+    weight: 8
+    region: content
 hidden:
   field_categories: true
   field_tags: true

--- a/modules/acquia_cms_person/config/optional/core.entity_view_display.node.person.horizontal_card.yml
+++ b/modules/acquia_cms_person/config/optional/core.entity_view_display.node.person.horizontal_card.yml
@@ -56,7 +56,7 @@ content:
     type: entity_reference_entity_view
     label: hidden
     settings:
-      view_mode: large_super_landscape
+      view_mode: x_small_square
       link: false
     third_party_settings: {  }
     weight: 2

--- a/modules/acquia_cms_person/config/optional/core.entity_view_display.node.person.horizontal_card.yml
+++ b/modules/acquia_cms_person/config/optional/core.entity_view_display.node.person.horizontal_card.yml
@@ -57,7 +57,7 @@ content:
     label: hidden
     settings:
       view_mode: large_super_landscape
-      link: true
+      link: false
     third_party_settings: {  }
     weight: 2
     region: content

--- a/modules/acquia_cms_person/config/optional/core.entity_view_display.node.person.referenced_image.yml
+++ b/modules/acquia_cms_person/config/optional/core.entity_view_display.node.person.referenced_image.yml
@@ -2,7 +2,7 @@ langcode: en
 status: true
 dependencies:
   config:
-    - core.entity_view_mode.node.card
+    - core.entity_view_mode.node.referenced_image
     - field.field.node.person.body
     - field.field.node.person.field_categories
     - field.field.node.person.field_email
@@ -14,47 +14,32 @@ dependencies:
     - field.field.node.person.field_tags
     - node.type.person
   module:
-    - text
     - user
   enforced:
     module:
       - acquia_cms_person
-id: node.person.card
+id: node.person.referenced_image
 targetEntityType: node
 bundle: person
-mode: card
+mode: referenced_image
 content:
-  body:
-    type: text_summary_or_trimmed
-    label: hidden
-    settings:
-      trim_length: 128
-    third_party_settings: {  }
-    weight: 1
-    region: content
   field_person_image:
     type: entity_reference_entity_view
     label: hidden
     settings:
-      view_mode: x_small_square
+      view_mode: large
       link: false
     third_party_settings: {  }
     weight: 0
     region: content
-  field_person_type:
-    type: entity_reference_label
-    label: hidden
-    settings:
-      link: false
-    third_party_settings: {  }
-    weight: 2
-    region: content
 hidden:
+  body: true
   content_moderation_control: true
   field_categories: true
   field_email: true
   field_job_title: true
   field_person_telephone: true
+  field_person_type: true
   field_place: true
   field_tags: true
   langcode: true

--- a/modules/acquia_cms_person/config/optional/core.entity_view_display.node.person.search_results.yml
+++ b/modules/acquia_cms_person/config/optional/core.entity_view_display.node.person.search_results.yml
@@ -60,7 +60,7 @@ content:
     type: entity_reference_entity_view
     label: hidden
     settings:
-      view_mode: small
+      view_mode: x_small_square
       link: false
     third_party_settings: {  }
     weight: 2

--- a/modules/acquia_cms_person/config/optional/core.entity_view_display.node.person.search_results.yml
+++ b/modules/acquia_cms_person/config/optional/core.entity_view_display.node.person.search_results.yml
@@ -61,7 +61,7 @@ content:
     label: hidden
     settings:
       view_mode: small
-      link: true
+      link: false
     third_party_settings: {  }
     weight: 2
     region: content

--- a/modules/acquia_cms_person/config/optional/core.entity_view_display.node.person.search_results.yml
+++ b/modules/acquia_cms_person/config/optional/core.entity_view_display.node.person.search_results.yml
@@ -13,12 +13,12 @@ dependencies:
     - field.field.node.person.field_place
     - field.field.node.person.field_tags
     - node.type.person
-  enforced:
-    module:
-      - acquia_cms_person
   module:
     - smart_trim
     - user
+  enforced:
+    module:
+      - acquia_cms_person
 id: node.person.search_results
 targetEntityType: node
 bundle: person
@@ -26,57 +26,58 @@ mode: search_results
 content:
   body:
     type: smart_trim
-    weight: 3
-    region: content
     label: hidden
     settings:
       trim_length: 128
       trim_type: chars
       trim_suffix: ...
-      wrap_class: trimmed
-      more_text: More
-      more_class: more-link
-      summary_handler: trim
       wrap_output: false
+      wrap_class: trimmed
       more_link: false
+      more_class: more-link
+      more_text: More
+      summary_handler: trim
       trim_options:
         text: false
         trim_zero: false
     third_party_settings: {  }
-  content_moderation_control:
-    weight: 4
+    weight: 3
     region: content
+  content_moderation_control:
     settings: {  }
     third_party_settings: {  }
+    weight: 4
+    region: content
   field_job_title:
     type: string
-    weight: 0
-    region: content
     label: above
     settings:
       link_to_entity: false
     third_party_settings: {  }
-  field_person_image:
-    type: entity_reference_label
-    weight: 2
+    weight: 0
     region: content
+  field_person_image:
+    type: entity_reference_entity_view
     label: hidden
     settings:
+      view_mode: small
       link: true
     third_party_settings: {  }
+    weight: 2
+    region: content
   field_person_type:
     type: entity_reference_label
-    weight: 1
-    region: content
     label: hidden
     settings:
       link: false
     third_party_settings: {  }
-  links:
-    weight: 5
+    weight: 1
     region: content
+  links:
     settings: {  }
     third_party_settings: {  }
+    weight: 5
+    region: content
 hidden:
   field_categories: true
   field_email: true

--- a/modules/acquia_cms_person/config/optional/core.entity_view_display.node.person.teaser.yml
+++ b/modules/acquia_cms_person/config/optional/core.entity_view_display.node.person.teaser.yml
@@ -60,7 +60,7 @@ content:
     type: entity_reference_entity_view
     label: hidden
     settings:
-      view_mode: teaser
+      view_mode: x_small_square
       link: false
     third_party_settings: {  }
     weight: 2

--- a/modules/acquia_cms_person/config/optional/core.entity_view_display.node.person.teaser.yml
+++ b/modules/acquia_cms_person/config/optional/core.entity_view_display.node.person.teaser.yml
@@ -61,7 +61,7 @@ content:
     label: hidden
     settings:
       view_mode: teaser
-      link: true
+      link: false
     third_party_settings: {  }
     weight: 2
     region: content

--- a/modules/acquia_cms_person/config/optional/core.entity_view_display.node.person.teaser.yml
+++ b/modules/acquia_cms_person/config/optional/core.entity_view_display.node.person.teaser.yml
@@ -13,12 +13,12 @@ dependencies:
     - field.field.node.person.field_place
     - field.field.node.person.field_tags
     - node.type.person
-  enforced:
-    module:
-      - acquia_cms_person
   module:
     - smart_trim
     - user
+  enforced:
+    module:
+      - acquia_cms_person
 id: node.person.teaser
 targetEntityType: node
 bundle: person
@@ -26,57 +26,58 @@ mode: teaser
 content:
   body:
     type: smart_trim
-    weight: 3
-    region: content
     label: hidden
     settings:
       trim_length: 128
       trim_type: chars
       trim_suffix: ...
-      wrap_class: trimmed
-      more_text: More
-      more_class: more-link
-      summary_handler: trim
       wrap_output: false
+      wrap_class: trimmed
       more_link: false
+      more_class: more-link
+      more_text: More
+      summary_handler: trim
       trim_options:
         text: false
         trim_zero: false
     third_party_settings: {  }
-  content_moderation_control:
-    weight: 4
+    weight: 3
     region: content
+  content_moderation_control:
     settings: {  }
     third_party_settings: {  }
+    weight: 4
+    region: content
   field_job_title:
     type: string
-    weight: 0
-    region: content
     label: above
     settings:
       link_to_entity: false
     third_party_settings: {  }
-  field_person_image:
-    type: entity_reference_label
-    weight: 2
+    weight: 0
     region: content
+  field_person_image:
+    type: entity_reference_entity_view
     label: hidden
     settings:
+      view_mode: teaser
       link: true
     third_party_settings: {  }
+    weight: 2
+    region: content
   field_person_type:
     type: entity_reference_label
-    weight: 1
-    region: content
     label: hidden
     settings:
       link: false
     third_party_settings: {  }
-  links:
-    weight: 5
+    weight: 1
     region: content
+  links:
     settings: {  }
     third_party_settings: {  }
+    weight: 5
+    region: content
 hidden:
   field_categories: true
   field_email: true

--- a/modules/acquia_cms_person/config/pack_acquia_cms_person/cohesion_sync.cohesion_sync_package.pack_acquia_cms_person.yml
+++ b/modules/acquia_cms_person/config/pack_acquia_cms_person/cohesion_sync.cohesion_sync_package.pack_acquia_cms_person.yml
@@ -1095,5 +1095,14 @@ settings: |
               }
           },
           "checked": true
+      },
+      "b779c5f4-9238-4934-ba88-5e8b90a56d09": {
+          "type": "cohesion_content_templates",
+          "items": {
+              "b779c5f4-9238-4934-ba88-5e8b90a56d09": {
+                  "type": "cohesion_content_templates"
+              }
+          },
+          "checked": true
       }
   }

--- a/modules/acquia_cms_person/config/pack_acquia_cms_person/cohesion_templates.cohesion_content_templates.node_person_card.yml
+++ b/modules/acquia_cms_person/config/pack_acquia_cms_person/cohesion_templates.cohesion_content_templates.node_person_card.yml
@@ -3,7 +3,10 @@ langcode: en
 status: true
 dependencies:
   config:
-    - image.style.coh_small_square
+    - cohesion_custom_styles.cohesion_custom_style.097f31b2
+    - cohesion_custom_styles.cohesion_custom_style.65dc3072
+    - cohesion_custom_styles.cohesion_custom_style.a13b8c94
+    - cohesion_custom_styles.cohesion_custom_style.bfd0fecd
 label: 'Card (Node, Person)'
 id: node_person_card
 json_values: |
@@ -123,24 +126,19 @@ json_values: |
                       "uid": "container",
                       "title": "Container",
                       "status": {
-                          "collapsed": true
+                          "collapsed": false
                       },
                       "uuid": "3408250d-6b3c-4e4e-8f13-a8df1da4a6a6",
                       "parentUid": "container",
                       "children": [
                           {
-                              "type": "item",
-                              "uid": "picture",
-                              "title": "Picture",
-                              "selected": false,
+                              "type": "container",
+                              "uid": "drupal-field",
+                              "title": "Field",
                               "status": {
-                                  "collapsed": true,
-                                  "isopen": false,
-                                  "collapsedParents": [
-                                      "3408250d-6b3c-4e4e-8f13-a8df1da4a6a6"
-                                  ]
+                                  "collapsed": true
                               },
-                              "uuid": "441bd4ee-a623-4b54-aeae-4ad391715d7d",
+                              "uuid": "a505516d-fa2b-4856-a31d-c6f35378ef66",
                               "parentUid": "container",
                               "children": []
                           }
@@ -651,85 +649,6 @@ json_values: |
                       }
                   ],
                   "title": "Hide if no data",
-                  "selectorType": "topLevel",
-                  "form": null,
-                  "items": []
-              }
-          },
-          "441bd4ee-a623-4b54-aeae-4ad391715d7d": {
-              "settings": {
-                  "formDefinition": [
-                      {
-                          "formKey": "picture-settings",
-                          "children": [
-                              {
-                                  "formKey": "picture-info",
-                                  "breakpoints": [],
-                                  "activeFields": [
-                                      {
-                                          "name": "title",
-                                          "active": true
-                                      },
-                                      {
-                                          "name": "alt",
-                                          "active": true
-                                      },
-                                      {
-                                          "name": "lazyload",
-                                          "active": true
-                                      }
-                                  ]
-                              },
-                              {
-                                  "formKey": "picture-images",
-                                  "breakpoints": [
-                                      {
-                                          "name": "xl"
-                                      },
-                                      {
-                                          "name": "ps"
-                                      }
-                                  ],
-                                  "activeFields": [
-                                      {
-                                          "name": "displaySize",
-                                          "active": true
-                                      },
-                                      {
-                                          "name": "imageAlignment",
-                                          "active": true
-                                      },
-                                      {
-                                          "name": "pictureImagesArray",
-                                          "active": true
-                                      },
-                                      {
-                                          "name": "image",
-                                          "active": true
-                                      },
-                                      {
-                                          "name": "imageStyle",
-                                          "active": true
-                                      }
-                                  ]
-                              },
-                              {
-                                  "formKey": "picture-style",
-                                  "breakpoints": [],
-                                  "activeFields": [
-                                      {
-                                          "name": "customStyle",
-                                          "active": true
-                                      },
-                                      {
-                                          "name": "customStyle",
-                                          "active": true
-                                      }
-                                  ]
-                              }
-                          ]
-                      }
-                  ],
                   "selectorType": "topLevel",
                   "form": null,
                   "items": []
@@ -1964,7 +1883,8 @@ json_values: |
                   "form": null,
                   "items": []
               }
-          }
+          },
+          "a505516d-fa2b-4856-a31d-c6f35378ef66": {}
       },
       "model": {
           "4087bd19-e193-4b41-aa82-223bafb9f13e": {
@@ -2373,56 +2293,13 @@ json_values: |
                   "hideData": "[node:field_person_image]"
               }
           },
-          "441bd4ee-a623-4b54-aeae-4ad391715d7d": {
+          "a505516d-fa2b-4856-a31d-c6f35378ef66": {
               "settings": {
-                  "title": "Picture",
-                  "customStyle": [
-                      {
-                          "customStyle": ""
-                      }
-                  ],
-                  "styles": {
-                      "xl": {
-                          "pictureImagesArray": [
-                              {
-                                  "imageStyle": "coh_small_square",
-                                  "image": "[node:field_person_image:entity:image:entity:path]"
-                              }
-                          ],
-                          "displaySize": "coh-image-responsive"
-                      },
-                      "ps": {
-                          "pictureImagesArray": [
-                              {
-                                  "imageStyle": "x_small_square_320x320_"
-                              }
-                          ],
-                          "displaySize": "coh-image-responsive"
-                      }
-                  },
-                  "lazyload": false,
+                  "title": "Field",
                   "settings": {
-                      "lazyload": false,
-                      "styles": {
-                          "xl": {
-                              "displaySize": "coh-image-responsive",
-                              "pictureImagesArray": [
-                                  {
-                                      "imageStyle": ""
-                                  }
-                              ]
-                          }
-                      },
-                      "customStyle": [
-                          {
-                              "customStyle": ""
-                          }
-                      ]
+                      "drupalField": ""
                   },
-                  "attributes": {
-                      "title": "[node:field_person_image:entity:name]",
-                      "alt": "[node:field_person_image:entity:image:alt]"
-                  }
+                  "drupalField": "content.field_person_image"
               },
               "context-visibility": {
                   "contextVisibility": {
@@ -2431,7 +2308,7 @@ json_values: |
               },
               "styles": {
                   "settings": {
-                      "element": "picture"
+                      "element": "drupal-field"
                   }
               }
           }
@@ -2440,19 +2317,6 @@ json_values: |
           "4087bd19-e193-4b41-aa82-223bafb9f13e": {},
           "a6c28a75-3a79-4df9-b17f-8e5609a093e8": {},
           "3408250d-6b3c-4e4e-8f13-a8df1da4a6a6": {},
-          "441bd4ee-a623-4b54-aeae-4ad391715d7d": {
-              "settings": {
-                  "styles": {
-                      "xl": {
-                          "pictureImagesArray": [
-                              {
-                                  "image": ""
-                              }
-                          ]
-                      }
-                  }
-              }
-          },
           "f5f0c1fe-fa93-470c-b205-63dec9af5b6c": {},
           "b59bea3a-b8f6-4e86-bf7c-390ac4197f11": {
               "settings": {
@@ -2470,17 +2334,13 @@ json_values: |
               "settings": {
                   "linkText": "Type"
               }
-          }
+          },
+          "a505516d-fa2b-4856-a31d-c6f35378ef66": {}
       },
       "variableFields": {
           "4087bd19-e193-4b41-aa82-223bafb9f13e": [],
           "a6c28a75-3a79-4df9-b17f-8e5609a093e8": [],
           "3408250d-6b3c-4e4e-8f13-a8df1da4a6a6": [],
-          "441bd4ee-a623-4b54-aeae-4ad391715d7d": [
-              "settings.attributes.title",
-              "settings.attributes.alt",
-              "settings.styles.xl.pictureImagesArray.0.image"
-          ],
           "f5f0c1fe-fa93-470c-b205-63dec9af5b6c": [],
           "b59bea3a-b8f6-4e86-bf7c-390ac4197f11": [
               "settings.linkText",
@@ -2494,7 +2354,8 @@ json_values: |
           "187cbc97-6451-45e1-9b02-5dab75e4c41f": [
               "settings.linkText",
               "settings.linkToPage"
-          ]
+          ],
+          "a505516d-fa2b-4856-a31d-c6f35378ef66": []
       },
       "meta": {
           "fieldHistory": []

--- a/modules/acquia_cms_person/config/pack_acquia_cms_person/cohesion_templates.cohesion_content_templates.node_person_full.yml
+++ b/modules/acquia_cms_person/config/pack_acquia_cms_person/cohesion_templates.cohesion_content_templates.node_person_full.yml
@@ -3,8 +3,10 @@ langcode: en
 status: true
 dependencies:
   config:
+    - cohesion_custom_styles.cohesion_custom_style.6f04ac8e
+    - cohesion_custom_styles.cohesion_custom_style.7ef725fd
+    - cohesion_elements.cohesion_component.cpt_breadcrumbs
     - cohesion_templates.cohesion_master_templates.master_template
-    - image.style.coh_small_square
 label: 'Full content (Node, Person)'
 id: node_person_full
 json_values: |
@@ -205,23 +207,19 @@ json_values: |
                               "uid": "column",
                               "title": "Column",
                               "status": {
-                                  "collapsed": true,
-                                  "collapsedParents": []
+                                  "collapsed": false
                               },
                               "uuid": "4ae6c3dd-246a-4bce-8fcb-e82d2e5eeb61",
                               "parentUid": "row-for-columns",
                               "children": [
                                   {
-                                      "type": "item",
-                                      "uid": "image",
-                                      "title": "Image",
+                                      "type": "container",
+                                      "uid": "drupal-field",
+                                      "title": "Field",
                                       "status": {
-                                          "collapsed": true,
-                                          "collapsedParents": [
-                                              "4ae6c3dd-246a-4bce-8fcb-e82d2e5eeb61"
-                                          ]
+                                          "collapsed": true
                                       },
-                                      "uuid": "6d48bbc8-c0aa-4a6c-8fe7-d515b00bc832",
+                                      "uuid": "acdb39b4-50c1-43ae-897c-99ecfc4b1612",
                                       "parentUid": "column",
                                       "children": []
                                   }
@@ -590,78 +588,6 @@ json_values: |
                   ],
                   "items": [],
                   "form": null
-              }
-          },
-          "6d48bbc8-c0aa-4a6c-8fe7-d515b00bc832": {
-              "settings": {
-                  "formDefinition": [
-                      {
-                          "formKey": "image-settings",
-                          "children": [
-                              {
-                                  "formKey": "image-image",
-                                  "breakpoints": [],
-                                  "activeFields": [
-                                      {
-                                          "name": "image",
-                                          "active": true
-                                      },
-                                      {
-                                          "name": "title",
-                                          "active": true
-                                      },
-                                      {
-                                          "name": "alt",
-                                          "active": true
-                                      },
-                                      {
-                                          "name": "lazyload",
-                                          "active": true
-                                      }
-                                  ]
-                              },
-                              {
-                                  "formKey": "image-size",
-                                  "breakpoints": [
-                                      {
-                                          "name": "xl"
-                                      }
-                                  ],
-                                  "activeFields": [
-                                      {
-                                          "name": "displaySize",
-                                          "active": true
-                                      },
-                                      {
-                                          "name": "imageAlignment",
-                                          "active": true
-                                      }
-                                  ]
-                              },
-                              {
-                                  "formKey": "image-style",
-                                  "breakpoints": [],
-                                  "activeFields": [
-                                      {
-                                          "name": "imageStyle",
-                                          "active": true
-                                      },
-                                      {
-                                          "name": "customStyle",
-                                          "active": true
-                                      },
-                                      {
-                                          "name": "customStyle",
-                                          "active": true
-                                      }
-                                  ]
-                              }
-                          ]
-                      }
-                  ],
-                  "selectorType": "topLevel",
-                  "form": null,
-                  "items": []
               }
           },
           "0ea417c8-5be1-4737-a1d6-1a0ee96b2de3": {
@@ -1967,7 +1893,8 @@ json_values: |
                   "items": [],
                   "form": null
               }
-          }
+          },
+          "acdb39b4-50c1-43ae-897c-99ecfc4b1612": {}
       },
       "model": {
           "b664a5da-abd4-4196-a9dc-6d6a1e6ad646": {
@@ -2537,40 +2464,13 @@ json_values: |
                   }
               }
           },
-          "6d48bbc8-c0aa-4a6c-8fe7-d515b00bc832": {
+          "acdb39b4-50c1-43ae-897c-99ecfc4b1612": {
               "settings": {
-                  "title": "Image",
-                  "styles": {
-                      "xl": {
-                          "displaySize": "coh-image-responsive",
-                          "imageAlignment": "coh-image-align-left"
-                      }
-                  },
-                  "customStyle": [
-                      {
-                          "customStyle": ""
-                      }
-                  ],
-                  "lazyload": false,
+                  "title": "Field",
                   "settings": {
-                      "lazyload": false,
-                      "styles": {
-                          "xl": {
-                              "displaySize": "coh-image-responsive"
-                          }
-                      },
-                      "imageStyle": "",
-                      "customStyle": [
-                          {
-                              "customStyle": ""
-                          }
-                      ]
+                      "drupalField": ""
                   },
-                  "imageStyle": "coh_small_square",
-                  "image": "[node:field_person_image:entity:image:entity:path]",
-                  "attributes": {
-                      "alt": "[node:field_person_image:entity:image:alt]"
-                  }
+                  "drupalField": "content.field_person_image"
               },
               "context-visibility": {
                   "contextVisibility": {
@@ -2579,7 +2479,7 @@ json_values: |
               },
               "styles": {
                   "settings": {
-                      "element": "img"
+                      "element": "drupal-field"
                   }
               }
           }
@@ -2588,11 +2488,6 @@ json_values: |
           "da550fdf-2f55-4c2e-98d4-eaeeffccde1c": {},
           "0ea417c8-5be1-4737-a1d6-1a0ee96b2de3": {},
           "4ae6c3dd-246a-4bce-8fcb-e82d2e5eeb61": {},
-          "6d48bbc8-c0aa-4a6c-8fe7-d515b00bc832": {
-              "settings": {
-                  "image": ""
-              }
-          },
           "11794a9e-e1af-4a7a-bf32-29daa11e5d6f": {
               "settings": {
                   "content": "James Anderson"
@@ -2626,16 +2521,13 @@ json_values: |
           },
           "e99802f2-6ab7-40e7-b1b6-a08daf4a3d7a": {},
           "4ae17301-41bd-4118-bdf6-e47b5fb3d333": {},
-          "b664a5da-abd4-4196-a9dc-6d6a1e6ad646": {}
+          "b664a5da-abd4-4196-a9dc-6d6a1e6ad646": {},
+          "acdb39b4-50c1-43ae-897c-99ecfc4b1612": {}
       },
       "variableFields": {
           "da550fdf-2f55-4c2e-98d4-eaeeffccde1c": [],
           "0ea417c8-5be1-4737-a1d6-1a0ee96b2de3": [],
           "4ae6c3dd-246a-4bce-8fcb-e82d2e5eeb61": [],
-          "6d48bbc8-c0aa-4a6c-8fe7-d515b00bc832": [
-              "settings.image",
-              "settings.attributes.alt"
-          ],
           "11794a9e-e1af-4a7a-bf32-29daa11e5d6f": [
               "settings.content"
           ],
@@ -2666,7 +2558,8 @@ json_values: |
           ],
           "e99802f2-6ab7-40e7-b1b6-a08daf4a3d7a": [],
           "4ae17301-41bd-4118-bdf6-e47b5fb3d333": [],
-          "b664a5da-abd4-4196-a9dc-6d6a1e6ad646": []
+          "b664a5da-abd4-4196-a9dc-6d6a1e6ad646": [],
+          "acdb39b4-50c1-43ae-897c-99ecfc4b1612": []
       },
       "meta": {
           "fieldHistory": []

--- a/modules/acquia_cms_person/config/pack_acquia_cms_person/cohesion_templates.cohesion_content_templates.node_person_horizontal_card.yml
+++ b/modules/acquia_cms_person/config/pack_acquia_cms_person/cohesion_templates.cohesion_content_templates.node_person_horizontal_card.yml
@@ -1,7 +1,10 @@
 uuid: 3a8d98d7-1e2f-40ce-8393-e45f81530e0e
 langcode: en
 status: true
-dependencies: {  }
+dependencies:
+  config:
+    - cohesion_custom_styles.cohesion_custom_style.097f31b2
+    - cohesion_custom_styles.cohesion_custom_style.5f5e8fba
 label: 'Horizontal card (Node, Person)'
 id: node_person_horizontal_card
 json_values: |
@@ -77,22 +80,19 @@ json_values: |
                       "uid": "container",
                       "title": "Container",
                       "status": {
-                          "collapsed": true
+                          "collapsed": false
                       },
                       "uuid": "28a44604-339e-42b1-8f2d-ca3acb516675",
                       "parentUid": "container",
                       "children": [
                           {
-                              "type": "item",
-                              "uid": "image",
-                              "title": "Image",
+                              "type": "container",
+                              "uid": "drupal-field",
+                              "title": "Field",
                               "status": {
-                                  "collapsed": true,
-                                  "collapsedParents": [
-                                      "28a44604-339e-42b1-8f2d-ca3acb516675"
-                                  ]
+                                  "collapsed": true
                               },
-                              "uuid": "c81ef16a-cf06-4d86-9fdc-bc50098d702d",
+                              "uuid": "60fd2514-a44d-4a4e-b45b-417c982a5f58",
                               "parentUid": "container",
                               "children": []
                           }
@@ -552,6 +552,55 @@ json_values: |
                                           "active": false
                                       }
                                   ]
+                              },
+                              {
+                                  "formKey": "height",
+                                  "breakpoints": [
+                                      {
+                                          "name": "xl"
+                                      }
+                                  ],
+                                  "activeFields": [
+                                      {
+                                          "name": "min-height",
+                                          "active": false
+                                      },
+                                      {
+                                          "name": "max-height",
+                                          "active": false
+                                      },
+                                      {
+                                          "name": "height",
+                                          "active": true
+                                      }
+                                  ]
+                              }
+                          ]
+                      },
+                      {
+                          "formKey": "custom-css",
+                          "children": [
+                              {
+                                  "formKey": "css-property-and-css-value",
+                                  "breakpoints": [
+                                      {
+                                          "name": "xl"
+                                      }
+                                  ],
+                                  "activeFields": [
+                                      {
+                                          "name": "custom-css",
+                                          "active": true
+                                      },
+                                      {
+                                          "name": "customCssProperty",
+                                          "active": true
+                                      },
+                                      {
+                                          "name": "customCss",
+                                          "active": true
+                                      }
+                                  ]
                               }
                           ]
                       }
@@ -583,78 +632,6 @@ json_values: |
                       }
                   ],
                   "title": "Hide if no data",
-                  "selectorType": "topLevel",
-                  "form": null,
-                  "items": []
-              }
-          },
-          "c81ef16a-cf06-4d86-9fdc-bc50098d702d": {
-              "settings": {
-                  "formDefinition": [
-                      {
-                          "formKey": "image-settings",
-                          "children": [
-                              {
-                                  "formKey": "image-image",
-                                  "breakpoints": [],
-                                  "activeFields": [
-                                      {
-                                          "name": "image",
-                                          "active": true
-                                      },
-                                      {
-                                          "name": "title",
-                                          "active": true
-                                      },
-                                      {
-                                          "name": "alt",
-                                          "active": true
-                                      },
-                                      {
-                                          "name": "lazyload",
-                                          "active": true
-                                      }
-                                  ]
-                              },
-                              {
-                                  "formKey": "image-size",
-                                  "breakpoints": [
-                                      {
-                                          "name": "xl"
-                                      }
-                                  ],
-                                  "activeFields": [
-                                      {
-                                          "name": "displaySize",
-                                          "active": true
-                                      },
-                                      {
-                                          "name": "imageAlignment",
-                                          "active": true
-                                      }
-                                  ]
-                              },
-                              {
-                                  "formKey": "image-style",
-                                  "breakpoints": [],
-                                  "activeFields": [
-                                      {
-                                          "name": "imageStyle",
-                                          "active": true
-                                      },
-                                      {
-                                          "name": "customStyle",
-                                          "active": true
-                                      },
-                                      {
-                                          "name": "customStyle",
-                                          "active": true
-                                      }
-                                  ]
-                              }
-                          ]
-                      }
-                  ],
                   "selectorType": "topLevel",
                   "form": null,
                   "items": []
@@ -1379,7 +1356,8 @@ json_values: |
                   ],
                   "form": null
               }
-          }
+          },
+          "60fd2514-a44d-4a4e-b45b-417c982a5f58": {}
       },
       "model": {
           "741731aa-337e-422b-a4c0-4e3959a2ef7e": {
@@ -1650,6 +1628,19 @@ json_values: |
                           },
                           "max-width": {
                               "value": "144"
+                          },
+                          "custom-css": [
+                              {
+                                  "customCssProperty": {
+                                      "value": "object-fit"
+                                  },
+                                  "customCss": {
+                                      "value": "cover"
+                                  }
+                              }
+                          ],
+                          "height": {
+                              "value": "100%"
                           }
                       }
                   }
@@ -1659,41 +1650,13 @@ json_values: |
                   "hideData": "[node:field_person_image]"
               }
           },
-          "c81ef16a-cf06-4d86-9fdc-bc50098d702d": {
+          "60fd2514-a44d-4a4e-b45b-417c982a5f58": {
               "settings": {
-                  "title": "Image",
-                  "styles": {
-                      "xl": {
-                          "displaySize": "coh-image-responsive",
-                          "imageAlignment": "coh-image-align-left"
-                      }
-                  },
-                  "customStyle": [
-                      {
-                          "customStyle": ""
-                      }
-                  ],
-                  "lazyload": false,
+                  "title": "Field",
                   "settings": {
-                      "lazyload": false,
-                      "styles": {
-                          "xl": {
-                              "displaySize": "coh-image-responsive"
-                          }
-                      },
-                      "imageStyle": "",
-                      "customStyle": [
-                          {
-                              "customStyle": ""
-                          }
-                      ]
+                      "drupalField": ""
                   },
-                  "imageStyle": "x_small_square_320x320_",
-                  "image": "[node:field_person_image:entity:image:entity:path]",
-                  "attributes": {
-                      "title": "[node:field_person_image:entity:name]",
-                      "alt": "[node:field_person_image:entity:image:alt]"
-                  }
+                  "drupalField": "content.field_person_image"
               },
               "context-visibility": {
                   "contextVisibility": {
@@ -1702,7 +1665,7 @@ json_values: |
               },
               "styles": {
                   "settings": {
-                      "element": "img"
+                      "element": "drupal-field"
                   }
               }
           }
@@ -1711,11 +1674,6 @@ json_values: |
           "ab91ab40-fbb2-4a34-8cf3-ab70bd11573f": {},
           "28a44604-339e-42b1-8f2d-ca3acb516675": {},
           "741731aa-337e-422b-a4c0-4e3959a2ef7e": {},
-          "c81ef16a-cf06-4d86-9fdc-bc50098d702d": {
-              "settings": {
-                  "image": ""
-              }
-          },
           "09b805a2-c49e-46bf-adc8-ae2f2172c05e": {},
           "2400cbd9-d14d-4ec2-b6a3-eed8cb0e2429": {
               "settings": {
@@ -1726,17 +1684,13 @@ json_values: |
               "settings": {
                   "content": "Job title"
               }
-          }
+          },
+          "60fd2514-a44d-4a4e-b45b-417c982a5f58": {}
       },
       "variableFields": {
           "ab91ab40-fbb2-4a34-8cf3-ab70bd11573f": [],
           "28a44604-339e-42b1-8f2d-ca3acb516675": [],
           "741731aa-337e-422b-a4c0-4e3959a2ef7e": [],
-          "c81ef16a-cf06-4d86-9fdc-bc50098d702d": [
-              "settings.attributes.title",
-              "settings.attributes.alt",
-              "settings.image"
-          ],
           "09b805a2-c49e-46bf-adc8-ae2f2172c05e": [],
           "2400cbd9-d14d-4ec2-b6a3-eed8cb0e2429": [
               "settings.linkText",
@@ -1744,7 +1698,8 @@ json_values: |
           ],
           "8d02eee6-c6b8-46e8-aada-878817f57b3c": [
               "settings.content"
-          ]
+          ],
+          "60fd2514-a44d-4a4e-b45b-417c982a5f58": []
       },
       "meta": {
           "fieldHistory": []

--- a/modules/acquia_cms_person/config/pack_acquia_cms_person/cohesion_templates.cohesion_content_templates.node_person_referenced_image.yml
+++ b/modules/acquia_cms_person/config/pack_acquia_cms_person/cohesion_templates.cohesion_content_templates.node_person_referenced_image.yml
@@ -1,0 +1,66 @@
+uuid: b779c5f4-9238-4934-ba88-5e8b90a56d09
+langcode: en
+status: true
+dependencies: {  }
+label: 'Referenced Image (Node, Person)'
+id: node_person_referenced_image
+json_values: |
+  {
+      "canvas": [
+          {
+              "type": "container",
+              "uid": "drupal-field",
+              "title": "Field",
+              "status": {
+                  "collapsed": true
+              },
+              "uuid": "053bbbf3-4f7e-43b2-a82d-0f45bc4589e6",
+              "parentUid": "root",
+              "children": []
+          }
+      ],
+      "mapper": {
+          "053bbbf3-4f7e-43b2-a82d-0f45bc4589e6": {}
+      },
+      "model": {
+          "053bbbf3-4f7e-43b2-a82d-0f45bc4589e6": {
+              "settings": {
+                  "title": "Field",
+                  "settings": {
+                      "drupalField": ""
+                  },
+                  "drupalField": "content.field_person_image"
+              },
+              "context-visibility": {
+                  "contextVisibility": {
+                      "condition": "ALL"
+                  }
+              },
+              "styles": {
+                  "settings": {
+                      "element": "drupal-field"
+                  }
+              }
+          }
+      },
+      "previewModel": {
+          "053bbbf3-4f7e-43b2-a82d-0f45bc4589e6": {}
+      },
+      "variableFields": {
+          "053bbbf3-4f7e-43b2-a82d-0f45bc4589e6": []
+      },
+      "meta": {
+          "fieldHistory": []
+      }
+  }
+json_mapper: '{}'
+last_entity_update: entityupdate_0036
+modified: true
+selectable: false
+custom: false
+twig_template: node--cohesion--node-person-referenced-image
+default: true
+entity_type: node
+bundle: person
+view_mode: referenced_image
+master_template: ''

--- a/modules/acquia_cms_person/config/pack_acquia_cms_person/cohesion_templates.cohesion_content_templates.node_person_search_results.yml
+++ b/modules/acquia_cms_person/config/pack_acquia_cms_person/cohesion_templates.cohesion_content_templates.node_person_search_results.yml
@@ -1,7 +1,11 @@
 uuid: f28e2642-488c-4531-ad2d-73691018d460
 langcode: en
 status: true
-dependencies: {  }
+dependencies:
+  config:
+    - cohesion_custom_styles.cohesion_custom_style.65dc3072
+    - cohesion_custom_styles.cohesion_custom_style.bfd0fecd
+    - cohesion_custom_styles.cohesion_custom_style.f3dc1bea
 label: 'Search Results (Node, Person)'
 id: node_person_search_results
 json_values: |
@@ -121,24 +125,19 @@ json_values: |
                       "uid": "column",
                       "title": "Column",
                       "status": {
-                          "collapsed": true
+                          "collapsed": false
                       },
                       "uuid": "30a4aeeb-ae53-44a0-92a1-b8a5bea8e208",
                       "parentUid": "row-for-columns",
                       "children": [
                           {
-                              "type": "item",
-                              "uid": "picture",
-                              "title": "Picture",
-                              "selected": false,
+                              "type": "container",
+                              "uid": "drupal-field",
+                              "title": "Field",
                               "status": {
-                                  "collapsed": true,
-                                  "isopen": false,
-                                  "collapsedParents": [
-                                      "30a4aeeb-ae53-44a0-92a1-b8a5bea8e208"
-                                  ]
+                                  "collapsed": true
                               },
-                              "uuid": "753e4bc1-479b-4961-91d1-854f9bc8d8a3",
+                              "uuid": "c38625d8-0b3b-442d-9dfa-3c114b3ec917",
                               "parentUid": "column",
                               "children": []
                           }
@@ -500,82 +499,6 @@ json_values: |
                       }
                   ],
                   "title": "Hide if no data",
-                  "selectorType": "topLevel",
-                  "form": null,
-                  "items": []
-              }
-          },
-          "753e4bc1-479b-4961-91d1-854f9bc8d8a3": {
-              "settings": {
-                  "formDefinition": [
-                      {
-                          "formKey": "picture-settings",
-                          "children": [
-                              {
-                                  "formKey": "picture-info",
-                                  "breakpoints": [],
-                                  "activeFields": [
-                                      {
-                                          "name": "title",
-                                          "active": true
-                                      },
-                                      {
-                                          "name": "alt",
-                                          "active": true
-                                      },
-                                      {
-                                          "name": "lazyload",
-                                          "active": true
-                                      }
-                                  ]
-                              },
-                              {
-                                  "formKey": "picture-images",
-                                  "breakpoints": [
-                                      {
-                                          "name": "xl"
-                                      }
-                                  ],
-                                  "activeFields": [
-                                      {
-                                          "name": "displaySize",
-                                          "active": true
-                                      },
-                                      {
-                                          "name": "imageAlignment",
-                                          "active": true
-                                      },
-                                      {
-                                          "name": "pictureImagesArray",
-                                          "active": true
-                                      },
-                                      {
-                                          "name": "image",
-                                          "active": true
-                                      },
-                                      {
-                                          "name": "imageStyle",
-                                          "active": true
-                                      }
-                                  ]
-                              },
-                              {
-                                  "formKey": "picture-style",
-                                  "breakpoints": [],
-                                  "activeFields": [
-                                      {
-                                          "name": "customStyle",
-                                          "active": true
-                                      },
-                                      {
-                                          "name": "customStyle",
-                                          "active": true
-                                      }
-                                  ]
-                              }
-                          ]
-                      }
-                  ],
                   "selectorType": "topLevel",
                   "form": null,
                   "items": []
@@ -1990,7 +1913,8 @@ json_values: |
                   "form": null,
                   "items": []
               }
-          }
+          },
+          "c38625d8-0b3b-442d-9dfa-3c114b3ec917": {}
       },
       "model": {
           "9cbe10e0-5524-44e7-b4ed-905f3e9e0c55": {
@@ -2462,48 +2386,13 @@ json_values: |
                   "hideData": "[node:field_person_image]"
               }
           },
-          "753e4bc1-479b-4961-91d1-854f9bc8d8a3": {
+          "c38625d8-0b3b-442d-9dfa-3c114b3ec917": {
               "settings": {
-                  "title": "Picture",
-                  "customStyle": [
-                      {
-                          "customStyle": ""
-                      }
-                  ],
-                  "styles": {
-                      "xl": {
-                          "pictureImagesArray": [
-                              {
-                                  "imageStyle": "x_small_square_320x320_",
-                                  "image": "[node:field_person_image:entity:image:entity:path]"
-                              }
-                          ],
-                          "displaySize": "coh-image-responsive"
-                      }
-                  },
-                  "lazyload": false,
+                  "title": "Field",
                   "settings": {
-                      "lazyload": false,
-                      "styles": {
-                          "xl": {
-                              "displaySize": "coh-image-responsive",
-                              "pictureImagesArray": [
-                                  {
-                                      "imageStyle": ""
-                                  }
-                              ]
-                          }
-                      },
-                      "customStyle": [
-                          {
-                              "customStyle": ""
-                          }
-                      ]
+                      "drupalField": ""
                   },
-                  "attributes": {
-                      "title": "[node:field_person_image:entity:name]",
-                      "alt": "[node:field_person_image:entity:image:alt]"
-                  }
+                  "drupalField": "content.field_person_image"
               },
               "context-visibility": {
                   "contextVisibility": {
@@ -2512,7 +2401,7 @@ json_values: |
               },
               "styles": {
                   "settings": {
-                      "element": "picture"
+                      "element": "drupal-field"
                   }
               }
           }
@@ -2520,19 +2409,6 @@ json_values: |
       "previewModel": {
           "f9808a44-aa90-46ba-a48d-bfe8d6d15008": {},
           "30a4aeeb-ae53-44a0-92a1-b8a5bea8e208": {},
-          "753e4bc1-479b-4961-91d1-854f9bc8d8a3": {
-              "settings": {
-                  "styles": {
-                      "xl": {
-                          "pictureImagesArray": [
-                              {
-                                  "image": ""
-                              }
-                          ]
-                      }
-                  }
-              }
-          },
           "9aad25bd-e531-4c1b-8721-45035bc03cc9": {},
           "1de6b1d4-f4c7-4c1f-b4b8-81954c1a8e58": {
               "settings": {
@@ -2554,16 +2430,12 @@ json_values: |
               }
           },
           "4a551ca2-47e9-4fb7-a0e5-1fa90ac3a357": [],
-          "9cbe10e0-5524-44e7-b4ed-905f3e9e0c55": {}
+          "9cbe10e0-5524-44e7-b4ed-905f3e9e0c55": {},
+          "c38625d8-0b3b-442d-9dfa-3c114b3ec917": {}
       },
       "variableFields": {
           "f9808a44-aa90-46ba-a48d-bfe8d6d15008": [],
           "30a4aeeb-ae53-44a0-92a1-b8a5bea8e208": [],
-          "753e4bc1-479b-4961-91d1-854f9bc8d8a3": [
-              "settings.styles.xl.pictureImagesArray.0.image",
-              "settings.attributes.title",
-              "settings.attributes.alt"
-          ],
           "9aad25bd-e531-4c1b-8721-45035bc03cc9": [],
           "1de6b1d4-f4c7-4c1f-b4b8-81954c1a8e58": [
               "settings.linkText",
@@ -2581,7 +2453,8 @@ json_values: |
               "settings.content"
           ],
           "4a551ca2-47e9-4fb7-a0e5-1fa90ac3a357": [],
-          "9cbe10e0-5524-44e7-b4ed-905f3e9e0c55": []
+          "9cbe10e0-5524-44e7-b4ed-905f3e9e0c55": [],
+          "c38625d8-0b3b-442d-9dfa-3c114b3ec917": []
       },
       "meta": {
           "fieldHistory": []

--- a/modules/acquia_cms_person/config/pack_acquia_cms_person/cohesion_templates.cohesion_content_templates.node_person_teaser.yml
+++ b/modules/acquia_cms_person/config/pack_acquia_cms_person/cohesion_templates.cohesion_content_templates.node_person_teaser.yml
@@ -1,7 +1,11 @@
 uuid: 066508b1-d013-4f06-9a54-fee1a1940f3f
 langcode: en
 status: true
-dependencies: {  }
+dependencies:
+  config:
+    - cohesion_custom_styles.cohesion_custom_style.65dc3072
+    - cohesion_custom_styles.cohesion_custom_style.bfd0fecd
+    - cohesion_custom_styles.cohesion_custom_style.f3dc1bea
 label: 'Teaser (Node, Person)'
 id: node_person_teaser
 json_values: |
@@ -135,24 +139,19 @@ json_values: |
                       "uid": "column",
                       "title": "Column",
                       "status": {
-                          "collapsed": true
+                          "collapsed": false
                       },
                       "uuid": "f5f270f6-bfdf-45e1-b05f-a2127db810a1",
                       "parentUid": "row-for-columns",
                       "children": [
                           {
-                              "type": "item",
-                              "uid": "picture",
-                              "title": "Picture",
-                              "selected": false,
+                              "type": "container",
+                              "uid": "drupal-field",
+                              "title": "Field",
                               "status": {
-                                  "collapsed": true,
-                                  "isopen": false,
-                                  "collapsedParents": [
-                                      "f5f270f6-bfdf-45e1-b05f-a2127db810a1"
-                                  ]
+                                  "collapsed": true
                               },
-                              "uuid": "031699ef-01bf-403f-92a1-1df1bf15bb15",
+                              "uuid": "ef850c3b-b4d2-4839-89c0-0625c31e09b6",
                               "parentUid": "column",
                               "children": []
                           }
@@ -514,82 +513,6 @@ json_values: |
                       }
                   ],
                   "title": "Hide if no data",
-                  "selectorType": "topLevel",
-                  "form": null,
-                  "items": []
-              }
-          },
-          "031699ef-01bf-403f-92a1-1df1bf15bb15": {
-              "settings": {
-                  "formDefinition": [
-                      {
-                          "formKey": "picture-settings",
-                          "children": [
-                              {
-                                  "formKey": "picture-info",
-                                  "breakpoints": [],
-                                  "activeFields": [
-                                      {
-                                          "name": "title",
-                                          "active": true
-                                      },
-                                      {
-                                          "name": "alt",
-                                          "active": true
-                                      },
-                                      {
-                                          "name": "lazyload",
-                                          "active": true
-                                      }
-                                  ]
-                              },
-                              {
-                                  "formKey": "picture-images",
-                                  "breakpoints": [
-                                      {
-                                          "name": "xl"
-                                      }
-                                  ],
-                                  "activeFields": [
-                                      {
-                                          "name": "displaySize",
-                                          "active": true
-                                      },
-                                      {
-                                          "name": "imageAlignment",
-                                          "active": true
-                                      },
-                                      {
-                                          "name": "pictureImagesArray",
-                                          "active": true
-                                      },
-                                      {
-                                          "name": "image",
-                                          "active": true
-                                      },
-                                      {
-                                          "name": "imageStyle",
-                                          "active": true
-                                      }
-                                  ]
-                              },
-                              {
-                                  "formKey": "picture-style",
-                                  "breakpoints": [],
-                                  "activeFields": [
-                                      {
-                                          "name": "customStyle",
-                                          "active": true
-                                      },
-                                      {
-                                          "name": "customStyle",
-                                          "active": true
-                                      }
-                                  ]
-                              }
-                          ]
-                      }
-                  ],
                   "selectorType": "topLevel",
                   "form": null,
                   "items": []
@@ -1977,7 +1900,8 @@ json_values: |
                   "form": null,
                   "items": []
               }
-          }
+          },
+          "ef850c3b-b4d2-4839-89c0-0625c31e09b6": {}
       },
       "model": {
           "3b9972f5-f259-4fcf-874b-981f7c84538e": {
@@ -2444,48 +2368,13 @@ json_values: |
                   "hideData": "[node:field_person_image]"
               }
           },
-          "031699ef-01bf-403f-92a1-1df1bf15bb15": {
+          "ef850c3b-b4d2-4839-89c0-0625c31e09b6": {
               "settings": {
-                  "title": "Picture",
-                  "customStyle": [
-                      {
-                          "customStyle": ""
-                      }
-                  ],
-                  "styles": {
-                      "xl": {
-                          "pictureImagesArray": [
-                              {
-                                  "imageStyle": "x_small_square_320x320_",
-                                  "image": "[node:field_person_image:entity:image:entity:path]"
-                              }
-                          ],
-                          "displaySize": "coh-image-responsive"
-                      }
-                  },
-                  "lazyload": false,
+                  "title": "Field",
                   "settings": {
-                      "lazyload": false,
-                      "styles": {
-                          "xl": {
-                              "displaySize": "coh-image-responsive",
-                              "pictureImagesArray": [
-                                  {
-                                      "imageStyle": ""
-                                  }
-                              ]
-                          }
-                      },
-                      "customStyle": [
-                          {
-                              "customStyle": ""
-                          }
-                      ]
+                      "drupalField": ""
                   },
-                  "attributes": {
-                      "title": "[node:field_person_image:entity:name]",
-                      "alt": "[node:field_person_image:entity:image:alt]"
-                  }
+                  "drupalField": "content.field_person_image"
               },
               "context-visibility": {
                   "contextVisibility": {
@@ -2494,7 +2383,7 @@ json_values: |
               },
               "styles": {
                   "settings": {
-                      "element": "picture"
+                      "element": "drupal-field"
                   }
               }
           }
@@ -2502,19 +2391,6 @@ json_values: |
       "previewModel": {
           "2e096c61-81a1-4b70-a74a-6f138795312d": {},
           "f5f270f6-bfdf-45e1-b05f-a2127db810a1": {},
-          "031699ef-01bf-403f-92a1-1df1bf15bb15": {
-              "settings": {
-                  "styles": {
-                      "xl": {
-                          "pictureImagesArray": [
-                              {
-                                  "image": ""
-                              }
-                          ]
-                      }
-                  }
-              }
-          },
           "71ff273f-643b-4652-b514-456ead767844": {},
           "94d7355b-a269-4575-bafb-3a2abadb9c04": {
               "settings": {
@@ -2536,16 +2412,12 @@ json_values: |
               }
           },
           "31e0e96d-d2c4-4418-b784-722eddcf53cb": {},
-          "3b9972f5-f259-4fcf-874b-981f7c84538e": {}
+          "3b9972f5-f259-4fcf-874b-981f7c84538e": {},
+          "ef850c3b-b4d2-4839-89c0-0625c31e09b6": {}
       },
       "variableFields": {
           "2e096c61-81a1-4b70-a74a-6f138795312d": [],
           "f5f270f6-bfdf-45e1-b05f-a2127db810a1": [],
-          "031699ef-01bf-403f-92a1-1df1bf15bb15": [
-              "settings.attributes.title",
-              "settings.attributes.alt",
-              "settings.styles.xl.pictureImagesArray.0.image"
-          ],
           "71ff273f-643b-4652-b514-456ead767844": [],
           "94d7355b-a269-4575-bafb-3a2abadb9c04": [
               "settings.linkText",
@@ -2561,7 +2433,8 @@ json_values: |
               "settings.linkToPage"
           ],
           "31e0e96d-d2c4-4418-b784-722eddcf53cb": [],
-          "3b9972f5-f259-4fcf-874b-981f7c84538e": []
+          "3b9972f5-f259-4fcf-874b-981f7c84538e": [],
+          "ef850c3b-b4d2-4839-89c0-0625c31e09b6": []
       },
       "meta": {
           "fieldHistory": []

--- a/modules/acquia_cms_place/acquia_cms_place.install
+++ b/modules/acquia_cms_place/acquia_cms_place.install
@@ -88,29 +88,33 @@ function acquia_cms_place_update_8002() {
     'teaser',
   ];
   $view_modes = [
-    'full',
-    'card',
     'large_super_landscape',
-    'small',
+    'small_landscape',
+    'small_landscape',
+    'teaser',
     'teaser',
   ];
+  // Update Image field.
   foreach ($display_modes as $key => $display_mode) {
-    $place_default = \Drupal::configFactory()->getEditable('core.entity_view_display.node.place.' . $display_mode);
-    if ($place_default->get('hidden.field_place_image')) {
+    $place_view_mode = \Drupal::configFactory()->getEditable('core.entity_view_display.node.place.' . $display_mode);
+    if ($place_view_mode->get('hidden.field_place_image')) {
       $place_image_field['field_place_image']['settings']['view_mode'] = $view_modes[$key];
-      $place_default->set('content', array_merge($place_default->get('content'), $place_image_field));
-      if ($place_default->get('content.body')) {
-        $place_default->set('content.body.weight', $place_default->get('content.body.weight') + 1);
+      $place_view_mode->set('content', array_merge($place_view_mode->get('content'), $place_image_field));
+      if ($place_view_mode->get('content.body')) {
+        $place_view_mode->set('content.body.weight', $place_view_mode->get('content.body.weight') + 1);
       }
-      if ($place_default->get('content.field_place_address')) {
-        $place_default->set('content.field_place_address.weight', $place_default->get('content.field_place_address.weight') + 1);
+      if ($place_view_mode->get('content.field_place_address')) {
+        $place_view_mode->set('content.field_place_address.weight', $place_view_mode->get('content.field_place_address.weight') + 1);
       }
-      if ($place_default->get('content.field_place_telephone')) {
-        $place_default->set('content.field_place_telephone.weight', $place_default->get('content.field_place_telephone.weight') + 1);
+      if ($place_view_mode->get('content.field_place_telephone')) {
+        $place_view_mode->set('content.field_place_telephone.weight', $place_view_mode->get('content.field_place_telephone.weight') + 1);
       }
-      $place_default->clear('hidden.field_place_image');
-      $place_default->save();
+      $place_view_mode->clear('hidden.field_place_image');
+      $place_view_mode->save();
     }
   }
+
+  // Add referenced image view mode.
+  _acquia_cms_common_rewrite_configuration('core.entity_view_display.node.place.referenced_image', 'acquia_cms_place');
 
 }

--- a/modules/acquia_cms_place/acquia_cms_place.install
+++ b/modules/acquia_cms_place/acquia_cms_place.install
@@ -59,3 +59,58 @@ function acquia_cms_place_update_8001() {
     }
   }
 }
+
+/**
+ * Implements hook_update_N().
+ *
+ * Update Place display modes.
+ */
+function acquia_cms_place_update_8002() {
+  // Load and update default view mode.
+  $place_image_field = [
+    'field_place_image' => [
+      'type' => 'entity_reference_entity_view',
+      'label' => 'hidden',
+      'settings' => [
+        'view_mode' => 'full',
+        'link' => 'false',
+      ],
+      'third_party_settings' => [],
+      'weight' => 0,
+      'region' => 'content',
+    ],
+  ];
+  $display_modes = [
+    'default',
+    'card',
+    'horizontal_card',
+    'search_results',
+    'teaser',
+  ];
+  $view_modes = [
+    'full',
+    'card',
+    'large_super_landscape',
+    'small',
+    'teaser',
+  ];
+  foreach ($display_modes as $key => $display_mode) {
+    $place_default = \Drupal::configFactory()->getEditable('core.entity_view_display.node.place.' . $display_mode);
+    if ($place_default->get('hidden.field_place_image')) {
+      $place_image_field['field_place_image']['settings']['view_mode'] = $view_modes[$key];
+      $place_default->set('content', array_merge($place_default->get('content'), $place_image_field));
+      if ($place_default->get('content.body')) {
+        $place_default->set('content.body.weight', $place_default->get('content.body.weight') + 1);
+      }
+      if ($place_default->get('content.field_place_address')) {
+        $place_default->set('content.field_place_address.weight', $place_default->get('content.field_place_address.weight') + 1);
+      }
+      if ($place_default->get('content.field_place_telephone')) {
+        $place_default->set('content.field_place_telephone.weight', $place_default->get('content.field_place_telephone.weight') + 1);
+      }
+      $place_default->clear('hidden.field_place_image');
+      $place_default->save();
+    }
+  }
+
+}

--- a/modules/acquia_cms_place/config/optional/core.entity_view_display.node.place.card.yml
+++ b/modules/acquia_cms_place/config/optional/core.entity_view_display.node.place.card.yml
@@ -28,6 +28,15 @@ content:
     label: above
     settings: {  }
     third_party_settings: {  }
+    weight: 1
+    region: content
+  field_place_image:
+    type: entity_reference_entity_view
+    label: hidden
+    settings:
+      view_mode: small_landscape
+      link: false
+    third_party_settings: {  }
     weight: 0
     region: content
   field_place_telephone:
@@ -38,17 +47,6 @@ content:
     third_party_settings: {  }
     weight: 2
     region: content
-  field_place_image:
-    type: entity_reference_entity_view
-    label: hidden
-    settings:
-      view_mode: card
-      link: false
-    third_party_settings: {  }
-    weight: 0
-    region: content
-  body:
-    weight: 1
 hidden:
   body: true
   content_moderation_control: true

--- a/modules/acquia_cms_place/config/optional/core.entity_view_display.node.place.card.yml
+++ b/modules/acquia_cms_place/config/optional/core.entity_view_display.node.place.card.yml
@@ -5,6 +5,7 @@ dependencies:
     - core.entity_view_mode.node.card
     - field.field.node.place.body
     - field.field.node.place.field_categories
+    - field.field.node.place.field_geofield
     - field.field.node.place.field_place_address
     - field.field.node.place.field_place_image
     - field.field.node.place.field_place_telephone
@@ -27,15 +28,6 @@ content:
     label: above
     settings: {  }
     third_party_settings: {  }
-    weight: 1
-    region: content
-  field_place_image:
-    type: entity_reference_entity_view
-    label: hidden
-    settings:
-      view_mode: card
-      link: false
-    third_party_settings: {  }
     weight: 0
     region: content
   field_place_telephone:
@@ -46,10 +38,22 @@ content:
     third_party_settings: {  }
     weight: 2
     region: content
+  field_place_image:
+    type: entity_reference_entity_view
+    label: hidden
+    settings:
+      view_mode: card
+      link: false
+    third_party_settings: {  }
+    weight: 0
+    region: content
+  body:
+    weight: 1
 hidden:
   body: true
   content_moderation_control: true
   field_categories: true
+  field_geofield: true
   field_place_type: true
   field_tags: true
   langcode: true

--- a/modules/acquia_cms_place/config/optional/core.entity_view_display.node.place.card.yml
+++ b/modules/acquia_cms_place/config/optional/core.entity_view_display.node.place.card.yml
@@ -11,12 +11,12 @@ dependencies:
     - field.field.node.place.field_place_type
     - field.field.node.place.field_tags
     - node.type.place
-  enforced:
-    module:
-      - acquia_cms_place
   module:
     - address
     - user
+  enforced:
+    module:
+      - acquia_cms_place
 id: node.place.card
 targetEntityType: node
 bundle: place
@@ -24,24 +24,32 @@ mode: card
 content:
   field_place_address:
     type: address_default
-    weight: 0
-    region: content
     label: above
     settings: {  }
     third_party_settings: {  }
-  field_place_telephone:
-    type: string
     weight: 1
     region: content
+  field_place_image:
+    type: entity_reference_entity_view
+    label: hidden
+    settings:
+      view_mode: card
+      link: false
+    third_party_settings: {  }
+    weight: 0
+    region: content
+  field_place_telephone:
+    type: string
     label: above
     settings:
       link_to_entity: false
     third_party_settings: {  }
+    weight: 2
+    region: content
 hidden:
   body: true
   content_moderation_control: true
   field_categories: true
-  field_place_image: true
   field_place_type: true
   field_tags: true
   langcode: true

--- a/modules/acquia_cms_place/config/optional/core.entity_view_display.node.place.default.yml
+++ b/modules/acquia_cms_place/config/optional/core.entity_view_display.node.place.default.yml
@@ -38,7 +38,7 @@ content:
       output_format: wkt
       output_escape: true
     third_party_settings: {  }
-    weight: 4
+    weight: 3
     region: content
   field_place_address:
     type: address_default
@@ -47,15 +47,6 @@ content:
     third_party_settings: {  }
     weight: 2
     region: content
-  field_place_image:
-    type: entity_reference_entity_view
-    label: hidden
-    settings:
-      view_mode: full
-      link: false
-    third_party_settings: {  }
-    weight: 0
-    region: content
   field_place_telephone:
     type: string
     label: above
@@ -63,6 +54,15 @@ content:
       link_to_entity: false
     third_party_settings: {  }
     weight: 3
+    region: content
+  field_place_image:
+    type: entity_reference_entity_view
+    label: hidden
+    settings:
+      view_mode: full
+      link: true
+    third_party_settings: {  }
+    weight: 0
     region: content
 hidden:
   content_moderation_control: true

--- a/modules/acquia_cms_place/config/optional/core.entity_view_display.node.place.default.yml
+++ b/modules/acquia_cms_place/config/optional/core.entity_view_display.node.place.default.yml
@@ -47,6 +47,15 @@ content:
     third_party_settings: {  }
     weight: 2
     region: content
+  field_place_image:
+    type: entity_reference_entity_view
+    label: hidden
+    settings:
+      view_mode: large_super_landscape
+      link: false
+    third_party_settings: {  }
+    weight: 0
+    region: content
   field_place_telephone:
     type: string
     label: above
@@ -54,15 +63,6 @@ content:
       link_to_entity: false
     third_party_settings: {  }
     weight: 3
-    region: content
-  field_place_image:
-    type: entity_reference_entity_view
-    label: hidden
-    settings:
-      view_mode: full
-      link: true
-    third_party_settings: {  }
-    weight: 0
     region: content
 hidden:
   content_moderation_control: true

--- a/modules/acquia_cms_place/config/optional/core.entity_view_display.node.place.default.yml
+++ b/modules/acquia_cms_place/config/optional/core.entity_view_display.node.place.default.yml
@@ -11,14 +11,14 @@ dependencies:
     - field.field.node.place.field_place_type
     - field.field.node.place.field_tags
     - node.type.place
-  enforced:
-    module:
-      - acquia_cms_place
   module:
     - address
     - geofield
     - text
     - user
+  enforced:
+    module:
+      - acquia_cms_place
 id: node.place.default
 targetEntityType: node
 bundle: place
@@ -26,39 +26,47 @@ mode: default
 content:
   body:
     type: text_default
-    weight: 0
-    region: content
     label: hidden
     settings: {  }
     third_party_settings: {  }
+    weight: 1
+    region: content
   field_geofield:
-    weight: 3
+    type: geofield_default
     label: above
     settings:
       output_format: wkt
       output_escape: true
     third_party_settings: {  }
-    type: geofield_default
+    weight: 4
     region: content
   field_place_address:
     type: address_default
-    weight: 1
-    region: content
     label: above
     settings: {  }
     third_party_settings: {  }
-  field_place_telephone:
-    type: string
     weight: 2
     region: content
+  field_place_image:
+    type: entity_reference_entity_view
+    label: hidden
+    settings:
+      view_mode: full
+      link: false
+    third_party_settings: {  }
+    weight: 0
+    region: content
+  field_place_telephone:
+    type: string
     label: above
     settings:
       link_to_entity: false
     third_party_settings: {  }
+    weight: 3
+    region: content
 hidden:
   content_moderation_control: true
   field_categories: true
-  field_place_image: true
   field_place_type: true
   field_tags: true
   langcode: true

--- a/modules/acquia_cms_place/config/optional/core.entity_view_display.node.place.horizontal_card.yml
+++ b/modules/acquia_cms_place/config/optional/core.entity_view_display.node.place.horizontal_card.yml
@@ -11,13 +11,13 @@ dependencies:
     - field.field.node.place.field_place_type
     - field.field.node.place.field_tags
     - node.type.place
-  enforced:
-    module:
-      - acquia_cms_place
   module:
     - address
     - text
     - user
+  enforced:
+    module:
+      - acquia_cms_place
 id: node.place.horizontal_card
 targetEntityType: node
 bundle: place
@@ -25,30 +25,38 @@ mode: horizontal_card
 content:
   body:
     type: text_default
-    weight: 0
-    region: content
     label: hidden
     settings: {  }
     third_party_settings: {  }
-  field_place_address:
-    type: address_default
     weight: 1
     region: content
+  field_place_address:
+    type: address_default
     label: above
     settings: {  }
     third_party_settings: {  }
-  field_place_telephone:
-    type: string
     weight: 2
     region: content
+  field_place_image:
+    type: entity_reference_entity_view
+    label: hidden
+    settings:
+      view_mode: large_super_landscape
+      link: false
+    third_party_settings: {  }
+    weight: 0
+    region: content
+  field_place_telephone:
+    type: string
     label: above
     settings:
       link_to_entity: false
     third_party_settings: {  }
+    weight: 3
+    region: content
 hidden:
   content_moderation_control: true
   field_categories: true
-  field_place_image: true
   field_place_type: true
   field_tags: true
   langcode: true

--- a/modules/acquia_cms_place/config/optional/core.entity_view_display.node.place.horizontal_card.yml
+++ b/modules/acquia_cms_place/config/optional/core.entity_view_display.node.place.horizontal_card.yml
@@ -5,6 +5,7 @@ dependencies:
     - core.entity_view_mode.node.horizontal_card
     - field.field.node.place.body
     - field.field.node.place.field_categories
+    - field.field.node.place.field_geofield
     - field.field.node.place.field_place_address
     - field.field.node.place.field_place_image
     - field.field.node.place.field_place_telephone
@@ -37,15 +38,6 @@ content:
     third_party_settings: {  }
     weight: 2
     region: content
-  field_place_image:
-    type: entity_reference_entity_view
-    label: hidden
-    settings:
-      view_mode: large_super_landscape
-      link: false
-    third_party_settings: {  }
-    weight: 0
-    region: content
   field_place_telephone:
     type: string
     label: above
@@ -54,9 +46,19 @@ content:
     third_party_settings: {  }
     weight: 3
     region: content
+  field_place_image:
+    type: entity_reference_entity_view
+    label: hidden
+    settings:
+      view_mode: large_super_landscape
+      link: true
+    third_party_settings: {  }
+    weight: 0
+    region: content
 hidden:
   content_moderation_control: true
   field_categories: true
+  field_geofield: true
   field_place_type: true
   field_tags: true
   langcode: true

--- a/modules/acquia_cms_place/config/optional/core.entity_view_display.node.place.places.yml
+++ b/modules/acquia_cms_place/config/optional/core.entity_view_display.node.place.places.yml
@@ -28,15 +28,6 @@ content:
     label: hidden
     settings: {  }
     third_party_settings: {  }
-    weight: 1
-    region: content
-  field_place_image:
-    type: entity_reference_entity_view
-    label: hidden
-    settings:
-      view_mode: full
-      link: false
-    third_party_settings: {  }
     weight: 0
     region: content
   field_place_telephone:
@@ -45,13 +36,14 @@ content:
     settings:
       link_to_entity: false
     third_party_settings: {  }
-    weight: 2
+    weight: 1
     region: content
 hidden:
   body: true
   content_moderation_control: true
   field_categories: true
   field_geofield: true
+  field_place_image: true
   field_place_type: true
   field_tags: true
   langcode: true

--- a/modules/acquia_cms_place/config/optional/core.entity_view_display.node.place.places.yml
+++ b/modules/acquia_cms_place/config/optional/core.entity_view_display.node.place.places.yml
@@ -12,12 +12,12 @@ dependencies:
     - field.field.node.place.field_place_type
     - field.field.node.place.field_tags
     - node.type.place
-  enforced:
-    module:
-      - acquia_cms_place
   module:
     - address
     - user
+  enforced:
+    module:
+      - acquia_cms_place
 id: node.place.places
 targetEntityType: node
 bundle: place
@@ -25,25 +25,33 @@ mode: places
 content:
   field_place_address:
     type: address_default
-    weight: 0
-    region: content
     label: hidden
     settings: {  }
     third_party_settings: {  }
-  field_place_telephone:
-    type: string
     weight: 1
     region: content
+  field_place_image:
+    type: entity_reference_entity_view
+    label: hidden
+    settings:
+      view_mode: full
+      link: false
+    third_party_settings: {  }
+    weight: 0
+    region: content
+  field_place_telephone:
+    type: string
     label: hidden
     settings:
       link_to_entity: false
     third_party_settings: {  }
+    weight: 2
+    region: content
 hidden:
   body: true
   content_moderation_control: true
   field_categories: true
   field_geofield: true
-  field_place_image: true
   field_place_type: true
   field_tags: true
   langcode: true

--- a/modules/acquia_cms_place/config/optional/core.entity_view_display.node.place.referenced_image.yml
+++ b/modules/acquia_cms_place/config/optional/core.entity_view_display.node.place.referenced_image.yml
@@ -2,7 +2,7 @@ langcode: en
 status: true
 dependencies:
   config:
-    - core.entity_view_mode.node.horizontal_card
+    - core.entity_view_mode.node.referenced_image
     - field.field.node.place.body
     - field.field.node.place.field_categories
     - field.field.node.place.field_geofield
@@ -13,31 +13,15 @@ dependencies:
     - field.field.node.place.field_tags
     - node.type.place
   module:
-    - address
-    - text
     - user
   enforced:
     module:
       - acquia_cms_place
-id: node.place.horizontal_card
+id: node.place.referenced_image
 targetEntityType: node
 bundle: place
-mode: horizontal_card
+mode: referenced_image
 content:
-  body:
-    type: text_default
-    label: hidden
-    settings: {  }
-    third_party_settings: {  }
-    weight: 1
-    region: content
-  field_place_address:
-    type: address_default
-    label: above
-    settings: {  }
-    third_party_settings: {  }
-    weight: 2
-    region: content
   field_place_image:
     type: entity_reference_entity_view
     label: hidden
@@ -47,18 +31,13 @@ content:
     third_party_settings: {  }
     weight: 0
     region: content
-  field_place_telephone:
-    type: string
-    label: above
-    settings:
-      link_to_entity: false
-    third_party_settings: {  }
-    weight: 3
-    region: content
 hidden:
+  body: true
   content_moderation_control: true
   field_categories: true
   field_geofield: true
+  field_place_address: true
+  field_place_telephone: true
   field_place_type: true
   field_tags: true
   langcode: true

--- a/modules/acquia_cms_place/config/optional/core.entity_view_display.node.place.search_results.yml
+++ b/modules/acquia_cms_place/config/optional/core.entity_view_display.node.place.search_results.yml
@@ -50,6 +50,14 @@ content:
     third_party_settings: {  }
     weight: 2
     region: content
+  field_place_telephone:
+    type: string
+    label: hidden
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    weight: 3
+    region: content
   field_place_image:
     type: entity_reference_entity_view
     label: hidden
@@ -58,14 +66,6 @@ content:
       link: false
     third_party_settings: {  }
     weight: 0
-    region: content
-  field_place_telephone:
-    type: string
-    label: hidden
-    settings:
-      link_to_entity: false
-    third_party_settings: {  }
-    weight: 3
     region: content
 hidden:
   content_moderation_control: true

--- a/modules/acquia_cms_place/config/optional/core.entity_view_display.node.place.search_results.yml
+++ b/modules/acquia_cms_place/config/optional/core.entity_view_display.node.place.search_results.yml
@@ -50,6 +50,15 @@ content:
     third_party_settings: {  }
     weight: 2
     region: content
+  field_place_image:
+    type: entity_reference_entity_view
+    label: hidden
+    settings:
+      view_mode: teaser
+      link: false
+    third_party_settings: {  }
+    weight: 0
+    region: content
   field_place_telephone:
     type: string
     label: hidden
@@ -57,15 +66,6 @@ content:
       link_to_entity: false
     third_party_settings: {  }
     weight: 3
-    region: content
-  field_place_image:
-    type: entity_reference_entity_view
-    label: hidden
-    settings:
-      view_mode: small
-      link: false
-    third_party_settings: {  }
-    weight: 0
     region: content
 hidden:
   content_moderation_control: true

--- a/modules/acquia_cms_place/config/optional/core.entity_view_display.node.place.search_results.yml
+++ b/modules/acquia_cms_place/config/optional/core.entity_view_display.node.place.search_results.yml
@@ -12,13 +12,13 @@ dependencies:
     - field.field.node.place.field_place_type
     - field.field.node.place.field_tags
     - node.type.place
-  enforced:
-    module:
-      - acquia_cms_place
   module:
     - address
     - smart_trim
     - user
+  enforced:
+    module:
+      - acquia_cms_place
 id: node.place.search_results
 targetEntityType: node
 bundle: place
@@ -26,43 +26,51 @@ mode: search_results
 content:
   body:
     type: smart_trim
-    weight: 0
-    region: content
     label: hidden
     settings:
       trim_length: 128
       trim_type: chars
       trim_suffix: ...
-      wrap_class: trimmed
-      more_text: More
-      more_class: more-link
-      summary_handler: trim
       wrap_output: false
+      wrap_class: trimmed
       more_link: false
+      more_class: more-link
+      more_text: More
+      summary_handler: trim
       trim_options:
         text: false
         trim_zero: false
     third_party_settings: {  }
-  field_place_address:
-    type: address_default
     weight: 1
     region: content
+  field_place_address:
+    type: address_default
     label: hidden
     settings: {  }
     third_party_settings: {  }
-  field_place_telephone:
-    type: string
     weight: 2
     region: content
+  field_place_image:
+    type: entity_reference_entity_view
+    label: hidden
+    settings:
+      view_mode: small
+      link: false
+    third_party_settings: {  }
+    weight: 0
+    region: content
+  field_place_telephone:
+    type: string
     label: hidden
     settings:
       link_to_entity: false
     third_party_settings: {  }
+    weight: 3
+    region: content
 hidden:
   content_moderation_control: true
   field_categories: true
   field_geofield: true
-  field_place_image: true
   field_place_type: true
   field_tags: true
   langcode: true

--- a/modules/acquia_cms_place/config/optional/core.entity_view_display.node.place.teaser.yml
+++ b/modules/acquia_cms_place/config/optional/core.entity_view_display.node.place.teaser.yml
@@ -12,13 +12,13 @@ dependencies:
     - field.field.node.place.field_place_type
     - field.field.node.place.field_tags
     - node.type.place
-  enforced:
-    module:
-      - acquia_cms_place
   module:
     - address
     - smart_trim
     - user
+  enforced:
+    module:
+      - acquia_cms_place
 id: node.place.teaser
 targetEntityType: node
 bundle: place
@@ -26,42 +26,50 @@ mode: teaser
 content:
   body:
     type: smart_trim
-    weight: 0
-    region: content
     label: hidden
     settings:
       trim_length: 128
       trim_type: chars
       trim_suffix: ..
-      wrap_class: trimmed
-      more_text: More
-      more_class: more-link
-      summary_handler: trim
       wrap_output: false
+      wrap_class: trimmed
       more_link: false
+      more_class: more-link
+      more_text: More
+      summary_handler: trim
       trim_options:
         text: false
         trim_zero: false
     third_party_settings: {  }
-  field_place_address:
-    type: address_default
     weight: 1
     region: content
+  field_place_address:
+    type: address_default
     label: hidden
     settings: {  }
     third_party_settings: {  }
-  field_place_telephone:
-    type: string
     weight: 2
     region: content
+  field_place_image:
+    type: entity_reference_entity_view
+    label: hidden
+    settings:
+      view_mode: teaser
+      link: false
+    third_party_settings: {  }
+    weight: 0
+    region: content
+  field_place_telephone:
+    type: string
     label: hidden
     settings:
       link_to_entity: false
     third_party_settings: {  }
+    weight: 3
+    region: content
 hidden:
   content_moderation_control: true
   field_categories: true
-  field_place_image: true
   field_place_type: true
   field_tags: true
   langcode: true

--- a/modules/acquia_cms_place/config/optional/core.entity_view_display.node.place.teaser.yml
+++ b/modules/acquia_cms_place/config/optional/core.entity_view_display.node.place.teaser.yml
@@ -50,15 +50,6 @@ content:
     third_party_settings: {  }
     weight: 2
     region: content
-  field_place_image:
-    type: entity_reference_entity_view
-    label: hidden
-    settings:
-      view_mode: teaser
-      link: false
-    third_party_settings: {  }
-    weight: 0
-    region: content
   field_place_telephone:
     type: string
     label: hidden
@@ -67,9 +58,19 @@ content:
     third_party_settings: {  }
     weight: 3
     region: content
+  field_place_image:
+    type: entity_reference_entity_view
+    label: hidden
+    settings:
+      view_mode: teaser
+      link: true
+    third_party_settings: {  }
+    weight: 0
+    region: content
 hidden:
   content_moderation_control: true
   field_categories: true
+  field_geofield: true
   field_place_type: true
   field_tags: true
   langcode: true

--- a/modules/acquia_cms_place/config/pack_acquia_cms_place/cohesion_sync.cohesion_sync_package.pack_acquia_cms_place.yml
+++ b/modules/acquia_cms_place/config/pack_acquia_cms_place/cohesion_sync.cohesion_sync_package.pack_acquia_cms_place.yml
@@ -1323,5 +1323,14 @@ settings: |
               }
           },
           "checked": true
+      },
+      "7ef97a1e-87d2-4e2c-92f8-42145a598130": {
+          "type": "cohesion_content_templates",
+          "items": {
+              "7ef97a1e-87d2-4e2c-92f8-42145a598130": {
+                  "type": "cohesion_content_templates"
+              }
+          },
+          "checked": true
       }
   }

--- a/modules/acquia_cms_place/config/pack_acquia_cms_place/cohesion_templates.cohesion_content_templates.node_place_card.yml
+++ b/modules/acquia_cms_place/config/pack_acquia_cms_place/cohesion_templates.cohesion_content_templates.node_place_card.yml
@@ -3,7 +3,11 @@ langcode: en
 status: true
 dependencies:
   config:
-    - image.style.coh_small_landscape
+    - cohesion_custom_styles.cohesion_custom_style.097f31b2
+    - cohesion_custom_styles.cohesion_custom_style.2c64054a
+    - cohesion_custom_styles.cohesion_custom_style.65dc3072
+    - cohesion_custom_styles.cohesion_custom_style.a13b8c94
+    - cohesion_custom_styles.cohesion_custom_style.bfd0fecd
 label: 'Card (Node, Place)'
 id: node_place_card
 json_values: |
@@ -197,22 +201,19 @@ json_values: |
                       "uid": "container",
                       "title": "Container",
                       "status": {
-                          "collapsed": true
+                          "collapsed": false
                       },
                       "uuid": "d03c7a4d-9f6b-44f7-819c-d95b11d5ef50",
                       "parentUid": "container",
                       "children": [
                           {
-                              "type": "item",
-                              "uid": "image",
-                              "title": "Image",
+                              "type": "container",
+                              "uid": "drupal-field",
+                              "title": "Field",
                               "status": {
-                                  "collapsed": true,
-                                  "collapsedParents": [
-                                      "d03c7a4d-9f6b-44f7-819c-d95b11d5ef50"
-                                  ]
+                                  "collapsed": true
                               },
-                              "uuid": "6b0dbed4-e152-46cb-b587-860165e4a6f8",
+                              "uuid": "8014f6f6-8569-437e-a07e-8bbe4ba18921",
                               "parentUid": "container",
                               "children": []
                           }
@@ -723,78 +724,6 @@ json_values: |
                       }
                   ],
                   "title": "Hide if no data",
-                  "selectorType": "topLevel",
-                  "form": null,
-                  "items": []
-              }
-          },
-          "6b0dbed4-e152-46cb-b587-860165e4a6f8": {
-              "settings": {
-                  "formDefinition": [
-                      {
-                          "formKey": "image-settings",
-                          "children": [
-                              {
-                                  "formKey": "image-image",
-                                  "breakpoints": [],
-                                  "activeFields": [
-                                      {
-                                          "name": "image",
-                                          "active": true
-                                      },
-                                      {
-                                          "name": "title",
-                                          "active": true
-                                      },
-                                      {
-                                          "name": "alt",
-                                          "active": true
-                                      },
-                                      {
-                                          "name": "lazyload",
-                                          "active": true
-                                      }
-                                  ]
-                              },
-                              {
-                                  "formKey": "image-size",
-                                  "breakpoints": [
-                                      {
-                                          "name": "xl"
-                                      }
-                                  ],
-                                  "activeFields": [
-                                      {
-                                          "name": "displaySize",
-                                          "active": true
-                                      },
-                                      {
-                                          "name": "imageAlignment",
-                                          "active": true
-                                      }
-                                  ]
-                              },
-                              {
-                                  "formKey": "image-style",
-                                  "breakpoints": [],
-                                  "activeFields": [
-                                      {
-                                          "name": "imageStyle",
-                                          "active": true
-                                      },
-                                      {
-                                          "name": "customStyle",
-                                          "active": true
-                                      },
-                                      {
-                                          "name": "customStyle",
-                                          "active": true
-                                      }
-                                  ]
-                              }
-                          ]
-                      }
-                  ],
                   "selectorType": "topLevel",
                   "form": null,
                   "items": []
@@ -2192,7 +2121,8 @@ json_values: |
                   "form": null,
                   "items": []
               }
-          }
+          },
+          "8014f6f6-8569-437e-a07e-8bbe4ba18921": {}
       },
       "model": {
           "eb294133-0b8b-43d3-958c-ecca6afb52cb": {
@@ -2724,41 +2654,13 @@ json_values: |
                   "hideData": "[node:field_place_image]"
               }
           },
-          "6b0dbed4-e152-46cb-b587-860165e4a6f8": {
+          "8014f6f6-8569-437e-a07e-8bbe4ba18921": {
               "settings": {
-                  "title": "Image",
-                  "styles": {
-                      "xl": {
-                          "displaySize": "coh-image-responsive",
-                          "imageAlignment": "coh-image-align-left"
-                      }
-                  },
-                  "customStyle": [
-                      {
-                          "customStyle": ""
-                      }
-                  ],
-                  "lazyload": false,
+                  "title": "Field",
                   "settings": {
-                      "lazyload": false,
-                      "styles": {
-                          "xl": {
-                              "displaySize": "coh-image-responsive"
-                          }
-                      },
-                      "imageStyle": "",
-                      "customStyle": [
-                          {
-                              "customStyle": ""
-                          }
-                      ]
+                      "drupalField": ""
                   },
-                  "imageStyle": "coh_small_landscape",
-                  "image": "[node:field_place_image:entity:image:entity:path]",
-                  "attributes": {
-                      "title": "[node:field_place_image:entity:image:name]",
-                      "alt": "[node:field_place_image:entity:image:alt]"
-                  }
+                  "drupalField": "content.field_place_image"
               },
               "context-visibility": {
                   "contextVisibility": {
@@ -2767,7 +2669,7 @@ json_values: |
               },
               "styles": {
                   "settings": {
-                      "element": "img"
+                      "element": "drupal-field"
                   }
               }
           }
@@ -2776,11 +2678,6 @@ json_values: |
           "eb294133-0b8b-43d3-958c-ecca6afb52cb": {},
           "faded84d-e16e-425e-b1ee-9735aa367f0c": {},
           "d03c7a4d-9f6b-44f7-819c-d95b11d5ef50": {},
-          "6b0dbed4-e152-46cb-b587-860165e4a6f8": {
-              "settings": {
-                  "image": ""
-              }
-          },
           "0b0e3951-0c5e-45b0-a90d-a7737273c2c3": {},
           "21f68ac1-e932-4693-9821-f063fc9a35d8": {
               "settings": {
@@ -2801,17 +2698,13 @@ json_values: |
               "settings": {}
           },
           "d1b7c142-924b-48ec-8b68-5d569e1ce66d": {},
-          "bc9c8786-3e7f-4028-a970-93a289ed1d9d": {}
+          "bc9c8786-3e7f-4028-a970-93a289ed1d9d": {},
+          "8014f6f6-8569-437e-a07e-8bbe4ba18921": {}
       },
       "variableFields": {
           "eb294133-0b8b-43d3-958c-ecca6afb52cb": [],
           "faded84d-e16e-425e-b1ee-9735aa367f0c": [],
           "d03c7a4d-9f6b-44f7-819c-d95b11d5ef50": [],
-          "6b0dbed4-e152-46cb-b587-860165e4a6f8": [
-              "settings.attributes.title",
-              "settings.attributes.alt",
-              "settings.image"
-          ],
           "0b0e3951-0c5e-45b0-a90d-a7737273c2c3": [],
           "21f68ac1-e932-4693-9821-f063fc9a35d8": [
               "settings.linkText",
@@ -2828,7 +2721,8 @@ json_values: |
           "b69f94ae-07ba-42a7-98e5-110e28a838a3": [],
           "5f4adba5-a7fe-49b6-b667-3c8702430521": [],
           "d1b7c142-924b-48ec-8b68-5d569e1ce66d": [],
-          "bc9c8786-3e7f-4028-a970-93a289ed1d9d": []
+          "bc9c8786-3e7f-4028-a970-93a289ed1d9d": [],
+          "8014f6f6-8569-437e-a07e-8bbe4ba18921": []
       },
       "meta": {
           "fieldHistory": []

--- a/modules/acquia_cms_place/config/pack_acquia_cms_place/cohesion_templates.cohesion_content_templates.node_place_full.yml
+++ b/modules/acquia_cms_place/config/pack_acquia_cms_place/cohesion_templates.cohesion_content_templates.node_place_full.yml
@@ -3,11 +3,19 @@ langcode: en
 status: true
 dependencies:
   config:
+    - cohesion_custom_styles.cohesion_custom_style.097f31b2
+    - cohesion_custom_styles.cohesion_custom_style.0f2c7187
+    - cohesion_custom_styles.cohesion_custom_style.2c64054a
+    - cohesion_custom_styles.cohesion_custom_style.65dc3072
+    - cohesion_custom_styles.cohesion_custom_style.6f04ac8e
+    - cohesion_custom_styles.cohesion_custom_style.7ef725fd
+    - cohesion_custom_styles.cohesion_custom_style.a13b8c94
+    - cohesion_custom_styles.cohesion_custom_style.a59e0629
+    - cohesion_custom_styles.cohesion_custom_style.bfd0fecd
+    - cohesion_custom_styles.cohesion_custom_style.ee93d997
+    - cohesion_elements.cohesion_component.cpt_breadcrumbs
     - cohesion_templates.cohesion_master_templates.master_template
-    - image.style.coh_large_super_landscape
-    - image.style.coh_medium_super_landscape
-    - image.style.coh_small_landscape
-    - image.style.coh_x_large_super_landscape
+    - cohesion_website_settings.cohesion_color.gray-10
 label: 'Full content (Node, Place)'
 id: node_place_full
 json_values: |
@@ -151,25 +159,19 @@ json_values: |
                               "uid": "column",
                               "title": "Column",
                               "status": {
-                                  "collapsed": true,
-                                  "collapsedParents": []
+                                  "collapsed": false
                               },
                               "uuid": "68757f76-87e4-4762-8a7a-0e91f8007146",
                               "parentUid": "row-for-columns",
                               "children": [
                                   {
-                                      "type": "item",
-                                      "uid": "picture",
-                                      "title": "Picture",
-                                      "selected": false,
+                                      "type": "container",
+                                      "uid": "drupal-field",
+                                      "title": "Field",
                                       "status": {
-                                          "collapsed": true,
-                                          "isopen": false,
-                                          "collapsedParents": [
-                                              "68757f76-87e4-4762-8a7a-0e91f8007146"
-                                          ]
+                                          "collapsed": true
                                       },
-                                      "uuid": "f52a4742-313b-4f04-b826-770d2cb2b710",
+                                      "uuid": "5515124d-6f17-4c8e-bc45-194a79d97a49",
                                       "parentUid": "column",
                                       "children": []
                                   }
@@ -2082,91 +2084,6 @@ json_values: |
                   "items": []
               }
           },
-          "f52a4742-313b-4f04-b826-770d2cb2b710": {
-              "settings": {
-                  "formDefinition": [
-                      {
-                          "formKey": "picture-settings",
-                          "children": [
-                              {
-                                  "formKey": "picture-info",
-                                  "breakpoints": [],
-                                  "activeFields": [
-                                      {
-                                          "name": "title",
-                                          "active": true
-                                      },
-                                      {
-                                          "name": "alt",
-                                          "active": true
-                                      },
-                                      {
-                                          "name": "lazyload",
-                                          "active": true
-                                      }
-                                  ]
-                              },
-                              {
-                                  "formKey": "picture-images",
-                                  "breakpoints": [
-                                      {
-                                          "name": "xl"
-                                      },
-                                      {
-                                          "name": "md"
-                                      },
-                                      {
-                                          "name": "sm"
-                                      },
-                                      {
-                                          "name": "ps"
-                                      }
-                                  ],
-                                  "activeFields": [
-                                      {
-                                          "name": "displaySize",
-                                          "active": true
-                                      },
-                                      {
-                                          "name": "imageAlignment",
-                                          "active": true
-                                      },
-                                      {
-                                          "name": "pictureImagesArray",
-                                          "active": true
-                                      },
-                                      {
-                                          "name": "image",
-                                          "active": true
-                                      },
-                                      {
-                                          "name": "imageStyle",
-                                          "active": true
-                                      }
-                                  ]
-                              },
-                              {
-                                  "formKey": "picture-style",
-                                  "breakpoints": [],
-                                  "activeFields": [
-                                      {
-                                          "name": "customStyle",
-                                          "active": true
-                                      },
-                                      {
-                                          "name": "customStyle",
-                                          "active": true
-                                      }
-                                  ]
-                              }
-                          ]
-                      }
-                  ],
-                  "selectorType": "topLevel",
-                  "form": null,
-                  "items": []
-              }
-          },
           "6001acbb-894c-4c3e-8165-4f516da75b7b": {
               "settings": {
                   "formDefinition": [
@@ -2906,7 +2823,8 @@ json_values: |
                   "items": [],
                   "form": null
               }
-          }
+          },
+          "5515124d-6f17-4c8e-bc45-194a79d97a49": {}
       },
       "model": {
           "eac68ba6-bb27-4ee5-a439-08160949b893": {
@@ -3289,72 +3207,13 @@ json_values: |
                   "hideData": "[node:field_place_image]"
               }
           },
-          "f52a4742-313b-4f04-b826-770d2cb2b710": {
+          "5515124d-6f17-4c8e-bc45-194a79d97a49": {
               "settings": {
-                  "title": "Picture",
-                  "customStyle": [
-                      {
-                          "customStyle": ""
-                      }
-                  ],
-                  "styles": {
-                      "xl": {
-                          "pictureImagesArray": [
-                              {
-                                  "imageStyle": "coh_x_large_super_landscape",
-                                  "image": "[node:field_place_image:entity:image:entity:path]"
-                              }
-                          ],
-                          "displaySize": "coh-image-responsive"
-                      },
-                      "md": {
-                          "pictureImagesArray": [
-                              {
-                                  "imageStyle": "coh_large_super_landscape"
-                              }
-                          ],
-                          "displaySize": "coh-image-responsive"
-                      },
-                      "sm": {
-                          "pictureImagesArray": [
-                              {
-                                  "imageStyle": "coh_medium_super_landscape"
-                              }
-                          ],
-                          "displaySize": "coh-image-responsive"
-                      },
-                      "ps": {
-                          "pictureImagesArray": [
-                              {
-                                  "imageStyle": "coh_small_landscape"
-                              }
-                          ],
-                          "displaySize": "coh-image-responsive"
-                      }
-                  },
-                  "lazyload": false,
+                  "title": "Field",
                   "settings": {
-                      "lazyload": false,
-                      "styles": {
-                          "xl": {
-                              "displaySize": "coh-image-responsive",
-                              "pictureImagesArray": [
-                                  {
-                                      "imageStyle": ""
-                                  }
-                              ]
-                          }
-                      },
-                      "customStyle": [
-                          {
-                              "customStyle": ""
-                          }
-                      ]
+                      "drupalField": ""
                   },
-                  "attributes": {
-                      "title": "[node:field_place_image:entity:image:entity:name]",
-                      "alt": "[node:field_place_image:entity:image:alt]"
-                  }
+                  "drupalField": "content.field_place_image"
               },
               "context-visibility": {
                   "contextVisibility": {
@@ -3363,7 +3222,7 @@ json_values: |
               },
               "styles": {
                   "settings": {
-                      "element": "picture"
+                      "element": "drupal-field"
                   }
               }
           },
@@ -3853,19 +3712,6 @@ json_values: |
               }
           },
           "68757f76-87e4-4762-8a7a-0e91f8007146": {},
-          "f52a4742-313b-4f04-b826-770d2cb2b710": {
-              "settings": {
-                  "styles": {
-                      "xl": {
-                          "pictureImagesArray": [
-                              {
-                                  "image": ""
-                              }
-                          ]
-                      }
-                  }
-              }
-          },
           "cc17e2c1-8817-43ac-ae86-baef50d40985": {},
           "5031bd4e-23c1-4904-bd6e-72cdbe9b3487": {},
           "d3644b5a-848c-49aa-8295-6e06e00af51a": {},
@@ -3895,7 +3741,8 @@ json_values: |
           "4842feba-ce9f-4a27-9344-e90ce62d30cb": {},
           "dd6cf217-e8f7-4f4d-a58c-4e7d24cd7f93": {},
           "69d998bb-de86-4ceb-b19f-971db2a495e7": {},
-          "e2c00eb1-66be-4d3c-80f8-dbccbebccd90": {}
+          "e2c00eb1-66be-4d3c-80f8-dbccbebccd90": {},
+          "5515124d-6f17-4c8e-bc45-194a79d97a49": {}
       },
       "variableFields": {
           "a61b98d2-d200-4f1d-8e6a-1550360e5a89": [],
@@ -3905,11 +3752,6 @@ json_values: |
               "settings.content"
           ],
           "68757f76-87e4-4762-8a7a-0e91f8007146": [],
-          "f52a4742-313b-4f04-b826-770d2cb2b710": [
-              "settings.styles.xl.pictureImagesArray.0.image",
-              "settings.attributes.title",
-              "settings.attributes.alt"
-          ],
           "cc17e2c1-8817-43ac-ae86-baef50d40985": [
               "hideNoData.hideData"
           ],
@@ -3944,7 +3786,8 @@ json_values: |
               "settings.latlong"
           ],
           "69d998bb-de86-4ceb-b19f-971db2a495e7": [],
-          "e2c00eb1-66be-4d3c-80f8-dbccbebccd90": []
+          "e2c00eb1-66be-4d3c-80f8-dbccbebccd90": [],
+          "5515124d-6f17-4c8e-bc45-194a79d97a49": []
       },
       "meta": {
           "fieldHistory": []

--- a/modules/acquia_cms_place/config/pack_acquia_cms_place/cohesion_templates.cohesion_content_templates.node_place_horizontal_card.yml
+++ b/modules/acquia_cms_place/config/pack_acquia_cms_place/cohesion_templates.cohesion_content_templates.node_place_horizontal_card.yml
@@ -3,7 +3,9 @@ langcode: en
 status: true
 dependencies:
   config:
-    - image.style.coh_small_landscape
+    - cohesion_custom_styles.cohesion_custom_style.097f31b2
+    - cohesion_custom_styles.cohesion_custom_style.2c64054a
+    - cohesion_custom_styles.cohesion_custom_style.a13b8c94
 label: 'Horizontal card (Node, Place)'
 id: node_place_horizontal_card
 json_values: |
@@ -168,22 +170,19 @@ json_values: |
                       "uid": "column",
                       "title": "Column",
                       "status": {
-                          "collapsed": true
+                          "collapsed": false
                       },
                       "uuid": "643863c5-32a5-4702-b40b-df2f618d1d8f",
                       "parentUid": "row-for-columns",
                       "children": [
                           {
-                              "type": "item",
-                              "uid": "image",
-                              "title": "Image",
+                              "type": "container",
+                              "uid": "drupal-field",
+                              "title": "Field",
                               "status": {
-                                  "collapsed": true,
-                                  "collapsedParents": [
-                                      "643863c5-32a5-4702-b40b-df2f618d1d8f"
-                                  ]
+                                  "collapsed": true
                               },
-                              "uuid": "df16c319-18a8-4032-8bb8-afd202cde251",
+                              "uuid": "7b2ae103-6ce3-4144-946b-dd0d0a1cca35",
                               "parentUid": "column",
                               "children": []
                           }
@@ -508,117 +507,7 @@ json_values: |
                                           "active": true
                                       }
                                   ]
-                              }
-                          ]
-                      }
-                  ],
-                  "items": [],
-                  "form": null
-              },
-              "hideNoData": {
-                  "formDefinition": [
-                      {
-                          "formKey": "tab-hide-data-settings",
-                          "children": [
-                              {
-                                  "formKey": "tab-hide-data-hide",
-                                  "breakpoints": [],
-                                  "activeFields": [
-                                      {
-                                          "name": "hideEnable",
-                                          "active": true
-                                      },
-                                      {
-                                          "name": "hideData",
-                                          "active": true
-                                      }
-                                  ]
-                              }
-                          ]
-                      }
-                  ],
-                  "title": "Hide if no data",
-                  "selectorType": "topLevel",
-                  "form": null,
-                  "items": []
-              }
-          },
-          "df16c319-18a8-4032-8bb8-afd202cde251": {
-              "settings": {
-                  "formDefinition": [
-                      {
-                          "formKey": "image-settings",
-                          "children": [
-                              {
-                                  "formKey": "image-image",
-                                  "breakpoints": [],
-                                  "activeFields": [
-                                      {
-                                          "name": "image",
-                                          "active": true
-                                      },
-                                      {
-                                          "name": "title",
-                                          "active": true
-                                      },
-                                      {
-                                          "name": "alt",
-                                          "active": true
-                                      },
-                                      {
-                                          "name": "lazyload",
-                                          "active": true
-                                      }
-                                  ]
                               },
-                              {
-                                  "formKey": "image-size",
-                                  "breakpoints": [
-                                      {
-                                          "name": "xl"
-                                      }
-                                  ],
-                                  "activeFields": [
-                                      {
-                                          "name": "displaySize",
-                                          "active": true
-                                      },
-                                      {
-                                          "name": "imageAlignment",
-                                          "active": true
-                                      }
-                                  ]
-                              },
-                              {
-                                  "formKey": "image-style",
-                                  "breakpoints": [],
-                                  "activeFields": [
-                                      {
-                                          "name": "imageStyle",
-                                          "active": true
-                                      },
-                                      {
-                                          "name": "customStyle",
-                                          "active": true
-                                      },
-                                      {
-                                          "name": "customStyle",
-                                          "active": true
-                                      }
-                                  ]
-                              }
-                          ]
-                      }
-                  ],
-                  "selectorType": "topLevel",
-                  "form": null,
-                  "items": []
-              },
-              "styles": {
-                  "formDefinition": [
-                      {
-                          "formKey": "layout",
-                          "children": [
                               {
                                   "formKey": "height",
                                   "breakpoints": [
@@ -671,9 +560,35 @@ json_values: |
                           ]
                       }
                   ],
-                  "selectorType": "topLevel",
                   "items": [],
                   "form": null
+              },
+              "hideNoData": {
+                  "formDefinition": [
+                      {
+                          "formKey": "tab-hide-data-settings",
+                          "children": [
+                              {
+                                  "formKey": "tab-hide-data-hide",
+                                  "breakpoints": [],
+                                  "activeFields": [
+                                      {
+                                          "name": "hideEnable",
+                                          "active": true
+                                      },
+                                      {
+                                          "name": "hideData",
+                                          "active": true
+                                      }
+                                  ]
+                              }
+                          ]
+                      }
+                  ],
+                  "title": "Hide if no data",
+                  "selectorType": "topLevel",
+                  "form": null,
+                  "items": []
               }
           },
           "02010964-ee84-4d72-8dce-113feac2ff30": {
@@ -1942,7 +1857,8 @@ json_values: |
                   ],
                   "form": null
               }
-          }
+          },
+          "7b2ae103-6ce3-4144-946b-dd0d0a1cca35": {}
       },
       "model": {
           "d2d6ccce-3dae-445d-99e6-375b6c4b1596": {
@@ -2412,62 +2328,7 @@ json_values: |
                               "order": {
                                   "value": "-1"
                               }
-                          }
-                      }
-                  }
-              },
-              "hideNoData": {
-                  "hideEnable": true,
-                  "hideData": "[node:field_place_image]"
-              }
-          },
-          "df16c319-18a8-4032-8bb8-afd202cde251": {
-              "settings": {
-                  "title": "Image",
-                  "styles": {
-                      "xl": {
-                          "displaySize": "coh-image-responsive",
-                          "imageAlignment": "coh-image-align-left"
-                      }
-                  },
-                  "customStyle": [
-                      {
-                          "customStyle": ""
-                      }
-                  ],
-                  "lazyload": false,
-                  "settings": {
-                      "lazyload": false,
-                      "styles": {
-                          "xl": {
-                              "displaySize": "coh-image-responsive"
-                          }
-                      },
-                      "imageStyle": "",
-                      "customStyle": [
-                          {
-                              "customStyle": ""
-                          }
-                      ]
-                  },
-                  "imageStyle": "coh_small_landscape",
-                  "image": "[node:field_place_image:entity:image:entity:path]",
-                  "attributes": {
-                      "title": "[node:field_place_image:entity:image:name]",
-                      "alt": "[node:field_place_image:entity:image:alt]"
-                  }
-              },
-              "context-visibility": {
-                  "contextVisibility": {
-                      "condition": "ALL"
-                  }
-              },
-              "styles": {
-                  "settings": {
-                      "element": "img"
-                  },
-                  "styles": {
-                      "xl": {
+                          },
                           "custom-css": [
                               {
                                   "customCssProperty": {
@@ -2483,6 +2344,29 @@ json_values: |
                           }
                       }
                   }
+              },
+              "hideNoData": {
+                  "hideEnable": true,
+                  "hideData": "[node:field_place_image]"
+              }
+          },
+          "7b2ae103-6ce3-4144-946b-dd0d0a1cca35": {
+              "settings": {
+                  "title": "Field",
+                  "settings": {
+                      "drupalField": ""
+                  },
+                  "drupalField": "content.field_place_image"
+              },
+              "context-visibility": {
+                  "contextVisibility": {
+                      "condition": "ALL"
+                  }
+              },
+              "styles": {
+                  "settings": {
+                      "element": "drupal-field"
+                  }
               }
           }
       },
@@ -2490,11 +2374,6 @@ json_values: |
           "d2d6ccce-3dae-445d-99e6-375b6c4b1596": {},
           "02010964-ee84-4d72-8dce-113feac2ff30": {},
           "643863c5-32a5-4702-b40b-df2f618d1d8f": {},
-          "df16c319-18a8-4032-8bb8-afd202cde251": {
-              "settings": {
-                  "image": ""
-              }
-          },
           "acb8571d-804e-491e-ac86-15864d1b53b2": {
               "settings": {
                   "linkText": "Acquia Head Office"
@@ -2509,17 +2388,13 @@ json_values: |
           },
           "f02686ce-e2f8-4c43-9117-56a1d8758540": {},
           "d16817dd-2fc8-4a81-b1ec-93753e189d84": {},
-          "6dbd3551-4c30-421c-a4c3-39ca501d52eb": {}
+          "6dbd3551-4c30-421c-a4c3-39ca501d52eb": {},
+          "7b2ae103-6ce3-4144-946b-dd0d0a1cca35": {}
       },
       "variableFields": {
           "d2d6ccce-3dae-445d-99e6-375b6c4b1596": [],
           "02010964-ee84-4d72-8dce-113feac2ff30": [],
           "643863c5-32a5-4702-b40b-df2f618d1d8f": [],
-          "df16c319-18a8-4032-8bb8-afd202cde251": [
-              "settings.attributes.title",
-              "settings.attributes.alt",
-              "settings.image"
-          ],
           "acb8571d-804e-491e-ac86-15864d1b53b2": [
               "settings.linkText",
               "settings.linkToPage"
@@ -2531,7 +2406,8 @@ json_values: |
           "b4fb7bd8-6480-47e4-9c4c-41fb5391cf89": [],
           "f02686ce-e2f8-4c43-9117-56a1d8758540": [],
           "d16817dd-2fc8-4a81-b1ec-93753e189d84": [],
-          "6dbd3551-4c30-421c-a4c3-39ca501d52eb": []
+          "6dbd3551-4c30-421c-a4c3-39ca501d52eb": [],
+          "7b2ae103-6ce3-4144-946b-dd0d0a1cca35": []
       },
       "meta": {
           "fieldHistory": []

--- a/modules/acquia_cms_place/config/pack_acquia_cms_place/cohesion_templates.cohesion_content_templates.node_place_referenced_image.yml
+++ b/modules/acquia_cms_place/config/pack_acquia_cms_place/cohesion_templates.cohesion_content_templates.node_place_referenced_image.yml
@@ -1,0 +1,66 @@
+uuid: 7ef97a1e-87d2-4e2c-92f8-42145a598130
+langcode: en
+status: true
+dependencies: {  }
+label: 'Referenced Image (Node, Place)'
+id: node_place_referenced_image
+json_values: |
+  {
+      "canvas": [
+          {
+              "type": "container",
+              "uid": "drupal-field",
+              "title": "Field",
+              "status": {
+                  "collapsed": true
+              },
+              "uuid": "2142bb4e-339a-4de7-b393-18f01cd64b80",
+              "parentUid": "root",
+              "children": []
+          }
+      ],
+      "mapper": {
+          "2142bb4e-339a-4de7-b393-18f01cd64b80": {}
+      },
+      "model": {
+          "2142bb4e-339a-4de7-b393-18f01cd64b80": {
+              "settings": {
+                  "title": "Field",
+                  "settings": {
+                      "drupalField": ""
+                  },
+                  "drupalField": "content.field_place_image"
+              },
+              "context-visibility": {
+                  "contextVisibility": {
+                      "condition": "ALL"
+                  }
+              },
+              "styles": {
+                  "settings": {
+                      "element": "drupal-field"
+                  }
+              }
+          }
+      },
+      "previewModel": {
+          "2142bb4e-339a-4de7-b393-18f01cd64b80": {}
+      },
+      "variableFields": {
+          "2142bb4e-339a-4de7-b393-18f01cd64b80": []
+      },
+      "meta": {
+          "fieldHistory": []
+      }
+  }
+json_mapper: '{}'
+last_entity_update: entityupdate_0036
+modified: true
+selectable: false
+custom: false
+twig_template: node--cohesion--node-place-referenced-image
+default: true
+entity_type: node
+bundle: place
+view_mode: referenced_image
+master_template: ''

--- a/modules/acquia_cms_place/config/pack_acquia_cms_place/cohesion_templates.cohesion_content_templates.node_place_search_results.yml
+++ b/modules/acquia_cms_place/config/pack_acquia_cms_place/cohesion_templates.cohesion_content_templates.node_place_search_results.yml
@@ -3,7 +3,10 @@ langcode: en
 status: true
 dependencies:
   config:
-    - image.style.coh_small_landscape
+    - cohesion_custom_styles.cohesion_custom_style.2c64054a
+    - cohesion_custom_styles.cohesion_custom_style.65dc3072
+    - cohesion_custom_styles.cohesion_custom_style.bfd0fecd
+    - cohesion_custom_styles.cohesion_custom_style.f3dc1bea
 label: 'Search Results (Node, Place)'
 id: node_place_search_results
 json_values: |
@@ -173,24 +176,19 @@ json_values: |
                       "uid": "column",
                       "title": "Column",
                       "status": {
-                          "collapsed": true
+                          "collapsed": false
                       },
                       "uuid": "adc0f1f5-2ccc-4588-8aa1-02591bd3dc6e",
                       "parentUid": "row-for-columns",
                       "children": [
                           {
-                              "type": "item",
-                              "uid": "picture",
-                              "title": "Picture",
-                              "selected": false,
+                              "type": "container",
+                              "uid": "drupal-field",
+                              "title": "Field",
                               "status": {
-                                  "collapsed": true,
-                                  "isopen": false,
-                                  "collapsedParents": [
-                                      "adc0f1f5-2ccc-4588-8aa1-02591bd3dc6e"
-                                  ]
+                                  "collapsed": true
                               },
-                              "uuid": "80512b73-acf5-4211-966e-9a928dad2bb0",
+                              "uuid": "c51e4621-3589-479e-9f39-451afa47d316",
                               "parentUid": "column",
                               "children": []
                           }
@@ -552,85 +550,6 @@ json_values: |
                       }
                   ],
                   "title": "Hide if no data",
-                  "selectorType": "topLevel",
-                  "form": null,
-                  "items": []
-              }
-          },
-          "80512b73-acf5-4211-966e-9a928dad2bb0": {
-              "settings": {
-                  "formDefinition": [
-                      {
-                          "formKey": "picture-settings",
-                          "children": [
-                              {
-                                  "formKey": "picture-info",
-                                  "breakpoints": [],
-                                  "activeFields": [
-                                      {
-                                          "name": "title",
-                                          "active": true
-                                      },
-                                      {
-                                          "name": "alt",
-                                          "active": true
-                                      },
-                                      {
-                                          "name": "lazyload",
-                                          "active": true
-                                      }
-                                  ]
-                              },
-                              {
-                                  "formKey": "picture-images",
-                                  "breakpoints": [
-                                      {
-                                          "name": "xl"
-                                      },
-                                      {
-                                          "name": "ps"
-                                      }
-                                  ],
-                                  "activeFields": [
-                                      {
-                                          "name": "displaySize",
-                                          "active": true
-                                      },
-                                      {
-                                          "name": "imageAlignment",
-                                          "active": true
-                                      },
-                                      {
-                                          "name": "pictureImagesArray",
-                                          "active": true
-                                      },
-                                      {
-                                          "name": "image",
-                                          "active": true
-                                      },
-                                      {
-                                          "name": "imageStyle",
-                                          "active": true
-                                      }
-                                  ]
-                              },
-                              {
-                                  "formKey": "picture-style",
-                                  "breakpoints": [],
-                                  "activeFields": [
-                                      {
-                                          "name": "customStyle",
-                                          "active": true
-                                      },
-                                      {
-                                          "name": "customStyle",
-                                          "active": true
-                                      }
-                                  ]
-                              }
-                          ]
-                      }
-                  ],
                   "selectorType": "topLevel",
                   "form": null,
                   "items": []
@@ -2114,7 +2033,8 @@ json_values: |
                   "form": null,
                   "items": []
               }
-          }
+          },
+          "c51e4621-3589-479e-9f39-451afa47d316": {}
       },
       "model": {
           "8f5c71fb-40ad-42fd-afe5-5338a04537c7": {
@@ -2689,56 +2609,13 @@ json_values: |
                   "hideData": "[node:field_place_image]"
               }
           },
-          "80512b73-acf5-4211-966e-9a928dad2bb0": {
+          "c51e4621-3589-479e-9f39-451afa47d316": {
               "settings": {
-                  "title": "Picture",
-                  "customStyle": [
-                      {
-                          "customStyle": ""
-                      }
-                  ],
-                  "styles": {
-                      "xl": {
-                          "pictureImagesArray": [
-                              {
-                                  "imageStyle": "x_small_square_320x320_",
-                                  "image": "[node:field_place_image:entity:image:entity:path]"
-                              }
-                          ],
-                          "displaySize": "coh-image-responsive"
-                      },
-                      "ps": {
-                          "pictureImagesArray": [
-                              {
-                                  "imageStyle": "coh_small_landscape"
-                              }
-                          ],
-                          "displaySize": "coh-image-responsive"
-                      }
-                  },
-                  "lazyload": false,
+                  "title": "Field",
                   "settings": {
-                      "lazyload": false,
-                      "styles": {
-                          "xl": {
-                              "displaySize": "coh-image-responsive",
-                              "pictureImagesArray": [
-                                  {
-                                      "imageStyle": ""
-                                  }
-                              ]
-                          }
-                      },
-                      "customStyle": [
-                          {
-                              "customStyle": ""
-                          }
-                      ]
+                      "drupalField": ""
                   },
-                  "attributes": {
-                      "title": "[node:field_place_image:entity:image:name]",
-                      "alt": "[node:field_place_image:entity:image:alt]"
-                  }
+                  "drupalField": "content.field_place_image"
               },
               "context-visibility": {
                   "contextVisibility": {
@@ -2747,7 +2624,7 @@ json_values: |
               },
               "styles": {
                   "settings": {
-                      "element": "picture"
+                      "element": "drupal-field"
                   }
               }
           }
@@ -2755,19 +2632,6 @@ json_values: |
       "previewModel": {
           "739a9171-f14f-42b7-847e-2bb529668ca0": {},
           "adc0f1f5-2ccc-4588-8aa1-02591bd3dc6e": {},
-          "80512b73-acf5-4211-966e-9a928dad2bb0": {
-              "settings": {
-                  "styles": {
-                      "xl": {
-                          "pictureImagesArray": [
-                              {
-                                  "image": ""
-                              }
-                          ]
-                      }
-                  }
-              }
-          },
           "e02755c6-b305-49bb-8e77-cd04b5077ac8": {
               "settings": {
                   "linkText": "Acquia Head Office.",
@@ -2793,16 +2657,12 @@ json_values: |
           "8f5c71fb-40ad-42fd-afe5-5338a04537c7": {},
           "60742444-5c82-4441-a525-f003ae2c4b47": {},
           "318b0050-4de9-486a-b6ab-51f1a0aca0b0": {},
-          "9124c7dc-5ad7-4c46-8dcf-d3cb4e148e51": {}
+          "9124c7dc-5ad7-4c46-8dcf-d3cb4e148e51": {},
+          "c51e4621-3589-479e-9f39-451afa47d316": {}
       },
       "variableFields": {
           "739a9171-f14f-42b7-847e-2bb529668ca0": [],
           "adc0f1f5-2ccc-4588-8aa1-02591bd3dc6e": [],
-          "80512b73-acf5-4211-966e-9a928dad2bb0": [
-              "settings.attributes.title",
-              "settings.attributes.alt",
-              "settings.styles.xl.pictureImagesArray.0.image"
-          ],
           "e02755c6-b305-49bb-8e77-cd04b5077ac8": [
               "settings.linkText",
               "settings.linkToPage"
@@ -2822,7 +2682,8 @@ json_values: |
           "8f5c71fb-40ad-42fd-afe5-5338a04537c7": [],
           "60742444-5c82-4441-a525-f003ae2c4b47": [],
           "318b0050-4de9-486a-b6ab-51f1a0aca0b0": [],
-          "9124c7dc-5ad7-4c46-8dcf-d3cb4e148e51": []
+          "9124c7dc-5ad7-4c46-8dcf-d3cb4e148e51": [],
+          "c51e4621-3589-479e-9f39-451afa47d316": []
       },
       "meta": {
           "fieldHistory": []

--- a/modules/acquia_cms_place/config/pack_acquia_cms_place/cohesion_templates.cohesion_content_templates.node_place_teaser.yml
+++ b/modules/acquia_cms_place/config/pack_acquia_cms_place/cohesion_templates.cohesion_content_templates.node_place_teaser.yml
@@ -3,7 +3,10 @@ langcode: en
 status: true
 dependencies:
   config:
-    - image.style.coh_small_landscape
+    - cohesion_custom_styles.cohesion_custom_style.2c64054a
+    - cohesion_custom_styles.cohesion_custom_style.65dc3072
+    - cohesion_custom_styles.cohesion_custom_style.bfd0fecd
+    - cohesion_custom_styles.cohesion_custom_style.f3dc1bea
 label: 'Teaser (Node, Place)'
 id: node_place_teaser
 json_values: |
@@ -197,24 +200,19 @@ json_values: |
                       "uid": "column",
                       "title": "Column",
                       "status": {
-                          "collapsed": true
+                          "collapsed": false
                       },
                       "uuid": "f63e75fd-94ca-4997-b9a0-d52d6de244d7",
                       "parentUid": "row-for-columns",
                       "children": [
                           {
-                              "type": "item",
-                              "uid": "picture",
-                              "title": "Picture",
-                              "selected": false,
+                              "type": "container",
+                              "uid": "drupal-field",
+                              "title": "Field",
                               "status": {
-                                  "collapsed": true,
-                                  "isopen": false,
-                                  "collapsedParents": [
-                                      "f63e75fd-94ca-4997-b9a0-d52d6de244d7"
-                                  ]
+                                  "collapsed": true
                               },
-                              "uuid": "ebaddfe7-cf07-4398-ac01-2c8eff026c18",
+                              "uuid": "8bb79035-3819-44ae-bf09-64f8360adcfc",
                               "parentUid": "column",
                               "children": []
                           }
@@ -576,85 +574,6 @@ json_values: |
                       }
                   ],
                   "title": "Hide if no data",
-                  "selectorType": "topLevel",
-                  "form": null,
-                  "items": []
-              }
-          },
-          "ebaddfe7-cf07-4398-ac01-2c8eff026c18": {
-              "settings": {
-                  "formDefinition": [
-                      {
-                          "formKey": "picture-settings",
-                          "children": [
-                              {
-                                  "formKey": "picture-info",
-                                  "breakpoints": [],
-                                  "activeFields": [
-                                      {
-                                          "name": "title",
-                                          "active": true
-                                      },
-                                      {
-                                          "name": "alt",
-                                          "active": true
-                                      },
-                                      {
-                                          "name": "lazyload",
-                                          "active": true
-                                      }
-                                  ]
-                              },
-                              {
-                                  "formKey": "picture-images",
-                                  "breakpoints": [
-                                      {
-                                          "name": "xl"
-                                      },
-                                      {
-                                          "name": "ps"
-                                      }
-                                  ],
-                                  "activeFields": [
-                                      {
-                                          "name": "displaySize",
-                                          "active": true
-                                      },
-                                      {
-                                          "name": "imageAlignment",
-                                          "active": true
-                                      },
-                                      {
-                                          "name": "pictureImagesArray",
-                                          "active": true
-                                      },
-                                      {
-                                          "name": "image",
-                                          "active": true
-                                      },
-                                      {
-                                          "name": "imageStyle",
-                                          "active": true
-                                      }
-                                  ]
-                              },
-                              {
-                                  "formKey": "picture-style",
-                                  "breakpoints": [],
-                                  "activeFields": [
-                                      {
-                                          "name": "customStyle",
-                                          "active": true
-                                      },
-                                      {
-                                          "name": "customStyle",
-                                          "active": true
-                                      }
-                                  ]
-                              }
-                          ]
-                      }
-                  ],
                   "selectorType": "topLevel",
                   "form": null,
                   "items": []
@@ -2185,7 +2104,8 @@ json_values: |
                   "form": null,
                   "items": []
               }
-          }
+          },
+          "8bb79035-3819-44ae-bf09-64f8360adcfc": {}
       },
       "model": {
           "061ff893-3c6e-463c-a887-0f9264b9a5f2": {
@@ -2760,56 +2680,13 @@ json_values: |
                   "hideData": "[node:field_place_image]"
               }
           },
-          "ebaddfe7-cf07-4398-ac01-2c8eff026c18": {
+          "8bb79035-3819-44ae-bf09-64f8360adcfc": {
               "settings": {
-                  "title": "Picture",
-                  "customStyle": [
-                      {
-                          "customStyle": ""
-                      }
-                  ],
-                  "styles": {
-                      "xl": {
-                          "pictureImagesArray": [
-                              {
-                                  "imageStyle": "x_small_square_320x320_",
-                                  "image": "[node:field_place_image:entity:image:entity:path]"
-                              }
-                          ],
-                          "displaySize": "coh-image-responsive"
-                      },
-                      "ps": {
-                          "pictureImagesArray": [
-                              {
-                                  "imageStyle": "coh_small_landscape"
-                              }
-                          ],
-                          "displaySize": "coh-image-responsive"
-                      }
-                  },
-                  "lazyload": false,
+                  "title": "Field",
                   "settings": {
-                      "lazyload": false,
-                      "styles": {
-                          "xl": {
-                              "displaySize": "coh-image-responsive",
-                              "pictureImagesArray": [
-                                  {
-                                      "imageStyle": ""
-                                  }
-                              ]
-                          }
-                      },
-                      "customStyle": [
-                          {
-                              "customStyle": ""
-                          }
-                      ]
+                      "drupalField": ""
                   },
-                  "attributes": {
-                      "title": "[node:field_place_image:entity:image:name]",
-                      "alt": "[node:field_place_image:entity:image:alt]"
-                  }
+                  "drupalField": "content.field_place_image"
               },
               "context-visibility": {
                   "contextVisibility": {
@@ -2818,7 +2695,7 @@ json_values: |
               },
               "styles": {
                   "settings": {
-                      "element": "picture"
+                      "element": "drupal-field"
                   }
               }
           }
@@ -2826,19 +2703,6 @@ json_values: |
       "previewModel": {
           "8252cc36-94ed-4234-a982-8b50c7280755": {},
           "f63e75fd-94ca-4997-b9a0-d52d6de244d7": {},
-          "ebaddfe7-cf07-4398-ac01-2c8eff026c18": {
-              "settings": {
-                  "styles": {
-                      "xl": {
-                          "pictureImagesArray": [
-                              {
-                                  "image": ""
-                              }
-                          ]
-                      }
-                  }
-              }
-          },
           "482b0e53-ab1e-4da1-bc85-93ffcbeeb23c": {},
           "7bb6f75d-2d5d-4d0b-93c7-365182a90747": {
               "settings": {
@@ -2863,16 +2727,12 @@ json_values: |
           "edc64daa-0883-4152-a402-9b10f837b395": {},
           "061ff893-3c6e-463c-a887-0f9264b9a5f2": {},
           "55842c8a-5f87-45d1-a45b-5e80a00175f9": {},
-          "6fdb5310-c132-4764-b854-ef468e72277a": {}
+          "6fdb5310-c132-4764-b854-ef468e72277a": {},
+          "8bb79035-3819-44ae-bf09-64f8360adcfc": {}
       },
       "variableFields": {
           "8252cc36-94ed-4234-a982-8b50c7280755": [],
           "f63e75fd-94ca-4997-b9a0-d52d6de244d7": [],
-          "ebaddfe7-cf07-4398-ac01-2c8eff026c18": [
-              "settings.attributes.title",
-              "settings.attributes.alt",
-              "settings.styles.xl.pictureImagesArray.0.image"
-          ],
           "482b0e53-ab1e-4da1-bc85-93ffcbeeb23c": [],
           "7bb6f75d-2d5d-4d0b-93c7-365182a90747": [
               "settings.linkText",
@@ -2890,7 +2750,8 @@ json_values: |
           "edc64daa-0883-4152-a402-9b10f837b395": [],
           "061ff893-3c6e-463c-a887-0f9264b9a5f2": [],
           "55842c8a-5f87-45d1-a45b-5e80a00175f9": [],
-          "6fdb5310-c132-4764-b854-ef468e72277a": []
+          "6fdb5310-c132-4764-b854-ef468e72277a": [],
+          "8bb79035-3819-44ae-bf09-64f8360adcfc": []
       },
       "meta": {
           "fieldHistory": []


### PR DESCRIPTION
**Motivation**
Fixes #ACMS-1389

**Proposed changes**
- Rewrite Image field to include DAM media.
- Updated content type templates for Article, Person, Place, Event, Page for Media(CORE, DAM).
- Added new view mode 'Referenced Image' for Place and Person content type.
- Updated Article, Event Site studio templates, default view mode.
- Added update hook to update view mode for Article, Event, Person, Place.

**Alternatives considered**
NA

**Testing steps**
- Use this branch
- Install site using acms site:install
- Install ACMS DAM module drush in acquia_cms_dam
- Login into application
- Create node using any content type
- Select DAM media for image in first node
- Select CORE media for image in second node
- Verify images rendering fine on both nodes

**Merge requirements**
- [ ] _Major change_, _Minor change_, _Bug_, _Enhancement_, and/or _Chore_ label applied
- [ ] Manual testing by a reviewer
