### PR TITLE
ACMS-000: Removed checklistapi patches.

### DIFF
--- a/modules/acquia_cms_common/composer.json
+++ b/modules/acquia_cms_common/composer.json
@@ -102,9 +102,7 @@
                 "3162210 - Preview link accidentally closes the media library": "https://www.drupal.org/files/issues/2020-10-06/3162210-17.patch"
             },
             "drupal/checklistapi": {
-                "2311855: Count the default setting on the total percentage counter": "https://www.drupal.org/files/issues/2021-10-26/checklistapi-count-default-values-forprogress-2311855-2.patch",
-                "3345172: Fix Drupal 10 - PHP Fatal error: Type of ChecklistapiCommands::$logger must be LoggerInterface": "https://git.drupalcode.org/project/checklistapi/-/commit/4b02386.patch"
-
+                "2311855: Count the default setting on the total percentage counter": "https://www.drupal.org/files/issues/2021-10-26/checklistapi-count-default-values-forprogress-2311855-2.patch"
             }
         }
     },


### PR DESCRIPTION
**Motivation**
<!-- What problem does this solve? Why is it important? What's the context? If this fixes an issue, link to it above. -->
Fixes ACMS-000

**Proposed changes**
checklistapi patches used in acquia_cms_common are now merged in the module and hence removing this fixes ACMS installation issue.


