### PR TITLE
ACMS-1420: Updated entity update hook for site studio custom style to support 6.9 and 7.0

### DIFF
--- a/modules/acquia_cms_common/composer.json
+++ b/modules/acquia_cms_common/composer.json
@@ -92,8 +92,8 @@
             },
             "drupal/core": {
                 "3059955 - It is possible to overflow the number of items allowed in Media Library": "https://www.drupal.org/files/issues/2019-12-28/3082690-80.patch",
-                "3301692: Passing null to parameter to mb_strtolower() is deprecated with PHP 8.1": "https://git.drupalcode.org/project/drupal/-/merge_requests/2598.patch",
                 "3222107 - jQuery UI library order is incorrect when a large number of javascript files is loaded between two jQuery UI libraries": "https://www.drupal.org/files/issues/2022-11-11/3222107-2.patch",
+                "3301692: Passing null to parameter to mb_strtolower() is deprecated with PHP 8.1": "https://git.drupalcode.org/project/drupal/-/merge_requests/2598.patch",
                 "REMOVE: Allow installation profile to be changed from Acquia CMS to minimal during config sync": "https://gist.githubusercontent.com/rajeshreeputra/ae198ea15a2584f00de3327067056fe0/raw/3d69baaa16bfcc7b2af41deef102eaebd4291906/profile-change-acms-to-minimal.patch"
             },
             "drupal/default_content": {

--- a/modules/acquia_cms_site_studio/config/pack_acquia_cms_core/cohesion_custom_styles.cohesion_custom_style.b2c36087.yml
+++ b/modules/acquia_cms_site_studio/config/pack_acquia_cms_core/cohesion_custom_styles.cohesion_custom_style.b2c36087.yml
@@ -1630,7 +1630,7 @@ json_mapper: |
           "form": null
       }
   }
-last_entity_update: entityupdate_0041
+last_entity_update: entityupdate_0036
 locked: false
 modified: true
 selectable: true


### PR DESCRIPTION
**Motivation**
Fixes #ACMS-1420

**Proposed changes**
updated entity update hook in site studio config to support 6.9 and 7.0

**Alternatives considered**
NA

**Testing steps**
Install site with this branch and verify it works with site studio 6.9 and 7.0 both versions.

**Merge requirements**
- [ ] _Major change_, _Minor change_, _Bug_, _Enhancement_, and/or _Chore_ label applied
- [ ] Manual testing by a reviewer
