### PR TITLE
ACMS-1480: acquia_cms_headless: PHPUnit testcases for Frontpage

### DIFF
--- a/modules/acquia_cms_headless/modules/acquia_cms_headless_ui/tests/src/Functional/HeadlessFrontpageTest.php
+++ b/modules/acquia_cms_headless/modules/acquia_cms_headless_ui/tests/src/Functional/HeadlessFrontpageTest.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Drupal\Tests\acquia_cms_headless_ui\Functional;
+
+use Drupal\Tests\acquia_cms_headless\Functional\HeadlessBrowserTestBase;
+
+/**
+ * Tests for acquia_cms_headless frontpage.
+ *
+ * @group acquia_cms_headless
+ * @group low_risk
+ */
+class HeadlessFrontpageTest extends HeadlessBrowserTestBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected static $modules = [
+    'acquia_cms_headless_ui',
+  ];
+
+  /**
+   * Assert that frontpage for non logged-in user is login page.
+   */
+  public function testFrontPageIsLoginPage(): void {
+    $this->drupalGet('/frontpage');
+    $assert_session = $this->assertSession();
+    $assert_session->elementExists('css', '.user-login-form');
+  }
+
+  /**
+   * Assert that frontpage for logged-in user is admin/content page.
+   */
+  public function testFrontPageIsAdminContentPage(): void {
+    $account = $this->createUser();
+    $account->addRole('administrator');
+    $account->save();
+    $this->drupalLogin($account);
+    $assert_session = $this->assertSession();
+    $assert_session->addressEquals('/admin/content');
+  }
+
+}

--- a/modules/acquia_cms_headless/tests/src/Functional/HeadlessBrowserTestBase.php
+++ b/modules/acquia_cms_headless/tests/src/Functional/HeadlessBrowserTestBase.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Drupal\Tests\acquia_cms_headless\Functional;
+
+use Acquia\DrupalEnvironmentDetector\AcquiaDrupalEnvironmentDetector;
+use Drupal\Tests\BrowserTestBase;
+
+/**
+ * Base class for the HeadlessDashboard Browser tests.
+ */
+class HeadlessBrowserTestBase extends BrowserTestBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected $defaultTheme = 'stark';
+
+  /**
+   * {@inheritdoc}
+   */
+  protected static $modules = [
+    'acquia_cms_headless',
+  ];
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp(): void {
+    // @todo Remove this check when Acquia Cloud IDEs support running functional
+    // JavaScript tests.
+    if (AcquiaDrupalEnvironmentDetector::isAhIdeEnv()) {
+      $this->markTestSkipped('This test cannot run in an Acquia Cloud IDE.');
+    }
+    parent::setUp();
+  }
+
+}


### PR DESCRIPTION
Motivation
Fixes https://github.com/acquia/acquia_cms/pull/1287

Proposed changes
Added test cases for headless installation frontpage checks. The test case checks for the following -
Frontpage is login when user is not authenticated.
Frontpage is content admin page when user logged in with admin.
Frontpage theme is admin theme.