### PR TITLE
ACMS-1500: Added modules uninstall validator for site studio packages.

### DIFF
--- a/modules/acquia_cms_common/acquia_cms_common.services.yml
+++ b/modules/acquia_cms_common/acquia_cms_common.services.yml
@@ -6,7 +6,9 @@ services:
 
   acquia_cms_common.event_subscriber:
     class: '\Drupal\acquia_cms_common\EventSubscriber\ConfigEventsSubscriber'
-    arguments: ['@module_handler', '@acquia_cms_common.utility']
+    arguments:
+      - '@module_handler'
+      - '@acquia_cms_common.utility'
     tags:
       - { name: 'event_subscriber' }
 
@@ -15,17 +17,27 @@ services:
 
   acquia_cms_common.utility:
     class:  Drupal\acquia_cms_common\Services\AcmsUtilityService
-    arguments: ['@module_handler', '@config.factory', '@state']
+    arguments:
+      - '@module_handler'
+      - '@config.factory'
+      - '@state'
 
   acquia_cms_common.uninstall_validator:
     class: Drupal\acquia_cms_common\AcmsModulesUninstallValidator
     tags:
       - { name: module_install.uninstall_validator }
-    arguments: ['@entity_type.manager', '@string_translation', '@module_handler']
+    arguments:
+      - '@entity_type.manager'
+      - '@string_translation'
+      - '@module_handler'
+      - '@config.factory'
     lazy: true
 
   acquia_cms_common.https_redirect_subscriber:
     class: '\Drupal\acquia_cms_common\EventSubscriber\HttpsRedirectSubscriber'
-    arguments: ['@config.factory', '@cache.config', '@request_stack']
+    arguments:
+      - '@config.factory'
+      - '@cache.config'
+      - '@request_stack'
     tags:
       - { name: 'event_subscriber' }

--- a/modules/acquia_cms_common/acquia_cms_common.services.yml
+++ b/modules/acquia_cms_common/acquia_cms_common.services.yml
@@ -21,7 +21,7 @@ services:
     class: Drupal\acquia_cms_common\AcmsModulesUninstallValidator
     tags:
       - { name: module_install.uninstall_validator }
-    arguments: ['@entity_type.manager', '@string_translation']
+    arguments: ['@entity_type.manager', '@string_translation', '@module_handler']
     lazy: true
 
   acquia_cms_common.https_redirect_subscriber:

--- a/modules/acquia_cms_common/src/AcmsModulesUninstallValidator.php
+++ b/modules/acquia_cms_common/src/AcmsModulesUninstallValidator.php
@@ -3,6 +3,7 @@
 namespace Drupal\acquia_cms_common;
 
 use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\Extension\ModuleHandlerInterface;
 use Drupal\Core\Extension\ModuleUninstallValidatorInterface;
 use Drupal\Core\StringTranslation\StringTranslationTrait;
 use Drupal\Core\StringTranslation\TranslationInterface;
@@ -22,16 +23,29 @@ class AcmsModulesUninstallValidator implements ModuleUninstallValidatorInterface
   protected $entityTypeManager;
 
   /**
+   * The module handler.
+   *
+   * @var \Drupal\Core\Extension\ModuleHandlerInterface
+   */
+  protected $moduleHandler;
+
+  /**
    * Constructs a new AcmsModulesUninstallValidator.
    *
    * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager
    *   The entity type manager service.
    * @param \Drupal\Core\StringTranslation\TranslationInterface $string_translation
    *   The string translation service.
+   * @param \Drupal\Core\Extension\ModuleHandlerInterface $module_handler
+   *   The module handler.
    */
-  public function __construct(EntityTypeManagerInterface $entity_type_manager, TranslationInterface $string_translation) {
+  public function __construct(
+    EntityTypeManagerInterface $entity_type_manager,
+    TranslationInterface $string_translation,
+    ModuleHandlerInterface $module_handler) {
     $this->entityTypeManager = $entity_type_manager;
     $this->stringTranslation = $string_translation;
+    $this->moduleHandler = $module_handler;
   }
 
   /**
@@ -65,6 +79,24 @@ class AcmsModulesUninstallValidator implements ModuleUninstallValidatorInterface
     elseif ($module == 'acquia_cms_starter'  && $type = $this->hasMediaAndContent()) {
       $reasons[] = $this->t('There are content/media available for type [@type], please manually delete content before uninstallation.', [
         '@type' => $type,
+      ]);
+    }
+    $sitestudio_modules = [
+      'acquia_cms_article',
+      'acquia_cms_event',
+      'acquia_cms_image',
+      'acquia_cms_page',
+      'acquia_cms_person',
+      'acquia_cms_place',
+      'acquia_cms_search',
+      'acquia_cms_site_studio',
+      'acquia_cms_video',
+    ];
+    if ($this->moduleHandler->moduleExists('acquia_cms_site_studio') &&
+    in_array($module, $sitestudio_modules) &&
+    $this->hasSiteStudioPackage($module)) {
+      $reasons[] = $this->t('There are site studio package available for module [@module], please manually delete package before uninstallation.', [
+        '@module' => $module,
       ]);
     }
     return $reasons;
@@ -136,6 +168,72 @@ class AcmsModulesUninstallValidator implements ModuleUninstallValidatorInterface
         ->condition('bundle', $media_type)
         ->execute();
       return (bool) $media;
+    }
+    return FALSE;
+  }
+
+  /**
+   * Check if media with certain type is available.
+   *
+   * @param string $module
+   *   The media type.
+   *
+   * @return bool
+   *   The status of data available for certain node type.
+   *
+   * @throws \Drupal\Component\Plugin\Exception\InvalidPluginDefinitionException
+   * @throws \Drupal\Component\Plugin\Exception\PluginNotFoundException
+   */
+  protected function hasSiteStudioPackage(string $module): bool {
+    if ($module) {
+      $packages = $config = [];
+      switch ($module) {
+        case 'acquia_cms_article':
+          $packages = ['pack_acquia_cms_article'];
+          break;
+
+        case 'acquia_cms_event':
+          $packages = ['pack_acquia_cms_event'];
+          break;
+
+        case 'acquia_cms_image':
+          $packages = [
+            'pack_acquia_cms_image',
+            'pack_acquia_cms_core_image',
+          ];
+          break;
+
+        case 'acquia_cms_page':
+          $packages = ['pack_acquia_cms_page'];
+          break;
+
+        case 'acquia_cms_person':
+          $packages = ['pack_acquia_cms_person'];
+          break;
+
+        case 'acquia_cms_place':
+          $packages = ['pack_acquia_cms_place'];
+          break;
+
+        case 'acquia_cms_search':
+          $packages = [
+            'pack_acquia_cms_search',
+            'pack_acquia_cms_search_content',
+          ];
+          break;
+
+        case 'acquia_cms_site_studio':
+          $packages = ['pack_acquia_cms_core'];
+          break;
+
+        case 'acquia_cms_video':
+          $packages = ['pack_acquia_cms_video'];
+          break;
+      }
+      foreach ($packages as $package) {
+        $config = \Drupal::configFactory()->getEditable($package);
+      }
+      return (bool) $config;
     }
     return FALSE;
   }

--- a/modules/acquia_cms_common/src/AcmsModulesUninstallValidator.php
+++ b/modules/acquia_cms_common/src/AcmsModulesUninstallValidator.php
@@ -2,6 +2,7 @@
 
 namespace Drupal\acquia_cms_common;
 
+use Drupal\Core\Config\ConfigFactoryInterface;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Extension\ModuleHandlerInterface;
 use Drupal\Core\Extension\ModuleUninstallValidatorInterface;
@@ -30,6 +31,13 @@ class AcmsModulesUninstallValidator implements ModuleUninstallValidatorInterface
   protected $moduleHandler;
 
   /**
+   * The config factory service object.
+   *
+   * @var \Drupal\Core\Config\ConfigFactoryInterface
+   */
+  protected $configFactory;
+
+  /**
    * Constructs a new AcmsModulesUninstallValidator.
    *
    * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager
@@ -38,14 +46,18 @@ class AcmsModulesUninstallValidator implements ModuleUninstallValidatorInterface
    *   The string translation service.
    * @param \Drupal\Core\Extension\ModuleHandlerInterface $module_handler
    *   The module handler.
+   * @param \Drupal\Core\Config\ConfigFactoryInterface $config_factory
+   *   The config factory.
    */
   public function __construct(
     EntityTypeManagerInterface $entity_type_manager,
     TranslationInterface $string_translation,
-    ModuleHandlerInterface $module_handler) {
+    ModuleHandlerInterface $module_handler,
+    ConfigFactoryInterface $config_factory) {
     $this->entityTypeManager = $entity_type_manager;
     $this->stringTranslation = $string_translation;
     $this->moduleHandler = $module_handler;
+    $this->configFactory = $config_factory;
   }
 
   /**
@@ -186,53 +198,45 @@ class AcmsModulesUninstallValidator implements ModuleUninstallValidatorInterface
    */
   protected function hasSiteStudioPackage(string $module): bool {
     if ($module) {
-      $packages = $config = [];
+      $package = $config = [];
       switch ($module) {
         case 'acquia_cms_article':
-          $packages = ['pack_acquia_cms_article'];
+          $package = 'pack_acquia_cms_article';
           break;
 
         case 'acquia_cms_event':
-          $packages = ['pack_acquia_cms_event'];
+          $package = 'pack_acquia_cms_event';
           break;
 
         case 'acquia_cms_image':
-          $packages = [
-            'pack_acquia_cms_image',
-            'pack_acquia_cms_core_image',
-          ];
+          $package = 'pack_acquia_cms_image';
           break;
 
         case 'acquia_cms_page':
-          $packages = ['pack_acquia_cms_page'];
+          $package = 'pack_acquia_cms_page';
           break;
 
         case 'acquia_cms_person':
-          $packages = ['pack_acquia_cms_person'];
+          $package = 'pack_acquia_cms_person';
           break;
 
         case 'acquia_cms_place':
-          $packages = ['pack_acquia_cms_place'];
+          $package = 'pack_acquia_cms_place';
           break;
 
         case 'acquia_cms_search':
-          $packages = [
-            'pack_acquia_cms_search',
-            'pack_acquia_cms_search_content',
-          ];
+          $package = 'pack_acquia_cms_search';
           break;
 
         case 'acquia_cms_site_studio':
-          $packages = ['pack_acquia_cms_core'];
+          $package = 'pack_acquia_cms_core';
           break;
 
         case 'acquia_cms_video':
-          $packages = ['pack_acquia_cms_video'];
+          $package = 'pack_acquia_cms_video';
           break;
       }
-      foreach ($packages as $package) {
-        $config = \Drupal::configFactory()->getEditable($package);
-      }
+      $config = $this->configFactory->getEditable('cohesion_sync.cohesion_sync_package.' . $package)->get('id');
       return (bool) $config;
     }
     return FALSE;


### PR DESCRIPTION
**Motivation**
Fixes #ACMS-1500

**Proposed changes**
Validate site studio packages deleted before uninstalling the module.

**Alternatives considered**
NA

**Testing steps**
- Install site with this code
- Install site studio module import packages
- Now try to uninstall any module having site studio package.
- It should give warning.
- Verify site.

**Merge requirements**
- [ ] _Major change_, _Minor change_, _Bug_, _Enhancement_, and/or _Chore_ label applied
- [ ] Manual testing by a reviewer
