### PR TITLE
ACMS-1489: PHPUnit testcases for headless subrequests functionality.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -126,6 +126,10 @@
             },
             "drupal/core": {
                 "3328187 - PHP Deprecated: strpos(): Passing null to parameter #1 ($haystack) of type string is deprecated in docroot/core/lib/Drupal/Core/Mail/Plugin/Mail/PhpMail.php on line 112": "https://git.drupalcode.org/project/drupal/-/merge_requests/3142.patch"
+            },
+            "drupal/decoupled_router": {
+                "3111456 - Unable to resolve path on node in other language than default": "https://www.drupal.org/files/issues/2022-11-30/decouple_router-3111456-resolve-language-issue-58.patch",
+                "3176615 - RouteNotFoundException when a jsonapi individual route is not available": "https://www.drupal.org/files/issues/2023-04-26/route-not-found-exception.patch"
             }
         }
     },

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "da2b9864b6bd706553e7df1780fa393f",
+    "content-hash": "087e5b18e8b7bc57b00cf28dc4618bdb",
     "packages": [
         {
             "name": "acquia/acquia-cms-starterkit",
@@ -2714,7 +2714,7 @@
             "dist": {
                 "type": "path",
                 "url": "./modules/acquia_cms_headless",
-                "reference": "ad4db97721a406f67ff326fc98911cefcaf6156f"
+                "reference": "9e0e4ee4781e56882cab3ef88593ae952adebd7c"
             },
             "require": {
                 "drupal/acquia_cms_tour": "2.x-dev",
@@ -2727,7 +2727,8 @@
             },
             "conflict": {
                 "drupal/consumers": "<1.16",
-                "drupal/decoupled_router": "<2.0.4"
+                "drupal/decoupled_router": "<2.0.4",
+                "drupal/subrequests": "<3.0.7"
             },
             "type": "drupal-module",
             "extra": {
@@ -2768,12 +2769,10 @@
                 },
                 "patches": {
                     "drupal/decoupled_router": {
-                        "3111456 - Unable to resolve path on node in other language than default": "https://www.drupal.org/files/issues/2022-11-30/decouple_router-3111456-resolve-language-issue-58.patch",
-                        "RouteNotFoundException when a jsonapi individual route is not available": "https://gist.githubusercontent.com/chandan-singh7929/b61efa05845d0c578a1c6093ee6b9762/raw/b4f5e48b53696cf490c42e002ffed475fdf51765/RouteNotFoundException.patch"
+                        "3111456 - Unable to resolve path on node in other language than default": "https://www.drupal.org/files/issues/2022-11-30/decouple_router-3111456-resolve-language-issue-58.patch"
                     },
                     "drupal/subrequests": {
-                        "3049395 - Page Cache causes different subrequests to return the same responses": "https://www.drupal.org/files/issues/2019-07-18/change_request_type-63049395-09.patch",
-                        "3338312 - Incompatible with latest versions of symfony/http-foundation": "https://git.drupalcode.org/project/subrequests/-/merge_requests/14.patch"
+                        "3049395 - Page Cache causes different subrequests to return the same responses": "https://www.drupal.org/files/issues/2019-07-18/change_request_type-63049395-09.patch"
                     }
                 }
             },
@@ -8833,17 +8832,17 @@
         },
         {
             "name": "drupal/subrequests",
-            "version": "3.0.6",
+            "version": "3.0.7",
             "source": {
                 "type": "git",
                 "url": "https://git.drupalcode.org/project/subrequests.git",
-                "reference": "3.0.6"
+                "reference": "3.0.7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://ftp.drupal.org/files/projects/subrequests-3.0.6.zip",
-                "reference": "3.0.6",
-                "shasum": "426a4cb77829648e3b67ec15ded57eb4b97a8e78"
+                "url": "https://ftp.drupal.org/files/projects/subrequests-3.0.7.zip",
+                "reference": "3.0.7",
+                "shasum": "f78f5a382583007b8844fc26b9f4ba7b58f9fa3d"
             },
             "require": {
                 "drupal/core": "^8 || ^9 || ^10",
@@ -8855,8 +8854,8 @@
             "type": "drupal-module",
             "extra": {
                 "drupal": {
-                    "version": "3.0.6",
-                    "datestamp": "1664452852",
+                    "version": "3.0.7",
+                    "datestamp": "1682600732",
                     "security-coverage": {
                         "status": "covered",
                         "message": "Covered by Drupal's security advisory policy"

--- a/composer.lock
+++ b/composer.lock
@@ -2714,7 +2714,7 @@
             "dist": {
                 "type": "path",
                 "url": "./modules/acquia_cms_headless",
-                "reference": "03db9df02c964cb60dd491c102abfcc46b06e618"
+                "reference": "ad4db97721a406f67ff326fc98911cefcaf6156f"
             },
             "require": {
                 "drupal/acquia_cms_tour": "2.x-dev",
@@ -2768,7 +2768,8 @@
                 },
                 "patches": {
                     "drupal/decoupled_router": {
-                        "3111456 - Unable to resolve path on node in other language than default": "https://www.drupal.org/files/issues/2022-11-30/decouple_router-3111456-resolve-language-issue-58.patch"
+                        "3111456 - Unable to resolve path on node in other language than default": "https://www.drupal.org/files/issues/2022-11-30/decouple_router-3111456-resolve-language-issue-58.patch",
+                        "RouteNotFoundException when a jsonapi individual route is not available": "https://gist.githubusercontent.com/chandan-singh7929/b61efa05845d0c578a1c6093ee6b9762/raw/b4f5e48b53696cf490c42e002ffed475fdf51765/RouteNotFoundException.patch"
                     },
                     "drupal/subrequests": {
                         "3049395 - Page Cache causes different subrequests to return the same responses": "https://www.drupal.org/files/issues/2019-07-18/change_request_type-63049395-09.patch",

--- a/composer.lock
+++ b/composer.lock
@@ -2714,7 +2714,7 @@
             "dist": {
                 "type": "path",
                 "url": "./modules/acquia_cms_headless",
-                "reference": "37bac73c6aef8dbbe7be9bfabf9c28fe6e7828df"
+                "reference": "03db9df02c964cb60dd491c102abfcc46b06e618"
             },
             "require": {
                 "drupal/acquia_cms_tour": "2.x-dev",
@@ -2771,7 +2771,8 @@
                         "3111456 - Unable to resolve path on node in other language than default": "https://www.drupal.org/files/issues/2022-11-30/decouple_router-3111456-resolve-language-issue-58.patch"
                     },
                     "drupal/subrequests": {
-                        "Get same results on different request": "https://www.drupal.org/files/issues/2019-07-18/change_request_type-63049395-09.patch"
+                        "3049395 - Page Cache causes different subrequests to return the same responses": "https://www.drupal.org/files/issues/2019-07-18/change_request_type-63049395-09.patch",
+                        "3338312 - Incompatible with latest versions of symfony/http-foundation": "https://git.drupalcode.org/project/subrequests/-/merge_requests/14.patch"
                     }
                 }
             },

--- a/modules/acquia_cms_headless/composer.json
+++ b/modules/acquia_cms_headless/composer.json
@@ -66,7 +66,8 @@
         },
         "patches": {
             "drupal/decoupled_router": {
-                "3111456 - Unable to resolve path on node in other language than default": "https://www.drupal.org/files/issues/2022-11-30/decouple_router-3111456-resolve-language-issue-58.patch"
+                "3111456 - Unable to resolve path on node in other language than default": "https://www.drupal.org/files/issues/2022-11-30/decouple_router-3111456-resolve-language-issue-58.patch",
+                "RouteNotFoundException when a jsonapi individual route is not available": "https://gist.githubusercontent.com/chandan-singh7929/b61efa05845d0c578a1c6093ee6b9762/raw/b4f5e48b53696cf490c42e002ffed475fdf51765/RouteNotFoundException.patch"
             },
             "drupal/subrequests": {
                 "3049395 - Page Cache causes different subrequests to return the same responses": "https://www.drupal.org/files/issues/2019-07-18/change_request_type-63049395-09.patch",

--- a/modules/acquia_cms_headless/composer.json
+++ b/modules/acquia_cms_headless/composer.json
@@ -69,7 +69,8 @@
                 "3111456 - Unable to resolve path on node in other language than default": "https://www.drupal.org/files/issues/2022-11-30/decouple_router-3111456-resolve-language-issue-58.patch"
             },
             "drupal/subrequests": {
-                "Get same results on different request": "https://www.drupal.org/files/issues/2019-07-18/change_request_type-63049395-09.patch"
+                "3049395 - Page Cache causes different subrequests to return the same responses": "https://www.drupal.org/files/issues/2019-07-18/change_request_type-63049395-09.patch",
+                "3338312 - Incompatible with latest versions of symfony/http-foundation": "https://git.drupalcode.org/project/subrequests/-/merge_requests/14.patch"
             }
         }
     },

--- a/modules/acquia_cms_headless/composer.json
+++ b/modules/acquia_cms_headless/composer.json
@@ -14,7 +14,8 @@
     },
     "conflict": {
         "drupal/consumers": "<1.16",
-        "drupal/decoupled_router": "<2.0.4"
+        "drupal/decoupled_router": "<2.0.4",
+        "drupal/subrequests": "<3.0.7"
     },
     "config": {
         "allow-plugins": {
@@ -66,12 +67,10 @@
         },
         "patches": {
             "drupal/decoupled_router": {
-                "3111456 - Unable to resolve path on node in other language than default": "https://www.drupal.org/files/issues/2022-11-30/decouple_router-3111456-resolve-language-issue-58.patch",
-                "RouteNotFoundException when a jsonapi individual route is not available": "https://gist.githubusercontent.com/chandan-singh7929/b61efa05845d0c578a1c6093ee6b9762/raw/b4f5e48b53696cf490c42e002ffed475fdf51765/RouteNotFoundException.patch"
+                "3111456 - Unable to resolve path on node in other language than default": "https://www.drupal.org/files/issues/2022-11-30/decouple_router-3111456-resolve-language-issue-58.patch"
             },
             "drupal/subrequests": {
-                "3049395 - Page Cache causes different subrequests to return the same responses": "https://www.drupal.org/files/issues/2019-07-18/change_request_type-63049395-09.patch",
-                "3338312 - Incompatible with latest versions of symfony/http-foundation": "https://git.drupalcode.org/project/subrequests/-/merge_requests/14.patch"
+                "3049395 - Page Cache causes different subrequests to return the same responses": "https://www.drupal.org/files/issues/2019-07-18/change_request_type-63049395-09.patch"
             }
         }
     },

--- a/modules/acquia_cms_headless/tests/src/Functional/HeadlessSubrequestsTest.php
+++ b/modules/acquia_cms_headless/tests/src/Functional/HeadlessSubrequestsTest.php
@@ -1,0 +1,95 @@
+<?php
+
+namespace Drupal\Tests\acquia_cms_headless\Functional;
+
+use Acquia\DrupalEnvironmentDetector\AcquiaDrupalEnvironmentDetector;
+use Drupal\Tests\BrowserTestBase;
+
+/**
+ * Base class for the Headless Content administrator browser tests.
+ */
+class HeadlessSubrequestsTest extends BrowserTestBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected $defaultTheme = 'stark';
+
+  /**
+   * Modules to enable.
+   *
+   * @var array
+   */
+  protected static $modules = [
+    'acquia_cms_headless',
+    'node',
+  ];
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp(): void {
+    // @todo Remove this check when Acquia Cloud IDEs support running functional
+    // JavaScript tests.
+    if (AcquiaDrupalEnvironmentDetector::isAhIdeEnv()) {
+      $this->markTestSkipped('This test cannot run in an Acquia Cloud IDE.');
+    }
+    parent::setUp();
+    $account = $this->drupalCreateUser();
+    $account->addRole('administrator');
+    $account->save();
+    $this->drupalLogin($account);
+
+    // Set up a content type.
+    $this->drupalCreateContentType([
+      'type' => 'test',
+      'name' => 'Test',
+    ]);
+  }
+
+  /**
+   * Content admin test.
+   */
+  public function testSubrequests(): void {
+    $host = \Drupal::request()->getSchemeAndHttpHost();
+
+    for ($i = 1; $i <= 5; $i++) {
+      // Create test node.
+      $node = $this->drupalCreateNode([
+        'type' => 'test',
+        'title' => 'Headless Test Page ' . $i,
+        'status' => 'published',
+      ]);
+      $client = \Drupal::httpClient();
+      $response = $client->post($host . '/subrequests?_format=json', [
+        'body' => json_encode([[
+          "requestId" => "router",
+          "action" => "view",
+          "uri" => "/router/translate-path?path=/node/" . $node->id() . "&_format=json",
+          "headers" => ["Accept" => "application/vnd.api+json"],
+        ],
+        [
+          "requestId" => "resolvedResource",
+          "action" => "view",
+          "uri" => "{{router.body@$.jsonapi.individual}}",
+          "waitFor" => ["router"],
+        ],
+        ]),
+        'headers' => [
+          'Accept' => "application/json",
+        ],
+        'http_errors' => FALSE,
+      ]);
+      $responseData = json_decode($response->getBody());
+      $body = json_decode($responseData->router->body);
+      $subrequest_response = end($responseData);
+      $subrequest_body = json_decode(end($subrequest_response));
+      // Assert title from first request.
+      $this->assertEquals('Headless Test Page ' . $i, $body->label);
+      // Assert title from sub request.
+      $this->assertEquals('Headless Test Page ' . $i, $subrequest_body->data->attributes->title);
+
+    }
+  }
+
+}


### PR DESCRIPTION
**Motivation**
Fixes #ACMS-1489

**Proposed changes**
PHPUnit testcase for headless subrequests functionality.

**Alternatives considered**
NA

**Testing steps**
Verify Acquia CMS Headless test passing in CI

**Merge requirements**
- [ ] _Major change_, _Minor change_, _Bug_, _Enhancement_, and/or _Chore_ label applied
- [ ] Manual testing by a reviewer
