### PR TITLE
ACMS-1643: Replace Gist with drupal.org URL from ACMS Headless.

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -2706,7 +2706,7 @@
             "dist": {
                 "type": "path",
                 "url": "./modules/acquia_cms_headless",
-                "reference": "5460cc4b8e5e3a0b656a50ae801224661c134343"
+                "reference": "b5516e183ba284300782f01589f3e13efd7def34"
             },
             "require": {
                 "drupal/acquia_cms_tour": "2.x-dev",
@@ -2763,7 +2763,7 @@
                         "3111456 - Unable to resolve path on node in other language than default": "https://www.drupal.org/files/issues/2022-11-30/decouple_router-3111456-resolve-language-issue-58.patch"
                     },
                     "drupal/next": {
-                        "Next Module Patch for Preview Button display on unplubshied nodes": "https://gist.githubusercontent.com/lauriii/c3f0308de3ee0807a625404d6b9fe404/raw/3bfbb3e5411cf2795627327336a08fac81419081/next-module-unpublished-preview.patch"
+                        "Add preview button display on unpublished nodes": "https://www.drupal.org/files/issues/2023-02-08/next-module-unpublished-preview-3340189.patch"
                     },
                     "drupal/subrequests": {
                         "Get same results on different request": "https://www.drupal.org/files/issues/2019-07-18/change_request_type-63049395-09.patch"

--- a/modules/acquia_cms_headless/composer.json
+++ b/modules/acquia_cms_headless/composer.json
@@ -67,7 +67,7 @@
                 "3111456 - Unable to resolve path on node in other language than default": "https://www.drupal.org/files/issues/2022-11-30/decouple_router-3111456-resolve-language-issue-58.patch"
             },
             "drupal/next": {
-                "Next Module Patch for Preview Button display on unplubshied nodes": "https://gist.githubusercontent.com/lauriii/c3f0308de3ee0807a625404d6b9fe404/raw/3bfbb3e5411cf2795627327336a08fac81419081/next-module-unpublished-preview.patch"
+                "Add preview button display on unpublished nodes": "https://www.drupal.org/files/issues/2023-02-08/next-module-unpublished-preview-3340189.patch"
             },
             "drupal/subrequests": {
                 "Get same results on different request": "https://www.drupal.org/files/issues/2019-07-18/change_request_type-63049395-09.patch"


### PR DESCRIPTION
**Motivation**
<!-- What problem does this solve? Why is it important? What's the context? If this fixes an issue, link to it above. -->
Fixes #[ACMS-1643](https://backlog.acquia.com/browse/ACMS-1643)

**Proposed changes**
<!-- What does this PR change? How does this impact end users? Are manual or automatic updates required? -->

**Alternatives considered**
<!-- How else could the original issue / use case be addressed? Why did you choose this solution over any others? -->

**Testing steps**
<!-- How can we replicate the issue and verify that this PR fixes it? -->

**Merge requirements**
- [ ] _Major change_, _Minor change_, _Bug_, _Enhancement_, and/or _Chore_ label applied
- [ ] Manual testing by a reviewer
