### PR TITLE
ACMS-1712: Enable drupal-check configurations with ignore specific errors.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -125,7 +125,7 @@
                 "3328187 - PHP Deprecated: strpos(): Passing null to parameter #1 ($haystack) of type string is deprecated in docroot/core/lib/Drupal/Core/Mail/Plugin/Mail/PhpMail.php on line 112": "https://git.drupalcode.org/project/drupal/-/merge_requests/3142.patch"
             },
             "mglaman/drupal-check": {
-                "Add custom rules to ignore specific error": "./patches/custom-rules.patch"
+                "Add custom rules to bypass check for buildForm": "https://github.com/mglaman/drupal-check/pull/286.patch"
             }
         }
     },

--- a/composer.json
+++ b/composer.json
@@ -123,6 +123,9 @@
         "patches": {
             "drupal/core": {
                 "3328187 - PHP Deprecated: strpos(): Passing null to parameter #1 ($haystack) of type string is deprecated in docroot/core/lib/Drupal/Core/Mail/Plugin/Mail/PhpMail.php on line 112": "https://git.drupalcode.org/project/drupal/-/merge_requests/3142.patch"
+            },
+            "mglaman/drupal-check": {
+                "Add custom rules to ignore specific error": "./patches/custom-rules.patch"
             }
         }
     },

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "0d99cceb2f10e69f7bb98fc16181277d",
+    "content-hash": "6453f354c15a4360be4145594ee58830",
     "packages": [
         {
             "name": "acquia/acquia-cms-starterkit",
@@ -8655,10 +8655,6 @@
                     "name": "Mark Casias (markie)",
                     "homepage": "https://www.drupal.org/u/markie",
                     "role": "Maintainer"
-                },
-                {
-                    "name": "newsignature",
-                    "homepage": "https://www.drupal.org/user/765518"
                 },
                 {
                     "name": "ultimike",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "6453f354c15a4360be4145594ee58830",
+    "content-hash": "a4d572d17ded61ca3a10bf851513ebbd",
     "packages": [
         {
             "name": "acquia/acquia-cms-starterkit",

--- a/modules/acquia_cms_article/acquia_cms_article.install
+++ b/modules/acquia_cms_article/acquia_cms_article.install
@@ -5,6 +5,7 @@
  * Install, update and uninstall functions for the acquia_cms_article module.
  */
 
+use Drupal\Core\Field\FieldConfigBase;
 use Drupal\field\Entity\FieldConfig;
 use Drupal\user\RoleInterface;
 
@@ -53,8 +54,9 @@ function acquia_cms_article_update_8001() {
  * Make Display Author field optional.
  */
 function acquia_cms_article_update_8002() {
+  /** @var \Drupal\Core\Field\FieldConfigBase $field */
   $field = FieldConfig::loadByName('node', 'article', 'field_display_author');
-  if ($field instanceof FieldConfig && $field->isRequired()) {
+  if ($field instanceof FieldConfigBase && $field->isRequired()) {
     $field->setRequired(FALSE);
     $field->save();
   }

--- a/modules/acquia_cms_common/acquia_cms_common.module
+++ b/modules/acquia_cms_common/acquia_cms_common.module
@@ -223,10 +223,11 @@ function _acquia_cms_common_rewrite_configuration(string $config, string $module
  * @throws \Drupal\Core\Entity\EntityStorageException
  */
 function _acquia_cms_common_update_view_display_options_style(string $view_name, string $display_id = 'default', string $views_template = NULL) {
-  /** @var \Drupal\views\ViewEntityInterface $view_storage */
+  /** @var \Drupal\Core\Entity\EntityStorageInterface $view_storage */
   $view_storage = \Drupal::entityTypeManager()->getStorage('view');
+  /** @var \Drupal\views\ViewEntityInterface $view */
   $view = $view_storage->load($view_name);
-  if (empty($view)) {
+  if (!$view) {
     return;
   }
   $display = &$view->getDisplay($display_id);
@@ -237,7 +238,7 @@ function _acquia_cms_common_update_view_display_options_style(string $view_name,
       'views_template' => $views_template ?? 'view_tpl_' . $view_name,
       'master_template' => 'master_template_boxed',
     ];
-    $view_storage->save();
+    $view_storage->save($view);
   }
 }
 

--- a/modules/acquia_cms_common/acquia_cms_common.module
+++ b/modules/acquia_cms_common/acquia_cms_common.module
@@ -211,10 +211,19 @@ function _acquia_cms_common_rewrite_configuration(string $config, string $module
 /**
  * Helper function to update views display_options's style.
  *
+ * @param string $view_name
+ *   The view names.
+ * @param string $display_id
+ *   The view display_id.
+ * @param string|null $views_template
+ *   The view template name.
+ *
+ * @throws \Drupal\Component\Plugin\Exception\InvalidPluginDefinitionException
+ * @throws \Drupal\Component\Plugin\Exception\PluginNotFoundException
  * @throws \Drupal\Core\Entity\EntityStorageException
  */
-function _acquia_cms_common_update_view_display_options_style($view_name, $display_id = 'default', $views_template = NULL) {
-  /** @var \Drupal\views\ViewEntityInterface $view */
+function _acquia_cms_common_update_view_display_options_style(string $view_name, string $display_id = 'default', string $views_template = NULL) {
+  /** @var \Drupal\views\ViewEntityInterface $view_storage */
   $view_storage = \Drupal::entityTypeManager()->getStorage('view');
   $view = $view_storage->load($view_name);
   if (empty($view)) {
@@ -228,7 +237,7 @@ function _acquia_cms_common_update_view_display_options_style($view_name, $displ
       'views_template' => $views_template ?? 'view_tpl_' . $view_name,
       'master_template' => 'master_template_boxed',
     ];
-    $view_storage->save($view);
+    $view_storage->save();
   }
 }
 
@@ -246,7 +255,7 @@ function _acquia_cms_common_update_page_configurations(string $config_name, arra
   $configFactory = \Drupal::service('config.factory');
   $config = $configFactory->getEditable($config_name);
   $need_save = FALSE;
-  if (!empty($config)) {
+  if ($config) {
     foreach ($configurations as $key => $value) {
       if ($config->get($key) != $value) {
         $config->set($key, $value);
@@ -394,12 +403,9 @@ function acquia_cms_common_modules_installed($modules, $is_syncing) {
         // configurations which is dependent on any of these roles.
         /** @var \Drupal\Core\Config\ConfigInstallerInterface $config_installer */
         $config_installer = \Drupal::service('config.installer');
-        $restrict_by_dependency = [
-          'config' => 'user.role.content_administrator',
-          'config' => 'user.role.content_author',
-          'config' => 'user.role.content_editor',
-        ];
-        $config_installer->installOptionalConfig(NULL, $restrict_by_dependency);
+        $config_installer->installOptionalConfig(NULL, ['config' => 'user.role.content_administrator']);
+        $config_installer->installOptionalConfig(NULL, ['config' => 'user.role.content_author']);
+        $config_installer->installOptionalConfig(NULL, ['config' => 'user.role.content_editor']);
       }
       if ($rolesToUpdate) {
         // We need to update only those roles, which are not created earlier.

--- a/modules/acquia_cms_common/modules/acquia_cms_development/acquia_cms_development.install
+++ b/modules/acquia_cms_common/modules/acquia_cms_development/acquia_cms_development.install
@@ -18,7 +18,7 @@ function acquia_cms_development_install($is_syncing) {
     $config_factory = \Drupal::configFactory();
     $key = getenv('CONNECTOR_KEY');
     $identifier = getenv('CONNECTOR_ID');
-    if (isset($key, $identifier)) {
+    if ($key && $identifier) {
       _acquia_connector_config($key, $identifier);
       _acquia_search_config($key, $identifier);
     }
@@ -27,7 +27,7 @@ function acquia_cms_development_install($is_syncing) {
 
       $shield_user = getenv('SHIELD_USER');
       $shield_pass = getenv('SHIELD_PASS');
-      if (isset($shield_user, $shield_pass)) {
+      if ($shield_user && $shield_pass) {
         \Drupal::service('module_installer')->install(['shield']);
         $config_factory->getEditable('shield.settings')
           ->set('credentials.shield.user', $shield_user)
@@ -105,7 +105,7 @@ function _acquia_search_config(string $key, string $identifier) {
 
   // Replicating Storage from acquia_search/src/Helper/Storage.php.
   $search_uuid = getenv('SEARCH_UUID');
-  if (isset($search_uuid)) {
+  if ($search_uuid) {
     \Drupal::configFactory()->getEditable('acquia_search.settings')
       ->set('api_host', 'https://api.sr-prod02.acquia.com')->save();
     \Drupal::state()->set('acquia_search.api_key', $key);

--- a/modules/acquia_cms_common/modules/acquia_cms_support/src/Controller/AcquiaCmsConfigDiff.php
+++ b/modules/acquia_cms_common/modules/acquia_cms_support/src/Controller/AcquiaCmsConfigDiff.php
@@ -115,7 +115,7 @@ class AcquiaCmsConfigDiff implements ContainerInjectionInterface {
    *   The storage of the configuration file.
    * @param string $source_name
    *   The name of the configuration file.
-   * @param string $target_name
+   * @param string|null $target_name
    *   (optional) The name of the target configuration file if different from
    *   the $source_name.
    *
@@ -124,8 +124,8 @@ class AcquiaCmsConfigDiff implements ContainerInjectionInterface {
    *
    * @throws \Drupal\Core\Config\StorageTransformerException
    */
-  public function diff($name, $type, $storage, $source_name, $target_name = NULL) {
-
+  public function diff(string $name, string $type, string $storage, string $source_name, string $target_name = NULL) {
+    $module_path = '';
     if ($type == "profile") {
       $module_path = $this->profileExtensionList->getPath($name);
     }
@@ -217,14 +217,13 @@ class AcquiaCmsConfigDiff implements ContainerInjectionInterface {
    */
   private function removeNonRequiredKeys(array $data) {
     // Remove the _core, uuid, default_config_hash from the configuration.
-    $data = array_values(array_filter(
+    return array_values(array_filter(
       $data,
-      function ($val) use (&$data) {
+      function ($val) {
         return (strpos($val, '_core') !== 0) && (strpos(trim($val), 'default_config_hash:') !== 0) && (strpos($val, 'uuid:') !== 0);
       },
       ARRAY_FILTER_USE_BOTH
     ));
-    return $data;
   }
 
 }

--- a/modules/acquia_cms_common/modules/acquia_cms_support/src/Service/AcquiaCmsConfigSyncService.php
+++ b/modules/acquia_cms_common/modules/acquia_cms_support/src/Service/AcquiaCmsConfigSyncService.php
@@ -103,14 +103,13 @@ class AcquiaCmsConfigSyncService {
    */
   public function removeNonRequiredKeys(array $data) {
     // Remove the _core, uuid, default_config_hash from the configuration.
-    $data = array_values(array_filter(
+    return array_values(array_filter(
       $data,
-      function ($val) use (&$data) {
+      function ($val) {
         return (strpos($val, '_core') !== 0) && (strpos(trim($val), 'default_config_hash:') !== 0) && (strpos($val, 'uuid:') !== 0);
       },
       ARRAY_FILTER_USE_BOTH
     ));
-    return $data;
   }
 
   /**

--- a/modules/acquia_cms_common/src/AcquiaCmsCommonServiceProvider.php
+++ b/modules/acquia_cms_common/src/AcquiaCmsCommonServiceProvider.php
@@ -39,8 +39,8 @@ final class AcquiaCmsCommonServiceProvider extends ServiceProviderBase {
    * {@inheritdoc}
    */
   public function alter(ContainerBuilder $container) {
-    /** @var \Symfony\Component\DependencyInjection\Definition $definition */
     if ($container->hasDefinition('acquia_connector.telemetry')) {
+      /** @var \Symfony\Component\DependencyInjection\Definition $definition */
       $definition = $container->getDefinition('acquia_connector.telemetry');
       $definition->setClass('Drupal\acquia_cms_common\EventSubscriber\KernelTerminate\AcquiaConnectorTelemetryOverride');
     }

--- a/modules/acquia_cms_common/src/Commands/AcmsCommands.php
+++ b/modules/acquia_cms_common/src/Commands/AcmsCommands.php
@@ -34,14 +34,14 @@ class AcmsCommands extends DrushCommands implements SiteAliasManagerAwareInterfa
   /**
    * Logger Factory.
    *
-   * @var \Drupal\Core\Logger\LoggerChannelFactory
+   * @var \Psr\Log\LoggerInterface
    */
   protected $loggerFactory;
 
   /**
    * The System schema object from KeyValue factory.
    *
-   * @var \Drupal\Core\KeyValueStore\KeyValueFactory
+   * @var \Drupal\Core\KeyValueStore\KeyValueStoreInterface
    */
   protected $systemSchema;
 
@@ -151,7 +151,12 @@ class AcmsCommands extends DrushCommands implements SiteAliasManagerAwareInterfa
       'entity-updates' => FALSE,
       'post-updates' => TRUE,
     ];
-    $process = $this->processManager()->drush($selfAlias, 'updatedb', [], $options);
+    $process = $this->processManager();
+
+    /** @var \Drush\SiteAlias\ProcessManager $process */
+    $process->drush($selfAlias, 'updatedb', [], $options);
+
+    /** @var \Symfony\Component\Process\Process $process */
     $process->mustRun();
 
     // Use symfony process component getIterator to get all output
@@ -202,8 +207,15 @@ class AcmsCommands extends DrushCommands implements SiteAliasManagerAwareInterfa
       'entity-updates' => FALSE,
       'post-updates' => TRUE,
     ];
-    $process = $this->processManager()->drush($selfAlias, 'updatedb', [], $options);
-    $process->mustRun($process->showRealtime());
+    $process = $this->processManager();
+    /** @var \Drush\SiteAlias\ProcessManager $process */
+    $process->drush($selfAlias, 'updatedb', [], $options);
+
+    /** @var \Consolidation\SiteProcess\ProcessBase $process */
+    $showRealtime = $process->showRealtime();
+
+    /** @var \Symfony\Component\Process\Process $process */
+    $process->mustRun($showRealtime);
   }
 
   /**

--- a/modules/acquia_cms_common/src/Commands/AcmsConfigImportCommands.php
+++ b/modules/acquia_cms_common/src/Commands/AcmsConfigImportCommands.php
@@ -72,9 +72,9 @@ final class AcmsConfigImportCommands extends DrushCommands {
   protected $stringTranslation;
 
   /**
-   * The ClassResolver.
+   * The cohesion facade.
    *
-   * @var \Drupal\Core\DependencyInjection\ClassResolver
+   * @var \Drupal\acquia_cms_site_studio\Facade\CohesionFacade
    */
   protected $cohesionFacade;
 

--- a/modules/acquia_cms_common/src/Commands/ToggleModules.php
+++ b/modules/acquia_cms_common/src/Commands/ToggleModules.php
@@ -13,7 +13,7 @@ class ToggleModules extends DrushCommands {
   /**
    * Toggle module Service.
    *
-   * @var Drupal\acquia_cms_common\Services\ToggleModulesService
+   * @var \Drupal\acquia_cms_common\Services\ToggleModulesService
    */
   private $toggleModuleServices;
 

--- a/modules/acquia_cms_common/src/EventSubscriber/HttpsRedirectSubscriber.php
+++ b/modules/acquia_cms_common/src/EventSubscriber/HttpsRedirectSubscriber.php
@@ -2,6 +2,7 @@
 
 namespace Drupal\acquia_cms_common\EventSubscriber;
 
+use Drupal\Component\DependencyInjection\ContainerInterface;
 use Drupal\Core\Cache\CacheBackendInterface;
 use Drupal\Core\Config\ConfigFactoryInterface;
 use Drupal\Core\Routing\TrustedRedirectResponse;
@@ -34,7 +35,7 @@ class HttpsRedirectSubscriber implements EventSubscriberInterface {
   /**
    * The Request URI Service.
    *
-   * @var \Symfony\Component\HttpFoundation\RequestStack
+   * @var \Symfony\Component\HttpFoundation\RequestStack|\Symfony\Component\HttpFoundation\Request
    */
   protected $request;
 
@@ -45,7 +46,7 @@ class HttpsRedirectSubscriber implements EventSubscriberInterface {
    *   The config factory service.
    * @param \Drupal\Core\Cache\CacheBackendInterface $cache
    *   A cache backend used to store configuration.
-   * @param Symfony\Component\HttpFoundation\RequestStack $request_stack
+   * @param \Symfony\Component\HttpFoundation\RequestStack $request_stack
    *   The request URI service to get request URL.
    */
   public function __construct(ConfigFactoryInterface $config_factory, CacheBackendInterface $cache, RequestStack $request_stack) {
@@ -58,9 +59,7 @@ class HttpsRedirectSubscriber implements EventSubscriberInterface {
    * {@inheritdoc}
    */
   public static function create(ContainerInterface $container) {
-    return new static(
-      $container->get('request_stack')
-    );
+    return new static($container->get('request_stack'));
   }
 
   /**

--- a/modules/acquia_cms_common/src/Facade/PermissionFacade.php
+++ b/modules/acquia_cms_common/src/Facade/PermissionFacade.php
@@ -128,7 +128,7 @@ class PermissionFacade implements ContainerInjectionInterface {
       "dependencies" => [],
       "id" => $role,
       "label" => $label,
-      "weight" => $configurations['weight'] ?? 0,
+      "weight" => 0,
       "is_admin" => NULL,
     ];
   }

--- a/modules/acquia_cms_common/src/Facade/WorkflowFacade.php
+++ b/modules/acquia_cms_common/src/Facade/WorkflowFacade.php
@@ -103,7 +103,7 @@ final class WorkflowFacade implements ContainerInjectionInterface {
     // Ensure the workflow exists, and log a warning if it doesn't.
     /** @var \Drupal\workflows\WorkflowInterface $workflow */
     $workflow = $this->workflowStorage->load($workflow_id);
-    if (empty($workflow)) {
+    if (!$workflow) {
       $this->logger->warning('Could not add the %node_type content type to the %workflow workflow because the workflow does not exist.', $variables);
       return;
     }

--- a/modules/acquia_cms_common/src/Plugin/views/area/MainListingPagesView.php
+++ b/modules/acquia_cms_common/src/Plugin/views/area/MainListingPagesView.php
@@ -36,7 +36,6 @@ final class MainListingPagesView extends Text {
    */
   public function render($empty = FALSE) {
     if (!$this->isServerAvailable()) {
-      $this->isEmpty = TRUE;
       return [];
     }
     return parent::render($empty);

--- a/modules/acquia_cms_common/src/RedirectHandler.php
+++ b/modules/acquia_cms_common/src/RedirectHandler.php
@@ -111,7 +111,7 @@ final class RedirectHandler implements ContainerInjectionInterface {
     $loginObject = get_class($form_state->getFormObject());
     // If the user is about to be redirected to their user page, do our special
     // sauce redirect handling based on the role(s) the user has.
-    if ((stripos($loginObject ?? '', 'userloginform') != FALSE) &&
+    if ((stripos($loginObject, 'userloginform') != FALSE) &&
       $this->willRedirectToUserPage()) {
       // Remove the 'destination' query sting parameter, since it will cause our
       // redirect to be totally ignored due to a core quirk.

--- a/modules/acquia_cms_common/src/Services/AcmsUtilityService.php
+++ b/modules/acquia_cms_common/src/Services/AcmsUtilityService.php
@@ -38,7 +38,7 @@ class AcmsUtilityService {
    * @see acquia_cms_search_modules_installed()
    */
 
-  private static $modulePreinstallTriggered;
+  protected static $modulePreinstallTriggered;
 
   /**
    * The state service.
@@ -57,9 +57,7 @@ class AcmsUtilityService {
    * @param \Drupal\Core\State\StateInterface $state
    *   The state service.
    */
-  public function __construct(ModuleHandlerInterface $moduleHandler,
-                              ConfigFactoryInterface $config_factory,
-                              StateInterface $state) {
+  public function __construct(ModuleHandlerInterface $moduleHandler, ConfigFactoryInterface $config_factory, StateInterface $state) {
     $this->moduleHandler = $moduleHandler;
     $this->configFactory = $config_factory;
     $this->state = $state;

--- a/modules/acquia_cms_common/src/SubtypeBreadcrumb.php
+++ b/modules/acquia_cms_common/src/SubtypeBreadcrumb.php
@@ -93,7 +93,10 @@ final class SubtypeBreadcrumb implements BreadcrumbBuilderInterface {
     if ($route_match->getRouteName() === 'entity.node.canonical') {
       /** @var \Drupal\node\NodeInterface $node */
       $node = $route_match->getParameter('node');
-      return $node->type->entity->getThirdPartySetting('acquia_cms_common', 'subtype', []);
+
+      /** @var \Drupal\node\Entity\NodeType $entity_type */
+      $entity_type = $node->type->entity;
+      return $entity_type->getThirdPartySetting('acquia_cms_common', 'subtype', []);
     }
     return [];
   }

--- a/modules/acquia_cms_common/tests/src/Functional/ContentTypeTestBase.php
+++ b/modules/acquia_cms_common/tests/src/Functional/ContentTypeTestBase.php
@@ -101,6 +101,7 @@ abstract class ContentTypeTestBase extends ContentModelTestBase {
 
     // While testing the add/edit form, make the required fields behave as they
     // normally would.
+    /** @var \Drupal\field\Entity\FieldConfig $required_field */
     foreach ($required_fields as $required_field) {
       $required_field->setRequired(TRUE);
       $field_storage->save($required_field);
@@ -441,6 +442,7 @@ abstract class ContentTypeTestBase extends ContentModelTestBase {
     ]);
     $media->save();
 
+    /** @var \Drupal\field\Entity\FieldConfig $field */
     $field->setDefaultValue($media->id())->save();
 
     return $file->createFileUrl(FALSE);

--- a/modules/acquia_cms_common/tests/src/Functional/NodeBreadcrumbTest.php
+++ b/modules/acquia_cms_common/tests/src/Functional/NodeBreadcrumbTest.php
@@ -36,7 +36,7 @@ class NodeBreadcrumbTest extends BrowserTestBase {
   /**
    * The drupal user object.
    *
-   * @var Drupal\user\Entity\User
+   * @var \Drupal\user\Entity\User
    */
   protected $adminUser;
 

--- a/modules/acquia_cms_common/tests/src/FunctionalJavascript/MediaEmbedTestBase.php
+++ b/modules/acquia_cms_common/tests/src/FunctionalJavascript/MediaEmbedTestBase.php
@@ -125,7 +125,9 @@ abstract class MediaEmbedTestBase extends WebDriverTestBase {
   protected function doTestCreateMedia() {
     $this->openMediaLibrary();
     $this->addMedia();
-    $added_media = $this->assertSession()->waitForElementVisible('css', '.js-media-library-add-form-added-media > li');
+    /** @var \Drupal\FunctionalJavascriptTests\JSWebAssert $assertSession */
+    $assertSession = $this->assertSession();
+    $added_media = $assertSession->waitForElementVisible('css', '.js-media-library-add-form-added-media > li');
     $this->assertNotEmpty($added_media);
     $this->assertAddedMedia($added_media);
   }
@@ -155,7 +157,9 @@ abstract class MediaEmbedTestBase extends WebDriverTestBase {
    * Asserts that an embedded media item is visible in CKEditor5.
    */
   protected function assertMediaIsEmbedded() {
-    $result = $this->assertSession()->waitForElementVisible('css', '.ck-content .ck-widget.drupal-media .media');
+    /** @var \Drupal\FunctionalJavascriptTests\JSWebAssert $assertSession */
+    $assertSession = $this->assertSession();
+    $result = $assertSession->waitForElementVisible('css', '.ck-content .ck-widget.drupal-media .media');
     $this->assertNotEmpty($result);
   }
 
@@ -175,7 +179,9 @@ abstract class MediaEmbedTestBase extends WebDriverTestBase {
    *   The zero-based index of the media item to select.
    */
   protected function selectMedia(int $position) {
-    $checkbox = $this->assertSession()
+    /** @var \Drupal\FunctionalJavascriptTests\JSWebAssert $assertSession */
+    $assertSession = $this->assertSession();
+    $checkbox = $assertSession
       ->waitForElementVisible('named', ['field', "media_library_select_form[$position]"]);
     $this->assertNotEmpty($checkbox);
     $checkbox->check();
@@ -194,7 +200,9 @@ abstract class MediaEmbedTestBase extends WebDriverTestBase {
     // additional button to navigate to other elements.
     $this->pressEditorButton('Show more items');
     $this->pressEditorButton('Insert Media');
-    $result = $this->assertSession()->waitForText('Add or select media');
+    /** @var \Drupal\FunctionalJavascriptTests\JSWebAssert $assertSession */
+    $assertSession = $this->assertSession();
+    $result = $assertSession->waitForText('Add or select media');
     $this->assertNotEmpty($result);
   }
 

--- a/modules/acquia_cms_event/acquia_cms_event.install
+++ b/modules/acquia_cms_event/acquia_cms_event.install
@@ -43,7 +43,7 @@ function acquia_cms_event_module_preinstall($module) {
 function acquia_cms_event_update_8001() {
   $configFactory = \Drupal::service('config.factory');
   $config = $configFactory->getEditable('views.view.event_cards');
-  if (!empty($config)) {
+  if ($config) {
     $config->set('display.past_events_block.display_title', 'Past Events')
       ->set('display.past_events_block.display_options.title', '')->save();
   }

--- a/modules/acquia_cms_event/src/DefaultContentEventUpdate.php
+++ b/modules/acquia_cms_event/src/DefaultContentEventUpdate.php
@@ -37,18 +37,24 @@ class DefaultContentEventUpdate {
    * Update event node with modified date & time.
    *
    * @param \Drupal\node\NodeInterface $entity
-   *   The entity object.
+   *   The entity objects.
    * @param array $updated_data
    *   Contains the updated event dates & time.
+   *
+   * @throws \Drupal\Core\Entity\EntityStorageException
    */
   public function updateEventNode(NodeInterface $entity, array $updated_data) {
-    $entity->set('field_event_start', date('Y-m-d\T' . $entity->get('field_event_start')->date->format('H:i:s'), strtotime($updated_data['start_date'])));
+
+    $field_event_start = new \DateTime($entity->get('field_event_start')->value);
+    $field_event_end = new \DateTime($entity->get('field_event_end')->value);
+    $field_door_time = new \DateTime($entity->get('field_door_time')->value);
+
+    $entity->set('field_event_start', date('Y-m-d\T' . $field_event_start->format('H:i:s'), strtotime($updated_data['start_date'])));
     if (!empty($updated_data['end_date']) && !empty($entity->get('field_event_end')->date)) {
-      $entity->set('field_event_end', date('Y-m-d\T' . $entity->get('field_event_end')->date->format('H:i:s'), strtotime($updated_data['end_date'])));
+      $entity->set('field_event_end', date('Y-m-d\T' . $field_event_end->format('H:i:s'), strtotime($updated_data['end_date'])));
+
       // Updating the duration field based on start and end date of event.
-      $time_diff = date_diff(
-        new \DateTime($entity->get('field_event_end')->value),
-        new \DateTime($entity->get('field_event_start')->value));
+      $time_diff = date_diff($field_event_end, $field_event_start);
 
       $day = $time_diff->d > 1 ? 'days' : 'day';
       $hour = $time_diff->h > 1 ? 'hours' : 'hour';
@@ -57,7 +63,7 @@ class DefaultContentEventUpdate {
         'field_event_duration',
         $time_diff->format("%a " . $day . ", %h " . $hour . ", %i " . $minute));
     }
-    $entity->set('field_door_time', date('Y-m-d\T' . $entity->get('field_door_time')->date->format('H:i:s'), strtotime($updated_data['door_time'])));
+    $entity->set('field_door_time', date('Y-m-d\T' . $field_door_time->format('H:i:s'), strtotime($updated_data['door_time'])));
 
     $entity->save();
   }

--- a/modules/acquia_cms_event/tests/src/Functional/EventTest.php
+++ b/modules/acquia_cms_event/tests/src/Functional/EventTest.php
@@ -70,12 +70,12 @@ class EventTest extends ContentTypeTestBase {
     // us to choose dates and times in the UI. To work around that, give the
     // date/time fields of this content type a default value.
     foreach (['field_event_start', 'field_door_time', 'field_event_end'] as $field) {
-      FieldConfig::loadByName('node', $this->nodeType, $field)
-        ->setDefaultValue([
-          'default_date_type' => 'relative',
-          'default_date' => gmdate('c', $this->defaultTime),
-        ])
-        ->save();
+      /** @var \Drupal\Core\Field\FieldConfigBase $fieldConfig */
+      $fieldConfig = FieldConfig::loadByName('node', $this->nodeType, $field);
+      $fieldConfig->setDefaultValue([
+        'default_date_type' => 'relative',
+        'default_date' => gmdate('c', $this->defaultTime),
+      ])->save();
     }
   }
 

--- a/modules/acquia_cms_headless/acquia_cms_headless.install
+++ b/modules/acquia_cms_headless/acquia_cms_headless.install
@@ -88,9 +88,12 @@ function acquia_cms_headless_update_8002() {
     ->execute();
   $config = \Drupal::configFactory()->getEditable('acquia_cms_headless.settings');
   if ($config->get('consumer_uuid')) {
+    /** @var \Drupal\consumers\Entity\ConsumerInterface $consumer */
     $consumer = \Drupal::service('entity.repository')->loadEntityByUuid("consumer", $config->get('consumer_uuid'));
-    if ($consumer instanceof EntityInterface && $consumer->user_id->entity instanceof EntityInterface) {
-      $user = $consumer->user_id->entity;
+    $uid = $consumer->user_id;
+    if ($consumer instanceof EntityInterface && $uid->entity instanceof EntityInterface) {
+      /** @var \Drupal\user\UserInterface $user */
+      $user = $uid->entity;
       foreach ($roleIds as $roleId) {
         $user->addRole($roleId);
       }

--- a/modules/acquia_cms_headless/modules/acquia_cms_headless_ui/src/Controller/SitePreviewController.php
+++ b/modules/acquia_cms_headless/modules/acquia_cms_headless_ui/src/Controller/SitePreviewController.php
@@ -2,6 +2,7 @@
 
 namespace Drupal\acquia_cms_headless_ui\Controller;
 
+use Drupal\Component\Plugin\Exception\PluginNotFoundException;
 use Drupal\Core\Controller\ControllerBase;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\next\NextEntityTypeManager;
@@ -91,8 +92,13 @@ class SitePreviewController extends ControllerBase {
    *
    * @return array
    *   Site preview data.
+   *
+   * @throws \Drupal\Component\Plugin\Exception\PluginNotFoundException
+   * @throws \Drupal\Component\Plugin\Exception\InvalidPluginDefinitionException
+   * @throws \Drupal\Component\Plugin\Exception\PluginException
    */
   public function nodePreview(Node $node): array {
+    /** @var \Drupal\Core\Entity\RevisionableStorageInterface $storage */
     $storage = $this->entityTypeManager->getStorage($node->getEntityTypeId());
     $revision = $storage->loadRevision($storage->getLatestRevisionId($node->id()));
     $nextEntityTypeConfig = $this->nextEntityTypeManager->getConfigForEntityType($revision->getEntityTypeId(), $revision->bundle());
@@ -108,7 +114,7 @@ class SitePreviewController extends ControllerBase {
     $config = $this->config('next.settings');
     $sitePreviewerId = $config->get('site_previewer') ?? 'iframe';
 
-    /** @var \Drupal\next\Plugin\SitePreviewerInterface $site_previewer */
+    /** @var \Drupal\next\Plugin\SitePreviewerInterface $sitePreviewer */
     $sitePreviewer = $this->sitePreviewerManager->createInstance($sitePreviewerId, $config->get('site_previewer_configuration') ?? []);
     if (!$sitePreviewer) {
       throw new PluginNotFoundException('Invalid site previewer.');

--- a/modules/acquia_cms_headless/modules/acquia_cms_headless_ui/src/Redirect.php
+++ b/modules/acquia_cms_headless/modules/acquia_cms_headless_ui/src/Redirect.php
@@ -30,7 +30,7 @@ class Redirect {
 
     $redirect = [
       static::class,
-      static::camelize($form_id),
+      Redirect::camelize($form_id),
     ];
 
     if (is_callable($redirect)) {

--- a/modules/acquia_cms_headless/src/AcquiaCmsHeadlessPluginBase.php
+++ b/modules/acquia_cms_headless/src/AcquiaCmsHeadlessPluginBase.php
@@ -8,6 +8,13 @@ namespace Drupal\acquia_cms_headless;
 abstract class AcquiaCmsHeadlessPluginBase implements AcquiaCmsHeadlessInterface {
 
   /**
+   * The plugin definition.
+   *
+   * @var mixed
+   */
+  protected $pluginDefinition;
+
+  /**
    * {@inheritdoc}
    */
   public function label() {

--- a/modules/acquia_cms_headless/src/Commands/AcquiaCmsHeadlessCommands.php
+++ b/modules/acquia_cms_headless/src/Commands/AcquiaCmsHeadlessCommands.php
@@ -193,12 +193,13 @@ class AcquiaCmsHeadlessCommands extends DrushCommands {
   ]) {
     if ($options['site-url']) {
       $cid = $this->starterKit->getHeadlessConsumerDataByUri($options['site-url'])->id();
+      /** @var \Drupal\consumers\Entity\Consumer $consumer */
       $consumer = $this->entityTypeManager->getStorage('consumer')->load($cid);
       if ($consumer) {
         // Generate a new secret key.
         $secret = $this->starterKit->createHeadlessSecret();
         // Apply the new secret to the consumer.
-        $consumer->secret = $secret;
+        $consumer->set('secret', $secret);
         // Set consumer secret.
         $this->starterKit->setConsumerSecret($secret);
         // Update the consumer.

--- a/modules/acquia_cms_headless/src/Controller/HeadlessKeyGenerator.php
+++ b/modules/acquia_cms_headless/src/Controller/HeadlessKeyGenerator.php
@@ -163,9 +163,10 @@ class HeadlessKeyGenerator extends ControllerBase {
     // Get the Consumer name.
     $consumer_name = $this->routeMatch->getParameter($entity_type)->label();
     // Load the consumer.
+    /** @var \Drupal\consumers\Entity\Consumer $consumer */
     $consumer = $this->entityTypeManager->getStorage($entity_type)->load($cid);
     // Apply the new secret to the consumer.
-    $consumer->secret = $secret;
+    $consumer->set('secret', $secret);
     // Update the consumer.
     $consumer->save();
 

--- a/modules/acquia_cms_headless/src/Plugin/AcquiaCmsHeadless/HeadlessApiKeys.php
+++ b/modules/acquia_cms_headless/src/Plugin/AcquiaCmsHeadless/HeadlessApiKeys.php
@@ -257,6 +257,7 @@ class HeadlessApiKeys extends AcquiaCmsDashboardBase {
     $entity_type = 'consumer';
     $consumer_data = $this->getEntityData();
     $storage = $this->entityTypeManager->getStorage($entity_type);
+    /** @var \Drupal\Core\Entity\EntityStorageInterface $consumers */
     $consumers = $storage->loadMultiple($consumer_data);
     $operations = $this->createOperationLinks($entity_type);
 

--- a/modules/acquia_cms_headless/src/Plugin/AcquiaCmsHeadless/HeadlessNextEntityTypes.php
+++ b/modules/acquia_cms_headless/src/Plugin/AcquiaCmsHeadless/HeadlessNextEntityTypes.php
@@ -235,7 +235,7 @@ class HeadlessNextEntityTypes extends AcquiaCmsDashboardBase {
     $operations = $this->createOperationLinks($entity_type);
     // Call the dashboard destination service.
     $destination = $this->starterKitNextjsService->dashboardDestination();
-
+    /** @var \Drupal\next\Entity\NextEntityTypeConfigInterface $next_type */
     foreach ($next_types as $next_type) {
       // Init some variables.
       $site_data = '';
@@ -247,14 +247,14 @@ class HeadlessNextEntityTypes extends AcquiaCmsDashboardBase {
 
       // Iterate through site data via referenced site id in order to get
       // labels, etc. from next sites.
-      if (!empty($sites)) {
+      if ($sites) {
         foreach ($sites as $site) {
           $site_data = $next_sites->load($site)->label();
         }
       }
 
       // If the entity type is a node, get the entity type label.
-      if (!empty($node_types) && $entity_data[0] === 'node') {
+      if (isset($node_types[0]) && $entity_data[0] === 'node') {
         $node_type = $node_types->load($entity_data[1]);
         $bundle_label = $node_type->label();
         $bundle_uri = $node_type->toUrl('edit-form', $destination);

--- a/modules/acquia_cms_headless/src/Plugin/AcquiaCmsHeadless/HeadlessNextSites.php
+++ b/modules/acquia_cms_headless/src/Plugin/AcquiaCmsHeadless/HeadlessNextSites.php
@@ -272,6 +272,7 @@ class HeadlessNextSites extends AcquiaCmsDashboardBase {
     $operations = $this->createOperationLinks($entity_type);
 
     // Match the data with the columns.
+    /** @var \Drupal\next\Entity\NextSiteInterface $site */
     foreach ($sites as $site) {
       $site_link = $site->getBaseUrl();
       $site_uri = Url::fromUri($site_link, ['external' => TRUE]);

--- a/modules/acquia_cms_headless/src/Plugin/AcquiaCmsTour/AcquiaHeadlessForm.php
+++ b/modules/acquia_cms_headless/src/Plugin/AcquiaCmsTour/AcquiaHeadlessForm.php
@@ -47,6 +47,13 @@ class AcquiaHeadlessForm extends AcquiaCmsDashboardBase {
   protected $starterkitNextjsService;
 
   /**
+   * Provides nextjs status..
+   *
+   * @var bool
+   */
+  private $isNextJs;
+
+  /**
    * {@inheritdoc}
    */
   public static function create(ContainerInterface $container) {

--- a/modules/acquia_cms_headless/src/Service/StarterkitNextjsService.php
+++ b/modules/acquia_cms_headless/src/Service/StarterkitNextjsService.php
@@ -121,10 +121,18 @@ class StarterkitNextjsService {
    *   Gets the site path, useful in cases of multi-site arrangements.
    * @param \Drupal\Core\File\FileSystemInterface $file_system
    *   Lets us create a directory.
-   * @param Symfony\Component\HttpFoundation\RequestStack $request_stack
+   * @param \Symfony\Component\HttpFoundation\RequestStack $request_stack
    *   The current request.
    */
-  public function __construct(ConfigFactoryInterface $config_factory, DefaultPasswordGenerator $defaultPasswordGenerator, EntityTypeManagerInterface $entity_type_manager, KeyGeneratorService $key_generator_service, MessengerInterface $messenger, string $site_path, FileSystemInterface $file_system, RequestStack $request_stack) {
+  public function __construct(
+    ConfigFactoryInterface $config_factory,
+    DefaultPasswordGenerator $defaultPasswordGenerator,
+    EntityTypeManagerInterface $entity_type_manager,
+    KeyGeneratorService $key_generator_service,
+    MessengerInterface $messenger,
+    string $site_path,
+    FileSystemInterface $file_system,
+    RequestStack $request_stack) {
     $this->configFactory = $config_factory;
     $this->defaultPasswordGenerator = $defaultPasswordGenerator;
     $this->entityTypeManager = $entity_type_manager;
@@ -617,9 +625,11 @@ class StarterkitNextjsService {
     // that is passed to the $isDefault var.
     if (!empty($cid)) {
       $consumer = $consumerStorage->load($cid[0]);
-      $consumer
-        ->set('is_default', $isDefault)
-        ->save();
+      if ($consumer instanceof Consumer) {
+        $consumer
+          ->set('is_default', $isDefault)
+          ->save();
+      }
     }
   }
 
@@ -721,9 +731,13 @@ class StarterkitNextjsService {
 
     if ($secret = $next_site->getPreviewSecret()) {
       $consumer = $this->getHeadlessConsumerData($next_site->label());
+      if ($consumer instanceof Consumer) {
+        $variables += [
+          'DRUPAL_CLIENT_ID' => $consumer->getClientId(),
+        ];
+      }
       $variables += [
         'DRUPAL_PREVIEW_SECRET' => $secret,
-        'DRUPAL_CLIENT_ID' => $consumer->getClientId(),
         'DRUPAL_CLIENT_SECRET' => $this->consumerSecret ?? 'insert secret here',
       ];
     }

--- a/modules/acquia_cms_headless/tests/src/Functional/DashboardApiDocumentTest.php
+++ b/modules/acquia_cms_headless/tests/src/Functional/DashboardApiDocumentTest.php
@@ -38,6 +38,7 @@ class DashboardApiDocumentTest extends HeadlessTestBase {
    * {@inheritdoc}
    */
   public function testSection(): void {
+    /** @var \Drupal\FunctionalJavascriptTests\JSWebAssert $assertSession */
     $assertSession = $this->assertSession();
 
     // Test API Documentation section exists, get API Documentation section.
@@ -57,12 +58,12 @@ class DashboardApiDocumentTest extends HeadlessTestBase {
 
     // Test Explore with Swagger UI with headless role.
     $this->drupalGet("/admin/config/services/openapi/swagger/jsonapi");
-    $this->assertSession()->pageTextContains('Access denied!');
+    $assertSession->pageTextContains('Access denied!');
 
     // Test Explore with Swagger UI with admin role.
     $this->visitHeadlessDashboardAdmin();
     $this->drupalGet("/admin/config/services/openapi/swagger/jsonapi");
-    $this->assertSession()->waitForElementVisible('css', '#swagger-ui');
+    $assertSession->waitForElementVisible('css', '#swagger-ui');
     $swaggerUi = $this->getSession()->getPage()->find('css', '#swagger-ui');
     $this->assertNotEmpty($swaggerUi);
   }

--- a/modules/acquia_cms_headless/tests/src/Functional/DashboardApiKeysTest.php
+++ b/modules/acquia_cms_headless/tests/src/Functional/DashboardApiKeysTest.php
@@ -49,7 +49,7 @@ class DashboardApiKeysTest extends HeadlessTestBase {
    * {@inheritdoc}
    */
   public function testSection(): void {
-
+    /** @var \Drupal\FunctionalJavascriptTests\JSWebAssert $assertSession */
     $assertSession = $this->assertSession();
 
     // Test API Keys section exists, get API Keys section.
@@ -85,9 +85,11 @@ class DashboardApiKeysTest extends HeadlessTestBase {
    * {@inheritdoc}
    */
   private function testGenerateNewSecret(mixed $consumersFieldset): void {
+    /** @var \Drupal\FunctionalJavascriptTests\JSWebAssert $assertSession */
+    $assertSession = $this->assertSession();
     $consumersFieldset->findButton('List additional actions')->click();
-    $this->assertSession()->elementExists('named', ['link', 'Generate New Secret'], $consumersFieldset)->click();
-    $consumerModal = $this->assertSession()->waitForElementVisible('css', '.ui-dialog');
+    $assertSession->elementExists('named', ['link', 'Generate New Secret'], $consumersFieldset)->click();
+    $consumerModal = $assertSession->waitForElementVisible('css', '.ui-dialog');
     $this->assertNotEmpty($consumerModal);
     $this->assertEquals('Generate New Consumer Secret', $consumerModal->find('css', '.ui-dialog-title')->getText());
     $this->assertNotEmpty($consumerModal->find('css', '.headless-dashboard-modal'));
@@ -98,13 +100,15 @@ class DashboardApiKeysTest extends HeadlessTestBase {
    * {@inheritdoc}
    */
   private function testGenerateNewKeys(mixed $consumersFieldset): void {
-    $this->assertSession()->elementExists('named', ['link', 'Generate New Keys'], $consumersFieldset)->click();
-    $keysModal = $this->assertSession()->waitForElementVisible('css', '.ui-dialog');
+    /** @var \Drupal\FunctionalJavascriptTests\JSWebAssert $assertSession */
+    $assertSession = $this->assertSession();
+    $assertSession->elementExists('named', ['link', 'Generate New Keys'], $consumersFieldset)->click();
+    $keysModal = $assertSession->waitForElementVisible('css', '.ui-dialog');
     $this->assertNotEmpty($keysModal);
     $this->assertEquals('Generate New API Keys', $keysModal->find('css', '.ui-dialog-title')->getText());
     $keysModalContent = $keysModal->find('css', '.headless-dashboard-modal');
     $this->assertNotEmpty($keysModalContent);
-    $this->assertSession()->elementExists('named', ['link', 'Oauth Settings'], $keysModalContent);
+    $assertSession->elementExists('named', ['link', 'Oauth Settings'], $keysModalContent);
     $keysModal->find('css', '.ui-dialog-titlebar-close')->click();
   }
 
@@ -112,11 +116,13 @@ class DashboardApiKeysTest extends HeadlessTestBase {
    * {@inheritdoc}
    */
   private function testDelete(mixed $consumersFieldset): void {
+    /** @var \Drupal\FunctionalJavascriptTests\JSWebAssert $assertSession */
+    $assertSession = $this->assertSession();
     $consumersFieldset->findButton('List additional actions')->click();
-    $this->assertSession()->elementExists('named', ['link', 'Delete'], $consumersFieldset)->click();
+    $assertSession->elementExists('named', ['link', 'Delete'], $consumersFieldset)->click();
     $page = $this->getSession()->getPage();
     $this->assertNotEmpty($page);
-    $this->assertSession()->pageTextContains('Access denied!');
+    $assertSession->pageTextContains('Access denied!');
     $expectedUrl = $this->baseUrl . '/admin/config/services/consumer/1/delete?destination=/admin/headless/dashboard';
     $this->assertSame($expectedUrl, $this->getSession()->getCurrentUrl());
   }
@@ -125,12 +131,14 @@ class DashboardApiKeysTest extends HeadlessTestBase {
    * {@inheritdoc}
    */
   private function testClone(mixed $consumersFieldset): void {
+    /** @var \Drupal\FunctionalJavascriptTests\JSWebAssert $assertSession */
+    $assertSession = $this->assertSession();
     $this->drupalGet("/admin/headless/dashboard");
     $consumersFieldset->findButton('List additional actions')->click();
-    $this->assertSession()->elementExists('named', ['link', 'Clone'], $consumersFieldset)->click();
+    $assertSession->elementExists('named', ['link', 'Clone'], $consumersFieldset)->click();
     $page = $this->getSession()->getPage();
     $this->assertNotEmpty($page);
-    $this->assertSession()->pageTextContains('Access denied!');
+    $assertSession->pageTextContains('Access denied!');
     $expectedUrl = $this->baseUrl . '/entity_clone/consumer/1?destination=/admin/headless/dashboard';
     $this->assertSame($expectedUrl, $this->getSession()->getCurrentUrl());
   }

--- a/modules/acquia_cms_headless/tests/src/Functional/DashboardNextjsSitesTest.php
+++ b/modules/acquia_cms_headless/tests/src/Functional/DashboardNextjsSitesTest.php
@@ -143,22 +143,24 @@ class DashboardNextjsSitesTest extends HeadlessTestBase {
    * {@inheritdoc}
    */
   private function testEnvironmentVariables(mixed $nextjsSitesFieldset): void {
-    $this->assertSession()->elementExists('named', ['link', 'Environment variables'], $nextjsSitesFieldset)->click();
-    $nextjsSitesModal = $this->assertSession()->waitForElementVisible('css', '.ui-dialog');
+    /** @var \Drupal\FunctionalJavascriptTests\JSWebAssert $assertSession */
+    $assertSession = $this->assertSession();
+    $assertSession->elementExists('named', ['link', 'Environment variables'], $nextjsSitesFieldset)->click();
+    $nextjsSitesModal = $assertSession->waitForElementVisible('css', '.ui-dialog');
     $this->assertNotEmpty($nextjsSitesModal);
     $this->assertEquals('Environment variables', $nextjsSitesModal->find('css', '.ui-dialog-title')->getText());
     $nextjsSitesModalContent = $nextjsSitesModal->find('css', '#drupal-modal');
     $this->assertNotEmpty($nextjsSitesModalContent);
-    $this->assertSession()->elementExists('named', ['content', 'Copy and paste these values in your .env or .env.local files. To learn more about required and optional environment variables, refer to the documentation.'], $nextjsSitesModalContent);
-    $this->assertSession()->elementExists('named', ['content', '# See https://next-drupal.org/docs/environment-variables'], $nextjsSitesModalContent);
+    $assertSession->elementExists('named', ['content', 'Copy and paste these values in your .env or .env.local files. To learn more about required and optional environment variables, refer to the documentation.'], $nextjsSitesModalContent);
+    $assertSession->elementExists('named', ['content', '# See https://next-drupal.org/docs/environment-variables'], $nextjsSitesModalContent);
     // Required section.
-    $this->assertSession()->elementExists('named', ['content', 'NEXT_PUBLIC_DRUPAL_BASE_URL=' . $this->baseUrl], $nextjsSitesModalContent);
-    $this->assertSession()->elementExists('named', ['content', 'NEXT_IMAGE_DOMAIN=' . str_replace(":8080", "", str_replace("http://", "", $this->baseUrl))], $nextjsSitesModalContent);
+    $assertSession->elementExists('named', ['content', 'NEXT_PUBLIC_DRUPAL_BASE_URL=' . $this->baseUrl], $nextjsSitesModalContent);
+    $assertSession->elementExists('named', ['content', 'NEXT_IMAGE_DOMAIN=' . str_replace(":8080", "", str_replace("http://", "", $this->baseUrl))], $nextjsSitesModalContent);
     // Authentication section.
-    $this->assertSession()->elementExists('named', ['content', 'DRUPAL_CLIENT_ID=Retrieve this from /admin/config/services/consumer'], $nextjsSitesModalContent);
-    $this->assertSession()->elementExists('named', ['content', 'DRUPAL_CLIENT_SECRET=Retrieve this from /admin/config/services/consumer'], $nextjsSitesModalContent);
+    $assertSession->elementExists('named', ['content', 'DRUPAL_CLIENT_ID=Retrieve this from /admin/config/services/consumer'], $nextjsSitesModalContent);
+    $assertSession->elementExists('named', ['content', 'DRUPAL_CLIENT_SECRET=Retrieve this from /admin/config/services/consumer'], $nextjsSitesModalContent);
     // Required for Preview Mode.
-    $this->assertSession()->elementExists('named', ['content', 'DRUPAL_PREVIEW_SECRET=preview_secrete'], $nextjsSitesModalContent);
+    $assertSession->elementExists('named', ['content', 'DRUPAL_PREVIEW_SECRET=preview_secrete'], $nextjsSitesModalContent);
     $nextjsSitesModal->find('css', '.ui-dialog-titlebar-close')->click();
   }
 
@@ -166,15 +168,17 @@ class DashboardNextjsSitesTest extends HeadlessTestBase {
    * {@inheritdoc}
    */
   private function testEdit(mixed $nextjsSitesFieldset): void {
+    /** @var \Drupal\FunctionalJavascriptTests\JSWebAssert $assertSession */
+    $assertSession = $this->assertSession();
     $nextjsSitesFieldset->findButton('List additional actions')->click();
-    $this->assertSession()->elementExists('named', ['link', 'Edit'], $nextjsSitesFieldset)->click();
-    $nextjsSitesModal = $this->assertSession()->waitForElementVisible('css', '.ui-dialog');
+    $assertSession->elementExists('named', ['link', 'Edit'], $nextjsSitesFieldset)->click();
+    $nextjsSitesModal = $assertSession->waitForElementVisible('css', '.ui-dialog');
     $this->assertNotEmpty($nextjsSitesModal);
     $this->assertEquals('Edit headless clone', $nextjsSitesModal->find('css', '.ui-dialog-title')->getText());
     $nextjsSitesModalContent = $nextjsSitesModal->find('css', '#drupal-modal');
     $this->assertNotEmpty($nextjsSitesModalContent);
     $nextjsSitesModalContent->fillField('Label', 'headless clone edit');
-    $this->assertSession()->waitForElementVisible('css', '.ui-dialog-buttonpane .ui-dialog-buttonset .button--primary');
+    $assertSession->waitForElementVisible('css', '.ui-dialog-buttonpane .ui-dialog-buttonset .button--primary');
     $nextjsSitesModal->find('css', '.ui-dialog-buttonpane')->findButton('Save')->click();
   }
 
@@ -182,15 +186,17 @@ class DashboardNextjsSitesTest extends HeadlessTestBase {
    * {@inheritdoc}
    */
   private function testDelete(mixed $nextjsSitesFieldset): void {
+    /** @var \Drupal\FunctionalJavascriptTests\JSWebAssert $assertSession */
+    $assertSession = $this->assertSession();
     $nextjsSitesFieldset->findButton('List additional actions')->click();
-    $this->assertSession()->elementExists('named', ['link', 'Delete'], $nextjsSitesFieldset)->click();
-    $nextjsSitesModal = $this->assertSession()->waitForElementVisible('css', '.ui-dialog');
+    $assertSession->elementExists('named', ['link', 'Delete'], $nextjsSitesFieldset)->click();
+    $nextjsSitesModal = $assertSession->waitForElementVisible('css', '.ui-dialog');
     $this->assertNotEmpty($nextjsSitesModal);
     $this->assertEquals('Are you sure you want to delete the Next.js site headless clone edit?', $nextjsSitesModal->find('css', '.ui-dialog-title')->getText());
     $nextjsSitesModalContent = $nextjsSitesModal->find('css', '#drupal-modal');
     $this->assertNotEmpty($nextjsSitesModalContent);
-    $this->assertSession()->elementExists('named', ['content', 'This action cannot be undone.'], $nextjsSitesModalContent);
-    $this->assertSession()->waitForElementVisible('css', '.ui-dialog-buttonpane .ui-dialog-buttonset .button--primary');
+    $assertSession->elementExists('named', ['content', 'This action cannot be undone.'], $nextjsSitesModalContent);
+    $assertSession->waitForElementVisible('css', '.ui-dialog-buttonpane .ui-dialog-buttonset .button--primary');
     $nextjsSitesModal->find('css', '.ui-dialog-buttonpane')->findButton('Delete')->click();
   }
 
@@ -198,16 +204,18 @@ class DashboardNextjsSitesTest extends HeadlessTestBase {
    * {@inheritdoc}
    */
   private function testClone(mixed $nextjsSitesFieldset): void {
+    /** @var \Drupal\FunctionalJavascriptTests\JSWebAssert $assertSession */
+    $assertSession = $this->assertSession();
     $nextjsSitesFieldset->findButton('List additional actions')->click();
-    $this->assertSession()->elementExists('named', ['link', 'Clone'], $nextjsSitesFieldset)->click();
-    $nextjsSitesModal = $this->assertSession()->waitForElementVisible('css', '.ui-dialog');
+    $assertSession->elementExists('named', ['link', 'Clone'], $nextjsSitesFieldset)->click();
+    $nextjsSitesModal = $assertSession->waitForElementVisible('css', '.ui-dialog');
     $this->assertNotEmpty($nextjsSitesModal);
     $this->assertEquals('Clone Next.js site', $nextjsSitesModal->find('css', '.ui-dialog-title')->getText());
     $nextjsSitesModalContent = $nextjsSitesModal->find('css', '#drupal-modal');
     $this->assertNotEmpty($nextjsSitesModalContent);
     $nextjsSitesModalContent->fillField('New Label', 'headless clone');
-    $this->assertSession()->waitForElementVisible('css', '.admin-link');
-    $this->assertSession()->waitForElementVisible('css', '.ui-dialog-buttonpane .ui-dialog-buttonset .button--primary');
+    $assertSession->waitForElementVisible('css', '.admin-link');
+    $assertSession->waitForElementVisible('css', '.ui-dialog-buttonpane .ui-dialog-buttonset .button--primary');
     $nextjsSitesModal->find('css', '.ui-dialog-buttonpane')->findButton('Clone')->click();
   }
 
@@ -215,15 +223,17 @@ class DashboardNextjsSitesTest extends HeadlessTestBase {
    * {@inheritdoc}
    */
   private function testNewPreviewSecret(mixed $nextjsSitesFieldset): void {
+    /** @var \Drupal\FunctionalJavascriptTests\JSWebAssert $assertSession */
+    $assertSession = $this->assertSession();
     $nextjsSitesFieldset->findButton('List additional actions')->click();
-    $this->assertSession()->elementExists('named', ['link', 'New preview secret'], $nextjsSitesFieldset)->click();
-    $nextjsSitesModal = $this->assertSession()->waitForElementVisible('css', '.ui-dialog');
+    $assertSession->elementExists('named', ['link', 'New preview secret'], $nextjsSitesFieldset)->click();
+    $nextjsSitesModal = $assertSession->waitForElementVisible('css', '.ui-dialog');
     $this->assertNotEmpty($nextjsSitesModal);
     $this->assertEquals('Generate New Preview Secret', $nextjsSitesModal->find('css', '.ui-dialog-title')->getText());
     $nextjsSitesModalContent = $nextjsSitesModal->find('css', '#drupal-modal');
     $this->assertNotEmpty($nextjsSitesModalContent);
-    $this->assertSession()->elementExists('named', ['content', 'A preview secret has been generated for the headless next.js site:'], $nextjsSitesModalContent);
-    $this->assertSession()->elementExists('named', ['content', 'This value can also be retrieved from the next.js site entity.'], $nextjsSitesModalContent);
+    $assertSession->elementExists('named', ['content', 'A preview secret has been generated for the headless next.js site:'], $nextjsSitesModalContent);
+    $assertSession->elementExists('named', ['content', 'This value can also be retrieved from the next.js site entity.'], $nextjsSitesModalContent);
     $nextjsSitesModal->find('css', '.ui-dialog-titlebar-close')->click();
   }
 

--- a/modules/acquia_cms_headless/tests/src/Functional/HeadlessContentTest.php
+++ b/modules/acquia_cms_headless/tests/src/Functional/HeadlessContentTest.php
@@ -105,6 +105,7 @@ class HeadlessContentTest extends WebDriverTestBase {
     $menuList = $this->cssSelect('ul.tabs--primary li');
     // Check the total count of node tabs.
     $this->assertCount(6, $menuList);
+    $menuOrder = [];
     foreach ($menuList as $menu) {
       $menuOrder[] = str_replace(' (active tab)', '', $menu->getText());
     }

--- a/modules/acquia_cms_headless/tests/src/Functional/HeadlessDrushCommandsTest.php
+++ b/modules/acquia_cms_headless/tests/src/Functional/HeadlessDrushCommandsTest.php
@@ -47,8 +47,8 @@ class HeadlessDrushCommandsTest extends BrowserTestBase {
     $this->assertEquals("NEXT_IMAGE_DOMAIN=default", $newNextJsData[2]);
     $this->assertEquals("DRUPAL_SITE_ID=headless_site", $newNextJsData[3]);
     $this->assertEquals("DRUPAL_FRONT_PAGE=/user/login", $newNextJsData[4]);
-    $this->assertStringStartsWith("DRUPAL_PREVIEW_SECRET", $newNextJsData[5]);
-    $this->assertStringStartsWith("DRUPAL_CLIENT_ID", $newNextJsData[6]);
+    $this->assertStringStartsWith("DRUPAL_CLIENT_ID", $newNextJsData[5]);
+    $this->assertStringStartsWith("DRUPAL_PREVIEW_SECRET", $newNextJsData[6]);
     $this->assertStringStartsWith("DRUPAL_CLIENT_SECRET", $newNextJsData[7]);
 
     // Validate for same site-name.

--- a/modules/acquia_cms_headless/tests/src/Functional/HeadlessModeEnablementTest.php
+++ b/modules/acquia_cms_headless/tests/src/Functional/HeadlessModeEnablementTest.php
@@ -46,6 +46,7 @@ class HeadlessModeEnablementTest extends HeadlessTestBase {
       $account->addRole('administrator');
       $account->save();
       $this->drupalLogin($account);
+      /** @var \Drupal\FunctionalJavascriptTests\JSWebAssert $assertSession */
       $assertSession = $this->assertSession();
 
       // Click on Setup manually button to close the modal,

--- a/modules/acquia_cms_headless/tests/src/Functional/PureHeadlessModeMenuTest.php
+++ b/modules/acquia_cms_headless/tests/src/Functional/PureHeadlessModeMenuTest.php
@@ -4,6 +4,7 @@ namespace Drupal\Tests\acquia_cms_headless\Functional;
 
 use Acquia\DrupalEnvironmentDetector\AcquiaDrupalEnvironmentDetector;
 use Drupal\Core\Extension\Exception\UnknownExtensionException;
+use Drupal\Core\Extension\ModuleExtensionList;
 use Drupal\FunctionalJavascriptTests\WebDriverTestBase;
 
 /**
@@ -40,7 +41,7 @@ class PureHeadlessModeMenuTest extends WebDriverTestBase {
   /**
    * The module installer object.
    *
-   * @var \Drupal\Core\Extension\ModuleInstallerInterface
+   * @var \Drupal\Core\Extension\ModuleExtensionList
    */
   protected $moduleList;
 
@@ -77,11 +78,13 @@ class PureHeadlessModeMenuTest extends WebDriverTestBase {
   public function testChildMenu(string $selector, string $parentMenuName, array $childs): void {
     if ($this->installModule('acquia_cms_toolbar')) {
       $this->drupalGet('/admin/headless/dashboard');
-      $menu = $this->assertSession()->waitForElementVisible('css', $selector);
+      /** @var \Drupal\FunctionalJavascriptTests\JSWebAssert $assertSession */
+      $assertSession = $this->assertSession();
+      $menu = $assertSession->waitForElementVisible('css', $selector);
       $this->assertEquals($parentMenuName, $menu->getText());
       $menu->mouseOver();
       foreach ($childs as $key => $child) {
-        $this->assertEquals($child, $this->assertSession()->waitForElementVisible('css', $selector . ' + ul > li:nth-child(' . ++$key . ')')->getText());
+        $this->assertEquals($child, $assertSession->waitForElementVisible('css', $selector . ' + ul > li:nth-child(' . ++$key . ')')->getText());
       }
     }
   }
@@ -97,7 +100,9 @@ class PureHeadlessModeMenuTest extends WebDriverTestBase {
    */
   protected function installModule(string $module): bool {
     try {
-      $this->moduleList->get($module);
+      if ($this->moduleList instanceof ModuleExtensionList) {
+        $this->moduleList->get($module);
+      }
     }
     catch (UnknownExtensionException $e) {
       return FALSE;

--- a/modules/acquia_cms_headless/tests/src/Traits/HeadlessNextJsTrait.php
+++ b/modules/acquia_cms_headless/tests/src/Traits/HeadlessNextJsTrait.php
@@ -11,6 +11,7 @@ trait HeadlessNextJsTrait {
    * Function to enable headless mode.
    */
   protected function enableHeadlessMode(): void {
+    /** @var \Drupal\FunctionalJavascriptTests\JSWebAssert $assert */
     $assert = $this->assertSession();
     $page = $this->getSession()->getPage();
     $this->drupalGet("admin/tour/dashboard");
@@ -28,6 +29,7 @@ trait HeadlessNextJsTrait {
    * Assert new nextjs site.
    */
   protected function assertNewNextJsSites(): void {
+    /** @var \Drupal\FunctionalJavascriptTests\JSWebAssert $assert */
     $assert = $this->assertSession();
     $page = $this->getSession()->getPage();
     // Visit add nextJs site page.
@@ -60,6 +62,7 @@ trait HeadlessNextJsTrait {
    * Assert configure nextJs entity type.
    */
   protected function assertNextJsEntityTypeConfigure(): void {
+    /** @var \Drupal\FunctionalJavascriptTests\JSWebAssert $assert */
     $assert = $this->assertSession();
     $page = $this->getSession()->getPage();
     $this->drupalGet("admin/config/services/next/entity-types/add");

--- a/modules/acquia_cms_image/acquia_cms_image.install
+++ b/modules/acquia_cms_image/acquia_cms_image.install
@@ -102,7 +102,7 @@ function acquia_cms_image_update_8002() {
         'third_party_settings' => [],
       ],
     ];
-    if (!empty($config)) {
+    if ($config) {
       $config->set('content', $content)->save();
     }
   }

--- a/modules/acquia_cms_page/tests/src/Kernel/PageWithLayoutCanvasFieldTest.php
+++ b/modules/acquia_cms_page/tests/src/Kernel/PageWithLayoutCanvasFieldTest.php
@@ -36,7 +36,7 @@ class PageWithLayoutCanvasFieldTest extends FieldKernelTestBase {
   /**
    * The field_config object.
    *
-   * @var \Drupal\Core\Field\FieldDefinitionInterface
+   * @var \Drupal\field\FieldConfigStorage
    */
   protected $fieldDefinition;
 

--- a/modules/acquia_cms_place/tests/src/Functional/PlaceTest.php
+++ b/modules/acquia_cms_place/tests/src/Functional/PlaceTest.php
@@ -64,11 +64,11 @@ class PlaceTest extends ContentTypeTestBase {
     // for us to set address values in the UI, because we'd need to select a
     // country first, and that requires AJAX. To get around that, we set the
     // default country of field_place_address.
-    FieldConfig::loadByName('node', 'place', 'field_place_address')
-      ->setDefaultValue([
-        'country_code' => 'US',
-      ])
-      ->save();
+    /** @var \Drupal\Core\Field\FieldConfigBase $fieldConfig */
+    $fieldConfig = FieldConfig::loadByName('node', 'place', 'field_place_address');
+    $fieldConfig->setDefaultValue([
+      'country_code' => 'US',
+    ])->save();
 
     // Use a random geocoder, since we don't want to actually call out to Google
     // Maps or any other real geocoding service in tests.

--- a/modules/acquia_cms_search/acquia_cms_search.module
+++ b/modules/acquia_cms_search/acquia_cms_search.module
@@ -53,7 +53,7 @@ function acquia_cms_search_node_type_insert(NodeTypeInterface $node_type) {
  * Implements hook_ENTITY_TYPE_insert() for configurable field.
  */
 function acquia_cms_search_field_config_insert(FieldConfigInterface $field_config) {
-
+  /** @var \Drupal\Core\Field\FieldConfigBase $field_storage */
   $field_storage = $field_config->getFieldStorageDefinition();
 
   // Adding the third party settings in the node.body storage configuration to

--- a/modules/acquia_cms_search/src/Facade/AcquiaSearchFacade.php
+++ b/modules/acquia_cms_search/src/Facade/AcquiaSearchFacade.php
@@ -197,7 +197,7 @@ final class AcquiaSearchFacade implements ContainerInjectionInterface {
       }
     }
 
-    /** @var \Drupal\search_api\ServerInterface $server */
+    /** @var \Drupal\Core\Config\Entity\ConfigEntityInterface $databaseServer */
     $databaseServer = $this->serverStorage->load('database');
     try {
       $databaseServer->disable()->save();

--- a/modules/acquia_cms_search/src/Facade/SearchFacade.php
+++ b/modules/acquia_cms_search/src/Facade/SearchFacade.php
@@ -136,7 +136,7 @@ final class SearchFacade implements ContainerInjectionInterface {
     // Update the view mode used for this node type in the Search view.
     /** @var \Drupal\views\ViewEntityInterface $view */
     $view = $this->viewStorage->load('search');
-    if (empty($view)) {
+    if (!$view) {
       return;
     }
 
@@ -160,6 +160,9 @@ final class SearchFacade implements ContainerInjectionInterface {
    *
    * @param \Drupal\field\FieldStorageConfigInterface $field_storage
    *   The new field's storage definition.
+   *
+   * @throws \Drupal\Core\Entity\EntityStorageException
+   * @throws \Drupal\search_api\SearchApiException
    */
   public function addTaxonomyField(FieldStorageConfigInterface $field_storage) {
     $index = $this->loadIndexFromSettings($field_storage);
@@ -211,6 +214,9 @@ final class SearchFacade implements ContainerInjectionInterface {
    *
    * @param \Drupal\field\FieldStorageConfigInterface $field_storage
    *   The new field's storage definition.
+   *
+   * @throws \Drupal\Core\Entity\EntityStorageException
+   * @throws \Drupal\search_api\SearchApiException
    */
   public function addFields(FieldStorageConfigInterface $field_storage) {
     $index = $this->loadIndexFromSettings($field_storage);

--- a/modules/acquia_cms_site_studio/acquia_cms_site_studio.install
+++ b/modules/acquia_cms_site_studio/acquia_cms_site_studio.install
@@ -67,7 +67,7 @@ function acquia_cms_site_studio_install($is_syncing) {
       // Trigger save on page body field to update it.
       if ($module_handler->moduleExists('acquia_cms_page')) {
         $config = $config_factory->getEditable('field.field.node.page.body');
-        if (!empty($config)) {
+        if ($config) {
           $config->save();
         }
       }
@@ -94,7 +94,7 @@ function acquia_cms_site_studio_install($is_syncing) {
 
     // Set default configurations for node revision delete module.
     $config = $config_factory->getEditable('node_revision_delete.settings');
-    if (!empty($config)) {
+    if ($config) {
       $config->set('node_revision_delete_cron', '50')
         ->set('node_revision_delete_time', '604800')
         ->save();
@@ -184,7 +184,7 @@ function _acquia_cms_site_studio_set_theme() {
 function acquia_cms_site_studio_uninstall($is_syncing) {
   if (!$is_syncing) {
     $config = \Drupal::service('config.factory')->getEditable('field.field.node.page.body');
-    if (!empty($config)) {
+    if ($config) {
       $config->set('label', 'Body');
       $config->set('description', '');
       $config->save();
@@ -201,7 +201,7 @@ function acquia_cms_site_studio_update_8001() {
   // as the media entity won't be included as Site Studio
   // does not export content entities as part of packages.
   $config = \Drupal::service('config.factory')->getEditable('cohesion.settings');
-  if (!empty($config)) {
+  if ($config) {
     $config->set('image_browser.config', [
       'type' => 'imce_imagebrowser',
       'dx8_entity_browser' => 'media_browser',
@@ -229,7 +229,7 @@ function acquia_cms_site_studio_update_8003() {
   // Install node revision delete module and set default configurations.
   \Drupal::service('module_installer')->install(['node_revision_delete']);
   $config = \Drupal::service('config.factory')->getEditable('node_revision_delete.settings');
-  if (!empty($config)) {
+  if ($config) {
     $config->set('node_revision_delete_cron', '50')
       ->set('node_revision_delete_time', '604800')
       ->save();

--- a/modules/acquia_cms_site_studio/acquia_cms_site_studio.module
+++ b/modules/acquia_cms_site_studio/acquia_cms_site_studio.module
@@ -130,17 +130,6 @@ function acquia_cms_site_studio_form_alter(array &$form, FormStateInterface $for
 }
 
 /**
- * Rebuilds cohesion styles & components.
- *
- * @throws Exception
- */
-function _acquia_cms_site_studio_rebuild_styles() {
-  // Get the batch array filled with operations that should be performed during
-  // rebuild.
-  batch_set(install_acms_site_studio_rebuild());
-}
-
-/**
  * Implements hook_content_model_role_presave_alter().
  */
 function acquia_cms_site_studio_content_model_role_presave_alter(RoleInterface &$role) {

--- a/modules/acquia_cms_starter/src/EventSubscriber/DefaultContentEventUpdateSubscriber.php
+++ b/modules/acquia_cms_starter/src/EventSubscriber/DefaultContentEventUpdateSubscriber.php
@@ -45,12 +45,15 @@ class DefaultContentEventUpdateSubscriber implements EventSubscriberInterface {
     $module = $event->getModule();
     if ($module === 'acquia_cms_starter') {
       foreach ($event->getImportedEntities() as $entity) {
-        /** @var \Drupal\node\NodeInterface */
+        /** @var \Drupal\node\NodeInterface  $entity*/
         if ($entity instanceof NodeInterface && $entity->bundle() === 'event') {
+          $field_event_start = new \DateTime($entity->get('field_event_start')->value);
+          $field_event_end = new \DateTime($entity->get('field_event_end')->value);
+          $field_door_time = new \DateTime($entity->get('field_door_time')->value);
           $date_time = [
-            'start_date' => $entity->get('field_event_start')->date->format('Y-m-d'),
-            'end_date' => !empty($entity->get('field_event_end')->value) ? $entity->get('field_event_end')->date->format('Y-m-d') : '',
-            'door_time' => $entity->get('field_door_time')->date->format('Y-m-d'),
+            'start_date' => $field_event_start->format('Y-m-d'),
+            'end_date' => $field_event_end->format('Y-m-d'),
+            'door_time' => $field_door_time->format('Y-m-d'),
           ];
           $updated_data = $this->updateEventImport->getUpdatedDates($date_time);
           // Updating event node with modified dates.

--- a/modules/acquia_cms_tour/src/AcquiaCmsStarterKitPluginBase.php
+++ b/modules/acquia_cms_tour/src/AcquiaCmsStarterKitPluginBase.php
@@ -8,6 +8,13 @@ namespace Drupal\acquia_cms_tour;
 abstract class AcquiaCmsStarterKitPluginBase implements AcquiaCmsStarterKitInterface {
 
   /**
+   * The plugin definition.
+   *
+   * @var mixed
+   */
+  protected $pluginDefinition;
+
+  /**
    * {@inheritdoc}
    */
   public function label() {

--- a/modules/acquia_cms_tour/src/AcquiaCmsTourPluginBase.php
+++ b/modules/acquia_cms_tour/src/AcquiaCmsTourPluginBase.php
@@ -8,6 +8,13 @@ namespace Drupal\acquia_cms_tour;
 abstract class AcquiaCmsTourPluginBase implements AcquiaCmsTourInterface {
 
   /**
+   * The plugin definition.
+   *
+   * @var mixed
+   */
+  protected $pluginDefinition;
+
+  /**
    * {@inheritdoc}
    */
   public function label() {

--- a/modules/acquia_cms_tour/src/Form/InstallationWizardForm.php
+++ b/modules/acquia_cms_tour/src/Form/InstallationWizardForm.php
@@ -38,9 +38,9 @@ class InstallationWizardForm extends FormBase {
   protected $useAjax = TRUE;
 
   /**
-   * The rendered array renderer.
+   * The rendered service.
    *
-   * @var array
+   * @var \Drupal\Core\Render\Renderer
    */
   protected $renderer;
 
@@ -440,8 +440,12 @@ class InstallationWizardForm extends FormBase {
     ];
     // Change details to fieldset for all form.
     $form[$key]['#type'] = 'fieldset';
-    unset($form[$key]['actions']);
-    unset($form[$key]['#title']);
+    if (isset($form[$key]['actions'])) {
+      unset($form[$key]['actions']);
+    }
+    if (isset($form[$key]['#title'])) {
+      unset($form[$key]['#title']);
+    }
     return $form;
   }
 

--- a/modules/acquia_cms_tour/src/Form/StarterKitSelectionWizardForm.php
+++ b/modules/acquia_cms_tour/src/Form/StarterKitSelectionWizardForm.php
@@ -38,9 +38,9 @@ class StarterKitSelectionWizardForm extends FormBase {
   protected $useAjax = TRUE;
 
   /**
-   * The rendered array renderer.
+   * The renderer service.
    *
-   * @var array
+   * @var \Drupal\Core\Render\Renderer
    */
   protected $renderer;
 
@@ -399,7 +399,9 @@ class StarterKitSelectionWizardForm extends FormBase {
     ];
     // Change details to fieldset for all form.
     $form[$key]['#type'] = 'fieldset';
-    unset($form[$key]['#title']);
+    if (isset($form[$key]['#title'])) {
+      unset($form[$key]['#title']);
+    }
     return $form;
   }
 

--- a/modules/acquia_cms_tour/src/Form/WelcomeModalForm.php
+++ b/modules/acquia_cms_tour/src/Form/WelcomeModalForm.php
@@ -48,7 +48,7 @@ class WelcomeModalForm extends FormBase {
    *
    * @param \Drupal\Core\State\StateInterface $state
    *   The state service.
-   * @param \Drupal\Core\State\ProfileExtensionList $profile_extension_list
+   * @param \Drupal\Core\Extension\ProfileExtensionList $profile_extension_list
    *   The profile extension list object.
    * @param \Drupal\Core\Config\ConfigFactoryInterface $config_factory
    *   The config.factory service object.

--- a/modules/acquia_cms_tour/src/Plugin/AcquiaCmsStarterKit/StarterKitConfigForm.php
+++ b/modules/acquia_cms_tour/src/Plugin/AcquiaCmsStarterKit/StarterKitConfigForm.php
@@ -3,7 +3,6 @@
 namespace Drupal\acquia_cms_tour\Plugin\AcquiaCmsStarterKit;
 
 use Drupal\acquia_cms_tour\Form\AcquiaCmsStarterKitBase;
-use Drupal\acquia_cms_tour\Services\StarterKitService;
 use Drupal\Component\Render\FormattableMarkup;
 use Drupal\Core\Form\FormStateInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
@@ -29,9 +28,9 @@ class StarterKitConfigForm extends AcquiaCmsStarterKitBase {
   /**
    * Starterkit service.
    *
-   * @var Drupal\acquia_cms_tour\Services\StarterKitService
+   * @var \Drupal\acquia_cms_tour\Services\StarterKitService
    */
-  protected StarterKitService $starterKitService;
+  protected $starterKitService;
 
   /**
    * {@inheritdoc}

--- a/modules/acquia_cms_video/tests/src/Functional/VideoTest.php
+++ b/modules/acquia_cms_video/tests/src/Functional/VideoTest.php
@@ -47,10 +47,12 @@ class VideoTest extends MediaTypeTestBase {
    */
   protected function setUp(): void {
     parent::setUp();
-    // Set the a default value for field_media_oembed_video so that we can
+    // Set the default value for field_media_oembed_video so that we can
     // bypass the oEmbed system's URL validation. (It's not necessary for this
     // test anyway).
-    FieldConfig::loadByName('media', $this->mediaType, 'field_media_oembed_video')
+    /** @var \Drupal\Core\Field\FieldConfigBase $fieldConfig */
+    $fieldConfig = FieldConfig::loadByName('media', $this->mediaType, 'field_media_oembed_video');
+    $fieldConfig
       ->setDefaultValue('https://www.youtube.com/watch?v=6e8QyfvQMmU&list=PLpVC00PAQQxHzlDeQvCNDKkyKRV1G3_vT')
       ->save();
   }

--- a/patches/custom-rules.patch
+++ b/patches/custom-rules.patch
@@ -1,0 +1,14 @@
+diff --git a/drupal-check/src/Command/CheckCommand.php b/drupal-check/src/Command/CheckCommand.php
+index 450dbd9..97d538b 100644
+--- a/drupal-check/src/Command/CheckCommand.php
++++ b/drupal-check/src/Command/CheckCommand.php
+@@ -170,7 +170,8 @@ class CheckCommand extends Command
+                 '#\Drupal calls should be avoided in classes, use dependency injection instead#',
+                 '#Plugin definitions cannot be altered.#',
+                 '#Missing cache backend declaration for performance.#',
+-                '#Plugin manager has cache backend specified but does not declare cache tags.#'
++                '#Plugin manager has cache backend specified but does not declare cache tags.#',
++                '#[a-zA-Z0-9\\_]+\\:\\:buildForm\\(\\) should return array but return statement is missing.#'
+             ];
+             $configuration_data['parameters']['ignoreErrors'] = array_merge($ignored_deprecation_errors, $configuration_data['parameters']['ignoreErrors']);
+         }


### PR DESCRIPTION
**Motivation**
<!-- What problem does this solve? Why is it important? What's the context? If this fixes an issue, link to it above. -->
Fixes #[ACMS-1712](https://backlog.acquia.com/browse/ACMS-1712)

**Proposed changes**
Fix drupal-check issue reported in all acquia_cms modules

**Alternatives considered**
NA

**Testing steps**

- Get this PR code in your local
- Run command `php vendor/bin/drupal-check  modules/`

**Merge requirements**
- [ ] _Major change_, _Minor change_, _Bug_, _Enhancement_, and/or _Chore_ label applied
- [ ] Manual testing by a reviewer
