### PR TITLE
ACMS-1555: Fixing null deprecations for site studio 6.9.x

### DIFF
--- a/modules/acquia_cms_site_studio/composer.json
+++ b/modules/acquia_cms_site_studio/composer.json
@@ -32,6 +32,7 @@
         "patches": {
             "acquia/cohesion": {
                 "Deprecation: Element, ElementModel & layoutCanvas return type issue fix": "https://gist.githubusercontent.com/alpha1892/e4becafe31597ac58563fb3219e48da6/raw/94ddcbab1fad39b215deb3159875684396781467/cohesion-jsonserialize-deprecation.patch",
+                "Deprecation: Null deprecations fixes for site studio 6.9.x": "https://gist.githubusercontent.com/alpha1892/3e69a771cfc6f22ce6d85a9318e5641c/raw/6547769e1b2859f0e0fb9d8b72a4803899a74cd6/cohesion-null-deprecations.patch",
                 "Error: Attempt to modify property 'styles' on array": "https://gist.githubusercontent.com/panshulK/86e53ac29386142b4204ab885018b36c/raw/c05e9c959cd8102534ccc1923809f90bc735785c/site-studio-updated-style.patch",
                 "Error: Must be type of array 'null' given in array_walk_recursive()": "https://gist.githubusercontent.com/alpha1892/bad7c337f0806ddaeb01be594fbc7405/raw/ef18ec4da7125f051099a8e8a84fa5bb015cc75e/cohesion-GoogleMapApiKeyForm.patch",
                 "Site Studio: Allow optional packages to import": "https://gist.githubusercontent.com/vishalkhode1/9a78437024d87b824fa3e54219b099a5/raw/316583e3291c6ae50175478cf772c85d327cb6d3/site-studio-allow-optional-packages.patch"


### PR DESCRIPTION
**Motivation**
<!-- What problem does this solve? Why is it important? What's the context? If this fixes an issue, link to it above. -->
Fixes ACMS-1555

**Proposed changes**
Update the patch to fix the null deprecations warnings.

**Testing steps**

- Add a page content type
- Add a component from site studio.


