### PR TITLE
ACMS-0000: Hotfix for backstop CI failure cause of search module.

### DIFF
--- a/modules/acquia_cms_common/modules/acquia_cms_development/config/rewrite/search_api.index.acquia_search_index.yml
+++ b/modules/acquia_cms_common/modules/acquia_cms_development/config/rewrite/search_api.index.acquia_search_index.yml
@@ -1,5 +1,0 @@
-third_party_settings:
-  search_api_solr:
-    multilingual:
-      limit_to_content_language: true
-      include_language_independent: true

--- a/modules/acquia_cms_common/modules/acquia_cms_development/config/rewrite/views.view.acquia_search.yml
+++ b/modules/acquia_cms_common/modules/acquia_cms_development/config/rewrite/views.view.acquia_search.yml
@@ -1,1 +1,0 @@
-status: false


### PR DESCRIPTION
**Motivation**
<!-- What problem does this solve? Why is it important? What's the context? If this fixes an issue, link to it above. -->
Fixes  Hotfix as per release of https://www.drupal.org/project/acquia_search/releases/3.1.6

