### PR TITLE
ACMS-1590: ACMS D10 Regression testing - Isolated Test - chartjs library not found issue fix.

### DIFF
--- a/modules/acquia_cms_common/composer.json
+++ b/modules/acquia_cms_common/composer.json
@@ -46,7 +46,8 @@
         "drupal/smart_trim": "^2.0",
         "drupal/social_media_links": "^2.7",
         "drupal/username_enumeration_prevention": "dev-3269921-drupal-10-compatibility",
-        "drupal/workbench_email": "^2.3"
+        "drupal/workbench_email": "^2.3",
+        "nnnick/chartjs": "^3.9"
     },
     "conflict": {
         "drupal/acquia_cms_article": "<1.4",
@@ -105,6 +106,18 @@
         }
     },
     "repositories": {
+        "chart.js": {
+            "type": "package",
+            "package": {
+                "name": "nnnick/chartjs",
+                "version": "v3.9.1",
+                "type": "drupal-library",
+                "dist": {
+                    "url": "https://github.com/chartjs/Chart.js/releases/download/v3.9.1/chart.js-3.9.1.tgz",
+                    "type": "tar"
+                }
+            }
+        },
         "drupal": {
             "type": "composer",
             "url": "https://packages.drupal.org/8",


### PR DESCRIPTION
**Motivation**
Fixes #ACMS-1590

**Proposed changes**
added nnnick/chartjs library requirement in acquia_cms_common modules composer.json file.

**Alternatives considered**
NA

**Testing steps**
- checkout ACMS-1590 branch
- execute composer install command
- verify that nnnick/chartjs library is getting downloaded and present in docroot/librarie.

**Merge requirements**
- [ ] _Major change_, _Minor change_, _Bug_, _Enhancement_, and/or _Chore_ label applied
- [ ] Manual testing by a reviewer
