### PR TITLE
Remove swagger-api/swagger-ui

### DIFF
--- a/modules/acquia_cms_headless/composer.json
+++ b/modules/acquia_cms_headless/composer.json
@@ -10,8 +10,7 @@
         "drupal/openapi_jsonapi": "^3.0",
         "drupal/openapi_ui_redoc": "^1.0",
         "drupal/openapi_ui_swagger": "1.x-dev#e2db6e53",
-        "drupal/restui": "^1.21",
-        "swagger-api/swagger-ui": "^3.0.17"
+        "drupal/restui": "^1.21"
     },
     "conflict": {
         "drupal/decoupled_router": "<2.0.4",


### PR DESCRIPTION
Removed swagger-api/swagger-ui as this is already included in openapi_ui_swagger module.

**Motivation**
Redundancy in swagger-api/swagger-ui

**Proposed changes**
Removal of swagger-api/swagger-ui from acquia_cms_headless composer.json file
