### PR TITLE
ACMS-1641: Remove deprecated jquery.once from acquia_cms_tour module.

### DIFF
--- a/modules/acquia_cms_tour/acquia_cms_tour.libraries.yml
+++ b/modules/acquia_cms_tour/acquia_cms_tour.libraries.yml
@@ -12,5 +12,6 @@ acquia_cms_tour_dashboard:
     js/acquia_cms_tour_dashboard.js: {}
   dependencies:
     - core/jquery #Just to be safe
+    - core/once #Just to be safe
     - core/drupal.dialog.ajax #Required for dialogs
     - core/drupalSettings #for drupalSettings

--- a/modules/acquia_cms_tour/js/acquia_cms_tour_dashboard.js
+++ b/modules/acquia_cms_tour/js/acquia_cms_tour_dashboard.js
@@ -4,12 +4,12 @@
  * Contains client-side support code for Acquia CMS's dashboard page.
  */
 
- (function ($, Drupal) {
+ (function ($, Drupal, once) {
   // Override the throbber icon.
   Drupal.theme.ajaxProgressThrobber = function () { return ""; };
   Drupal.behaviors.acquiaCmsDashboardDialog = {
     attach: function (context, settings) {
-      $('.acms-dashboard-form-wrapper', context).once('acquiaCmsDashboardDialog').each(function () {
+      $(once('acquiaCmsDashboardDialog','.acms-dashboard-form-wrapper',context)).each(function () {
         if (!settings.existing_site_acquia_cms && !settings.hide_starter_kit_wizard_modal && !settings.selected_starter_kit && settings.show_starter_kit_modal) {
           $('.acms-starterkit-modal-form').click();
         }
@@ -27,4 +27,4 @@
       });
     }
   }
-})(jQuery, Drupal);
+})(jQuery, Drupal, once);


### PR DESCRIPTION
**Motivation**
Fixes #ACMS-1641

**Proposed changes**
<!-- What does this PR change? How does this impact end users? Are manual or automatic updates required? -->

**Alternatives considered**
<!-- How else could the original issue / use case be addressed? Why did you choose this solution over any others? -->

**Testing steps**
<!-- How can we replicate the issue and verify that this PR fixes it? -->

**Merge requirements**
- [ ] _Major change_, _Minor change_, _Bug_, _Enhancement_, and/or _Chore_ label applied
- [ ] Manual testing by a reviewer
