### PR TITLE
ACMS-1661: Temporary pinning the php-http/discovery library as it's CI is failing with latest release.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,8 @@
         "drupal/acquia_cms_toolbar": "dev-develop",
         "drupal/acquia_cms_tour": "dev-develop",
         "drush/drush": "^10 || ^11",
-        "mnsami/composer-custom-directory-installer": "^2.0"
+        "mnsami/composer-custom-directory-installer": "^2.0",
+        "php-http/discovery": "1.14.3"
     },
     "require-dev": {
         "acquia/coding-standards": "^1.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "c040d478a0f88905648ba69d7f17a059",
+    "content-hash": "88ee2c917199e82fb90653a34b62a6a0",
     "packages": [
         {
             "name": "acquia/acquia-cms-starterkit",


### PR DESCRIPTION
Temporary pinning the php-http/discovery library as it's causing CI to fail.

**Proposed changes**
Pinn the library `php-http/discovery` to previous working version.

**Alternatives considered**
N/A