### PR TITLE
ACMS-1618: pin collapsiblock to 4.0.0.

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -2906,13 +2906,13 @@
             "dist": {
                 "type": "path",
                 "url": "./modules/acquia_cms_search",
-                "reference": "cc669fcd01ec8c7f63f21cb6b1de381fdcde5a3c"
+                "reference": "aa8bece4f1ac85788493495b31756fb7b1127691"
             },
             "require": {
                 "cweagans/composer-patches": "^1.7",
                 "drupal/acquia_cms_common": "1.x-dev || 2.x-dev",
                 "drupal/acquia_search": "^3.1",
-                "drupal/collapsiblock": "^4.0",
+                "drupal/collapsiblock": "4.0.0",
                 "drupal/facets": "^2.0.6",
                 "drupal/facets_pretty_paths": "^1.4",
                 "drupal/search_api": "1.28",
@@ -2948,13 +2948,13 @@
             "dist": {
                 "type": "path",
                 "url": "./modules/acquia_cms_site_studio",
-                "reference": "4667a8a03bee1cea08e508ce4123654f5783cd5c"
+                "reference": "1a0a5012e74744e6f2639852cdf4664a4cc8c050"
             },
             "require": {
                 "acquia/cohesion": "^6.9.2 || ^7.0",
                 "acquia/cohesion-theme": "^6.9 || ^7.0",
                 "drupal/acquia_cms_common": "1.x-dev || 2.x-dev",
-                "drupal/collapsiblock": "^4.0",
+                "drupal/collapsiblock": "4.0.0",
                 "drupal/node_revision_delete": "^1.0"
             },
             "conflict": {

--- a/modules/acquia_cms_search/composer.json
+++ b/modules/acquia_cms_search/composer.json
@@ -7,7 +7,7 @@
         "cweagans/composer-patches": "^1.7",
         "drupal/acquia_cms_common": "1.x-dev || 2.x-dev",
         "drupal/acquia_search": "^3.1",
-        "drupal/collapsiblock": "^4.0",
+        "drupal/collapsiblock": "4.0.0",
         "drupal/facets": "^2.0.6",
         "drupal/facets_pretty_paths": "^1.4",
         "drupal/search_api": "1.28",

--- a/modules/acquia_cms_site_studio/composer.json
+++ b/modules/acquia_cms_site_studio/composer.json
@@ -7,7 +7,7 @@
         "acquia/cohesion": "^6.9.2 || ^7.0",
         "acquia/cohesion-theme": "^6.9 || ^7.0",
         "drupal/acquia_cms_common": "1.x-dev || 2.x-dev",
-        "drupal/collapsiblock": "^4.0",
+        "drupal/collapsiblock": "4.0.0",
         "drupal/node_revision_delete": "^1.0"
     },
     "conflict": {


### PR DESCRIPTION
**Motivation**
Test in CI failing with collapsiblock 4.0.1 version, pin version to 4.0.0.

**Proposed changes**
Pin collapsiblock to 4.0.0.

**Alternatives considered**
N/A

**Testing steps**
Verify collapsiblock version 4.0.0
Verify test are passing in CI

**Merge requirements**
- [ ] _Major change_, _Minor change_, _Bug_, _Enhancement_, and/or _Chore_ label applied
- [ ] Manual testing by a reviewer
