### PR TITLE
ACMS-1489: PHPUnit testcase for headless subrequests functionality.

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -2718,7 +2718,7 @@
             "dist": {
                 "type": "path",
                 "url": "./modules/acquia_cms_headless",
-                "reference": "37bac73c6aef8dbbe7be9bfabf9c28fe6e7828df"
+                "reference": "03db9df02c964cb60dd491c102abfcc46b06e618"
             },
             "require": {
                 "drupal/acquia_cms_tour": "2.x-dev",
@@ -2775,7 +2775,8 @@
                         "3111456 - Unable to resolve path on node in other language than default": "https://www.drupal.org/files/issues/2022-11-30/decouple_router-3111456-resolve-language-issue-58.patch"
                     },
                     "drupal/subrequests": {
-                        "Get same results on different request": "https://www.drupal.org/files/issues/2019-07-18/change_request_type-63049395-09.patch"
+                        "3049395 - Page Cache causes different subrequests to return the same responses": "https://www.drupal.org/files/issues/2019-07-18/change_request_type-63049395-09.patch",
+                        "3338312 - Incompatible with latest versions of symfony/http-foundation": "https://git.drupalcode.org/project/subrequests/-/merge_requests/14.patch"
                     }
                 }
             },

--- a/modules/acquia_cms_headless/composer.json
+++ b/modules/acquia_cms_headless/composer.json
@@ -69,7 +69,8 @@
                 "3111456 - Unable to resolve path on node in other language than default": "https://www.drupal.org/files/issues/2022-11-30/decouple_router-3111456-resolve-language-issue-58.patch"
             },
             "drupal/subrequests": {
-                "Get same results on different request": "https://www.drupal.org/files/issues/2019-07-18/change_request_type-63049395-09.patch"
+                "3049395 - Page Cache causes different subrequests to return the same responses": "https://www.drupal.org/files/issues/2019-07-18/change_request_type-63049395-09.patch",
+                "3338312 - Incompatible with latest versions of symfony/http-foundation": "https://git.drupalcode.org/project/subrequests/-/merge_requests/14.patch"
             }
         }
     },

--- a/modules/acquia_cms_headless/tests/src/Functional/HeadlessSubrequestsTest.php
+++ b/modules/acquia_cms_headless/tests/src/Functional/HeadlessSubrequestsTest.php
@@ -1,0 +1,90 @@
+<?php
+
+namespace Drupal\Tests\acquia_cms_headless\Functional;
+
+use Acquia\DrupalEnvironmentDetector\AcquiaDrupalEnvironmentDetector;
+use Drupal\Tests\BrowserTestBase;
+
+/**
+ * Base class for the Headless Content administrator browser tests.
+ */
+class HeadlessSubrequestsTest extends BrowserTestBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected $defaultTheme = 'stark';
+
+  /**
+   * Modules to enable.
+   *
+   * @var array
+   */
+  protected static $modules = [
+    'acquia_cms_headless',
+    'node',
+  ];
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp(): void {
+    // @todo Remove this check when Acquia Cloud IDEs support running functional
+    // JavaScript tests.
+    if (AcquiaDrupalEnvironmentDetector::isAhIdeEnv()) {
+      $this->markTestSkipped('This test cannot run in an Acquia Cloud IDE.');
+    }
+    parent::setUp();
+    $account = $this->drupalCreateUser();
+    $account->addRole('administrator');
+    $account->save();
+    $this->drupalLogin($account);
+
+    // Set up a content type.
+    $this->drupalCreateContentType([
+      'type' => 'test',
+      'name' => 'Test',
+    ]);
+  }
+
+  /**
+   * Content admin test.
+   */
+  public function testSubrequests(): void {
+    $host = \Drupal::request()->getSchemeAndHttpHost();
+
+    for ($i = 1; $i <= 5; $i++) {
+      // Create test node.
+      $node = $this->drupalCreateNode([
+        'type' => 'test',
+        'title' => 'Headless Test Page ' . $i,
+        'status' => 'published',
+      ]);
+      $client = \Drupal::httpClient();
+      $response = $client->post($host . '/subrequests?_format=json', [
+        'body' => json_encode([[
+          "requestId" => "router",
+          "action" => "view",
+          "uri" => "/router/translate-path?path=/node/" . $node->id() . "&_format=json",
+          "headers" => ["Accept" => "application/vnd.api+json"],
+        ],
+        [
+          "requestId" => "resolvedResource",
+          "action" => "view",
+          "uri" => "{{router.body@$.jsonapi.individual}}",
+          "waitFor" => ["router"],
+        ],
+        ]),
+        'headers' => [
+          'Accept' => "application/json",
+        ],
+        'http_errors' => FALSE,
+      ]);
+      $responseData = json_decode($response->getBody());
+      $body = json_decode($responseData->router->body);
+      $this->assertEquals('Headless Test Page ' . $i, $body->label);
+
+    }
+  }
+
+}


### PR DESCRIPTION
**Motivation**
Fixes #ACMS-1489

**Proposed changes**
PHPUnit testcase for headless subrequests functionality.

**Alternatives considered**
NA

**Testing steps**
Verify Acquia CMS Headless test passing in CI

**Merge requirements**
- [ ] _Major change_, _Minor change_, _Bug_, _Enhancement_, and/or _Chore_ label applied
- [ ] Manual testing by a reviewer
