### PR TITLE
ACMS-1729: Fix failing ExistingSiteJavascript test in CI.

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -2845,13 +2845,13 @@
             "dist": {
                 "type": "path",
                 "url": "./modules/acquia_cms_search",
-                "reference": "837d0294e966a98118cc640254f42f3547249e3c"
+                "reference": "f3c4b4caa559235bc1cf050e880734ce8307506a"
             },
             "require": {
                 "cweagans/composer-patches": "^1.7",
                 "drupal/acquia_cms_common": "1.x-dev || 2.x-dev || 3.x-dev",
                 "drupal/acquia_search": "^3.1",
-                "drupal/collapsiblock": "4.0.0",
+                "drupal/collapsiblock": "^4.0",
                 "drupal/facets": "2.0.6",
                 "drupal/facets_pretty_paths": "^1.4",
                 "drupal/search_api": "^1.29",
@@ -2888,13 +2888,13 @@
             "dist": {
                 "type": "path",
                 "url": "./modules/acquia_cms_site_studio",
-                "reference": "ecdb7c39246a6a7672aa12ba005ec85a062ca550"
+                "reference": "08b095654e5ad98a41a959f2d86e9d78093c86d7"
             },
             "require": {
                 "acquia/cohesion": "^6.9.2 || ^7.0",
                 "acquia/cohesion-theme": "^6.9 || ^7.0",
                 "drupal/acquia_cms_common": "1.x-dev || 2.x-dev || 3.x-dev",
-                "drupal/collapsiblock": "4.0.0",
+                "drupal/collapsiblock": "^4.0",
                 "drupal/node_revision_delete": "^1.0",
                 "drupal/responsive_preview": "^2.1"
             },
@@ -3721,17 +3721,17 @@
         },
         {
             "name": "drupal/collapsiblock",
-            "version": "4.0.0",
+            "version": "4.0.2",
             "source": {
                 "type": "git",
                 "url": "https://git.drupalcode.org/project/collapsiblock.git",
-                "reference": "4.0.0"
+                "reference": "4.0.2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://ftp.drupal.org/files/projects/collapsiblock-4.0.0.zip",
-                "reference": "4.0.0",
-                "shasum": "182b1aa4a61d8a985e48730ed15ca6869785b45e"
+                "url": "https://ftp.drupal.org/files/projects/collapsiblock-4.0.2.zip",
+                "reference": "4.0.2",
+                "shasum": "61a5244a4a8944398977653ae88073711ae801d9"
             },
             "require": {
                 "drupal/core": "^9.2 || ^10"
@@ -3739,8 +3739,8 @@
             "type": "drupal-module",
             "extra": {
                 "drupal": {
-                    "version": "4.0.0",
-                    "datestamp": "1670190899",
+                    "version": "4.0.2",
+                    "datestamp": "1683500945",
                     "security-coverage": {
                         "status": "covered",
                         "message": "Covered by Drupal's security advisory policy"

--- a/modules/acquia_cms_search/composer.json
+++ b/modules/acquia_cms_search/composer.json
@@ -7,7 +7,7 @@
         "cweagans/composer-patches": "^1.7",
         "drupal/acquia_cms_common": "1.x-dev || 2.x-dev || 3.x-dev",
         "drupal/acquia_search": "^3.1",
-        "drupal/collapsiblock": "4.0.0",
+        "drupal/collapsiblock": "^4.0",
         "drupal/facets": "2.0.6",
         "drupal/facets_pretty_paths": "^1.4",
         "drupal/search_api": "^1.29",

--- a/modules/acquia_cms_site_studio/composer.json
+++ b/modules/acquia_cms_site_studio/composer.json
@@ -7,7 +7,7 @@
         "acquia/cohesion": "^6.9.2 || ^7.0",
         "acquia/cohesion-theme": "^6.9 || ^7.0",
         "drupal/acquia_cms_common": "1.x-dev || 2.x-dev || 3.x-dev",
-        "drupal/collapsiblock": "4.0.0",
+        "drupal/collapsiblock": "^4.0",
         "drupal/node_revision_delete": "^1.0",
         "drupal/responsive_preview": "^2.1"
     },

--- a/tests/ci/install.sh
+++ b/tests/ci/install.sh
@@ -48,6 +48,11 @@ curl "https://codeload.github.com/swagger-api/swagger-ui/zip/refs/tags/v3.0.17" 
 unzip ${ORCA_FIXTURE_DIR}/docroot/libraries/v3.0.17.zip
 mv swagger-ui-3.0.17 ${ORCA_FIXTURE_DIR}/docroot/libraries/swagger-ui
 
+# Add slide-element library locally
+mkdir -p ${ORCA_FIXTURE_DIR}/docroot/libraries/slide-element
+curl "https://unpkg.com/slide-element@2.3.1/dist/index.umd.js" -o ${ORCA_FIXTURE_DIR}/docroot/libraries/slide-element/index.umd.js
+
+# Add chartjs library locally
 mkdir -p ${ORCA_FIXTURE_DIR}/docroot/libraries/chartjs/dist/
 curl "https://cdn.jsdelivr.net/npm/chart.js@4.2.0/dist/chart.umd.min.js" -o ${ORCA_FIXTURE_DIR}/docroot/libraries/chartjs/dist/chart.min.js
 


### PR DESCRIPTION
**Motivation**
<!-- What problem does this solve? Why is it important? What's the context? If this fixes an issue, link to it above. -->
Fixes #[ACMS-1729](https://backlog.acquia.com/browse/ACMS-1729)

**Proposed changes**
Fix failing ExistingSiteJavascript test in CI.

**Alternatives considered**
Pin collapsiblock to version 4.0.0

**Testing steps**
- Checkout this branch and run composer install
- Install site with site studio key present
- Run test tests/src/ExistingSiteJavascript/SearchTest.php and you will see the failure.

**Merge requirements**
- [ ] _Major change_, _Minor change_, _Bug_, _Enhancement_, and/or _Chore_ label applied
- [ ] Manual testing by a reviewer
