### PR TITLE
ACMS-1677: Moving dependencies from Contrib to ACMS modules.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,14 @@
         "drupal/acquia_cms_starter": "^1.3.0",
         "drupal/acquia_cms_toolbar": "^1.3.3",
         "drupal/acquia_cms_tour": "^1.3.0",
-        "drush/drush": "^10 || ^11"
+        "drupal/google_analytics": "^4.0",
+        "drupal/google_tag": "^1.6",
+        "drupal/honeypot": "^2.1",
+        "drupal/recaptcha": "^3.1",
+        "drupal/reroute_email": "^2.2",
+        "drupal/shield": "^1.7",
+        "drush/drush": "^10 || ^11",
+        "nnnick/chartjs": "^3.9"
     },
     "conflict": {
         "drupal/acquia_cms_common": "<1.7.1",
@@ -49,6 +56,7 @@
             "dealerdirect/phpcodesniffer-composer-installer": true,
             "drupal/core-composer-scaffold": true,
             "ergebnis/composer-normalize": true,
+            "mnsami/composer-custom-directory-installer": true,
             "oomphinc/composer-installers-extender": true,
             "php-http/discovery": true,
             "phpro/grumphp-shim": true,

--- a/composer.json
+++ b/composer.json
@@ -24,6 +24,7 @@
         "drupal/acquia_cms_starter": "^1.3.0",
         "drupal/acquia_cms_toolbar": "^1.3.3",
         "drupal/acquia_cms_tour": "^1.3.0",
+        "drupal/acquia_search": "3.1.5",
         "drupal/google_analytics": "^4.0",
         "drupal/google_tag": "^1.6",
         "drupal/honeypot": "^2.1",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "88b446e129c051a16d12a4a4262c2791",
+    "content-hash": "5bc5220fa2f13ea2abebd81188a9f20a",
     "packages": [
         {
             "name": "acquia/cohesion",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "5bc5220fa2f13ea2abebd81188a9f20a",
+    "content-hash": "9632498167177d3ea69bbe4de6d667f5",
     "packages": [
         {
             "name": "acquia/cohesion",


### PR DESCRIPTION
### Motivation
Fixes: [ACMS-1677](https://backlog.acquia.com/browse/ACMS-1677)

### Proposed changes
Moving dependencies from Contrib to ACMS modules.

### Alternatives considered
NA

### Testing steps
Install site with ACMS-1677 branch. 
`git checkout ACMS-1677-1.5.x`
`composer install`
Installation site with minimal profile and Acquia CMS module.
` drush si acquia_cms --account-pass=admin `
Verify site working fine.

_**Note: pin acquia_search to 3.1.5 till ACMS-1707 get released.**_

**Merge requirements**
- [ ] _Major change_, _Minor change_, _Bug_, _Enhancement_, and/or _Chore_ label applied
- [ ] Manual testing by a reviewer
