### PR TITLE
ACMS-1272: Enable modules in a batch when enabling starter kits via Cloud UI and Site Factory UI

### DIFF
--- a/modules/acquia_cms_search/composer.json
+++ b/modules/acquia_cms_search/composer.json
@@ -32,7 +32,8 @@
                 "3259123 - ViewsDisplayBase::isRenderedInCurrentRequest() doesn't let the facet link to reset to original URL": "https://www.drupal.org/files/issues/2022-01-18/3259123-search-facet-reset-link.patch"
             },
             "drupal/search_api": {
-                "3236696 - Call to a member function preExecute() on null in SearchApiTagCache->alterCacheMetadata()": "https://www.drupal.org/files/issues/2022-08-02/3236696-5.patch"
+                "3236696 - Call to a member function preExecute() on null in SearchApiTagCache->alterCacheMetadata()": "https://www.drupal.org/files/issues/2022-08-02/3236696-5.patch",
+                "3151796 - Problems when executing Search API tasks during install, updates": "https://www.drupal.org/files/issues/2022-11-04/search_api-3151796-division-by-zero-error-7.patch"
             }
         }
     },

--- a/modules/acquia_cms_tour/src/Form/StarterKitSelectionWizardForm.php
+++ b/modules/acquia_cms_tour/src/Form/StarterKitSelectionWizardForm.php
@@ -332,7 +332,6 @@ class StarterKitSelectionWizardForm extends FormBase {
     $formController = $this->getCurrentFormController()['class'];
     $this->classResolver->getInstanceFromDefinition($formController)->submitForm($form, $form_state);
     $this->state->set('starter_kit_wizard_step', 'completed');
-    $this->messenger()->addStatus($this->t('The configuration options have been saved.'));
     $form_state->setRedirect('acquia_cms_tour.enabled_modules');
   }
 

--- a/modules/acquia_cms_tour/src/Plugin/AcquiaCmsStarterKit/StarterKitConfigForm.php
+++ b/modules/acquia_cms_tour/src/Plugin/AcquiaCmsStarterKit/StarterKitConfigForm.php
@@ -189,25 +189,34 @@ class StarterKitConfigForm extends AcquiaCmsStarterKitBase {
    * {@inheritdoc}
    */
   public function submitForm(array &$form, FormStateInterface $form_state) {
+    $starter_kits = [
+      'acquia_cms_enterprise_low_code' => 'Acquia CMS Enterprise low-code',
+      'acquia_cms_community' => 'Acquia CMS Community',
+      'acquia_cms_headless' => 'Acquia CMS Headless',
+    ];
     $starter_kit_demo = $form_state->getValue(['demo']) ?? 'No';
     $starter_kit_content_model = $form_state->getValue(['content_model']) ?? 'No';
     if ($starter_kit_demo && $starter_kit_content_model) {
       $this->state->set('acquia_cms.starter_kit_demo', $starter_kit_demo);
       $this->state->set('acquia_cms.starter_kit_content_model', $starter_kit_content_model);
       $this->state->set('acquia_cms_tour_staretr_kit_demo_progress', TRUE);
-      $this->messenger()->addStatus('The configuration options have been saved.');
+      $this->messenger()->addStatus($this->t('The configuration options have been saved.'));
     }
     $starter_kit = $this->state->get('acquia_cms.starter_kit');
     $service = \Drupal::service('acquia_cms_tour.starter_kit');
-    $missingModules = $service->getMissingModules($starter_kit, $starter_kit_demo, $starter_kit_content_model);
-    if (!$missingModules) {
+    $missing_modules = $service->getMissingModules($starter_kit, $starter_kit_demo, $starter_kit_content_model);
+    if (!$missing_modules) {
       $this->state->set('show_starter_kit_modal', FALSE);
       $this->state->set('starter_kit_wizard_completed', TRUE);
       $service->enableModules($starter_kit, $starter_kit_demo, $starter_kit_content_model);
-      $this->messenger()->addStatus('The required starter kit has been installed. Also, the related modules & themes have been enabled.');
+      $this->messenger()->addStatus($this->t('The %starter_kit starter kit has been installed. Also, the related modules & themes have been enabled.', [
+        '%starter_kit' => $starter_kits[$starter_kit],
+      ]));
     }
     else {
-      $this->messenger()->addStatus("It seems that the following modules are missing from the codebase. We suggest running the below command to add the missing modules and visiting this page again. Use 'composer require -W {$missingModules}'");
+      $this->messenger()->addStatus($this->t("It seems that the following modules are missing from the codebase. We suggest running the below command to add the missing modules and visiting this page again. Use 'composer require -W %missing_modules'", [
+        '%missing_modules' => $missing_modules,
+      ]));
     }
     // Update state.
     $this->setConfigurationState();

--- a/modules/acquia_cms_tour/src/Plugin/AcquiaCmsStarterKit/StarterKitConfigForm.php
+++ b/modules/acquia_cms_tour/src/Plugin/AcquiaCmsStarterKit/StarterKitConfigForm.php
@@ -3,6 +3,7 @@
 namespace Drupal\acquia_cms_tour\Plugin\AcquiaCmsStarterKit;
 
 use Drupal\acquia_cms_tour\Form\AcquiaCmsStarterKitBase;
+use Drupal\acquia_cms_tour\Services\StarterKitService;
 use Drupal\Component\Render\FormattableMarkup;
 use Drupal\Core\Form\FormStateInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
@@ -26,11 +27,20 @@ class StarterKitConfigForm extends AcquiaCmsStarterKitBase {
   protected $formName = 'acquia_cms_starter_kit_config';
 
   /**
+   * Starterkit service.
+   *
+   * @var Drupal\acquia_cms_tour\Services\StarterKitService
+   */
+  protected StarterKitService $starterKitService;
+
+  /**
    * {@inheritdoc}
    */
   public static function create(ContainerInterface $container) {
     /** @var static $instance */
     $instance = parent::create($container);
+    $instance->starterKitService = $container->get('acquia_cms_tour.starter_kit');
+
     return $instance;
   }
 
@@ -49,12 +59,11 @@ class StarterKitConfigForm extends AcquiaCmsStarterKitBase {
     // different features (Site Studio and Place nodes). Site Studio is always
     // enabled in ACMS, but Place may not.
     // Initialize an empty array.
-    $service = \Drupal::service('acquia_cms_tour.starter_kit');
     $starter_kit = $this->state->get('acquia_cms.starter_kit');
     $starterKit = [
-      'acquia_cms_demo_content' => $service->getMissingModules($starter_kit, 'Yes', 'No'),
-      'acquia_cms_content_model' => $service->getMissingModules($starter_kit, 'No', 'Yes'),
-      'acquia_cms_starter_kit_only' => $service->getMissingModules($starter_kit, 'No', 'No'),
+      'acquia_cms_demo_content' => $this->starterKitService->getMissingModules($starter_kit, 'Yes', 'No'),
+      'acquia_cms_content_model' => $this->starterKitService->getMissingModules($starter_kit, 'No', 'Yes'),
+      'acquia_cms_starter_kit_only' => $this->starterKitService->getMissingModules($starter_kit, 'No', 'No'),
     ];
     $formName = $this->formName;
     $form[$formName] = [
@@ -109,7 +118,7 @@ class StarterKitConfigForm extends AcquiaCmsStarterKitBase {
         '@message @missingModules </i></b></p></div>',
         [
           '@message' => $formattedMessage,
-          '@missingModules' => $service->getMissingModulesCommand($starterKit['acquia_cms_demo_content']),
+          '@missingModules' => $this->starterKitService->getMissingModulesCommand($starterKit['acquia_cms_demo_content']),
         ]
       );
       $form[$formName]['requirement_message_demo_content'] = [
@@ -128,7 +137,7 @@ class StarterKitConfigForm extends AcquiaCmsStarterKitBase {
         '@message @missingModules </i></b></p></div>',
         [
           '@message' => $formattedMessage,
-          '@missingModules' => $service->getMissingModulesCommand($starterKit['acquia_cms_demo_content']),
+          '@missingModules' => $this->starterKitService->getMissingModulesCommand($starterKit['acquia_cms_demo_content']),
         ]
       );
       $form[$formName]['requirement_message_demo_no_content_model'] = [
@@ -147,7 +156,7 @@ class StarterKitConfigForm extends AcquiaCmsStarterKitBase {
         '@message @missingModules </i></b></p></div>',
         [
           '@message' => $formattedMessage,
-          '@missingModules' => $service->getMissingModulesCommand($starterKit['acquia_cms_content_model']),
+          '@missingModules' => $this->starterKitService->getMissingModulesCommand($starterKit['acquia_cms_content_model']),
         ]
       );
       $form[$formName]['requirement_message_content_model'] = [
@@ -166,7 +175,7 @@ class StarterKitConfigForm extends AcquiaCmsStarterKitBase {
         '@message @missingModules </i></b></p></div>',
         [
           '@message' => $formattedMessage,
-          '@missingModules' => $service->getMissingModulesCommand($starterKit['acquia_cms_starter_kit_only']),
+          '@missingModules' => $this->starterKitService->getMissingModulesCommand($starterKit['acquia_cms_starter_kit_only']),
         ]
       );
       $form[$formName]['requirement_message_starter_kit_only'] = [
@@ -203,12 +212,11 @@ class StarterKitConfigForm extends AcquiaCmsStarterKitBase {
       $this->messenger()->addStatus($this->t('The configuration options have been saved.'));
     }
     $starter_kit = $this->state->get('acquia_cms.starter_kit');
-    $service = \Drupal::service('acquia_cms_tour.starter_kit');
-    $missing_modules = $service->getMissingModules($starter_kit, $starter_kit_demo, $starter_kit_content_model);
+    $missing_modules = $this->starterKitService->getMissingModules($starter_kit, $starter_kit_demo, $starter_kit_content_model);
     if (!$missing_modules) {
       $this->state->set('show_starter_kit_modal', FALSE);
       $this->state->set('starter_kit_wizard_completed', TRUE);
-      $service->enableModules($starter_kit, $starter_kit_demo, $starter_kit_content_model);
+      $this->starterKitService->enableModules($starter_kit, $starter_kit_demo, $starter_kit_content_model);
       $this->messenger()->addStatus($this->t('The %starter_kit starter kit has been installed. Also, the related modules & themes have been enabled.', [
         '%starter_kit' => $starter_kits[$starter_kit],
       ]));

--- a/modules/acquia_cms_tour/src/Services/StarterKitService.php
+++ b/modules/acquia_cms_tour/src/Services/StarterKitService.php
@@ -6,11 +6,14 @@ use Drupal\Core\Config\ConfigFactoryInterface;
 use Drupal\Core\Extension\ModuleExtensionList;
 use Drupal\Core\Extension\ModuleInstallerInterface;
 use Drupal\Core\Extension\ThemeInstallerInterface;
+use Drupal\Core\StringTranslation\StringTranslationTrait;
 
 /**
  * Defines a service that toggle modules based on environment.
  */
 class StarterKitService {
+
+  use StringTranslationTrait;
 
   /**
    * The module installer.
@@ -74,10 +77,38 @@ class StarterKitService {
    *   Variable holding the content model option selected.
    */
   public function enableModules(string $starter_kit, string $demo_question = NULL, string $content_model = NULL) {
+    $starter_kits = [
+      'acquia_cms_enterprise_low_code' => 'Acquia CMS Enterprise low-code',
+      'acquia_cms_community' => 'Acquia CMS Community',
+      'acquia_cms_headless' => 'Acquia CMS Headless',
+    ];
+    $batch = [
+      'title' => $this->t('Installing @starterkit', ['@starterkit' => $starter_kits[$starter_kit]]),
+      'operations' => [],
+      'init_message' => $this->t('Process is starting.'),
+      'progress_message' => $this->t('Processed @current out of @total. Estimated time: @estimate.'),
+      'error_message' => $this->t('The process has encountered an error....'),
+    ];
     $modulesAndThemes = $this->getModulesAndThemes($starter_kit, $demo_question, $content_model);
-    if (!empty($modulesAndThemes['enableModules'])) {
-      $this->moduleInstaller->install($modulesAndThemes['enableModules']);
+    if ($starter_kit == 'acquia_cms_enterprise_low_code') {
+      foreach ($modulesAndThemes['enableModules'] as $key => $module) {
+        if ($module == 'acquia_cms_site_studio') {
+          unset($modulesAndThemes['enableModules'][$key]);
+        }
+      }
+      $modulesAndThemes['enableModules'][] = 'acquia_cms_site_studio';
     }
+    if (!empty($modulesAndThemes['enableModules'])) {
+      foreach ($modulesAndThemes['enableModules'] as $module) {
+        $batch['operations'][] = [
+          '\Drupal\acquia_cms_tour\Services\StarterKitService::enableSingleModule',
+          [$module],
+        ];
+      }
+    }
+    batch_set($batch);
+    $batch =& batch_get();
+    // $batch['progressive'] = FALSE;
     foreach ($modulesAndThemes['enableThemes'] as $theme) {
       $this->themeInstaller->install([$theme]);
     }
@@ -89,6 +120,16 @@ class StarterKitService {
       ->getEditable('system.theme')
       ->set('admin', $modulesAndThemes['enableThemes']['admin'])
       ->save();
+  }
+
+  /**
+   * Handler for enabling modules.
+   *
+   * @param string $module
+   *   Variable holding the module name.
+   */
+  public static function enableSingleModule(string $module) {
+    \Drupal::service('module_installer')->install([$module]);
   }
 
   /**
@@ -159,12 +200,12 @@ class StarterKitService {
         $enableModules, ['acquia_cms_starter'],
       );
     }
-    elseif ($content_model == 'Yes') {
+    if ($content_model == 'Yes') {
       $enableModules = array_merge(
         $enableModules, [
           'acquia_cms_article',
-          'acquia_cms_page',
           'acquia_cms_event',
+          'acquia_cms_page',
         ],
       );
     }


### PR DESCRIPTION
**Motivation**
Fixes #ACMS-1272

**Proposed changes**
Enable modules in batch when enabling via UI using starterkit.

**Alternatives considered**
NA

**Testing steps**
- Use this branch.
- Install site `drush si minimal`
- Install tour module `drush in acquia_cms_tour`
- Login into application and head towards `/admin/tour/dashboard`
- Click on `Starter kit set-up`
- Select starter kit click on next
- Select Demo content or content model click on complete
- It should start batch and install modules
- Verify site working fine, all modules installed successfully.

**Merge requirements**
- [ ] _Major change_, _Minor change_, _Bug_, _Enhancement_, and/or _Chore_ label applied
- [ ] Manual testing by a reviewer
