### PR TITLE
Feature/moving dependencies 2.x

### DIFF
--- a/acquia_cms.info.yml
+++ b/acquia_cms.info.yml
@@ -5,17 +5,17 @@ type: module
 core_version_requirement: ^9 || ^10
 version: '2.1.0'
 dependencies:
-  - drupal:acquia_cms_article
-  - drupal:acquia_cms_document
-  - drupal:acquia_cms_event
-  - drupal:acquia_cms_page
-  - drupal:acquia_cms_search
-  - drupal:acquia_cms_site_studio
-  - drupal:acquia_cms_toolbar
-  - drupal:acquia_cms_tour
-  - drupal:acquia_cms_video
-  - drupal:google_analytics
-  - drupal:google_tag
+  - acquia_cms_article:acquia_cms_article
+  - acquia_cms_document:acquia_cms_document
+  - acquia_cms_event:acquia_cms_event
+  - acquia_cms_page:acquia_cms_page
+  - acquia_cms_search:acquia_cms_search
+  - acquia_cms_site_studio:acquia_cms_site_studio
+  - acquia_cms_toolbar:acquia_cms_toolbar
+  - acquia_cms_tour:acquia_cms_tour
+  - acquia_cms_video:acquia_cms_video
+  - google_analytics:google_analytics
+  - google_tag:google_tag
   - drupal:history
-  - drupal:honeypot
-  - drupal:recaptcha
+  - honeypot:honeypot
+  - recaptcha:recaptcha

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,15 @@
         "drupal/acquia_cms_starter": "^1.4",
         "drupal/acquia_cms_toolbar": "^1.4",
         "drupal/acquia_cms_tour": "^2.1",
-        "drush/drush": "^10 || ^11"
+        "drupal/acquia_search": "3.1.5",
+        "drupal/google_analytics": "^4.0",
+        "drupal/google_tag": "^1.6",
+        "drupal/honeypot": "^2.1",
+        "drupal/recaptcha": "^3.1",
+        "drupal/reroute_email": "^2.2",
+        "drupal/shield": "^1.7",
+        "drush/drush": "^10 || ^11",
+        "nnnick/chartjs": "^3.9"
     },
     "require-dev": {
         "acquia/coding-standards": "^1.0",
@@ -46,7 +54,9 @@
             "dealerdirect/phpcodesniffer-composer-installer": true,
             "drupal/core-composer-scaffold": true,
             "ergebnis/composer-normalize": true,
+            "mnsami/composer-custom-directory-installer": true,
             "oomphinc/composer-installers-extender": true,
+            "php-http/discovery": true,
             "phpro/grumphp-shim": true,
             "phpstan/extension-installer": true,
             "webdriver-binary/binary-chromedriver": true

--- a/tests/ci/install.sh
+++ b/tests/ci/install.sh
@@ -52,7 +52,7 @@ mkdir -p ${ORCA_FIXTURE_DIR}/docroot/libraries/chartjs/dist/
 curl "https://cdn.jsdelivr.net/npm/chart.js@4.2.0/dist/chart.umd.min.js" -o ${ORCA_FIXTURE_DIR}/docroot/libraries/chartjs/dist/chart.min.js
 
 # We require this patch in order to pass CI.
-composer config --json extra.patches '{"drupal/core":{"3313342 - [PHP 8.1] Deprecated function: strpos(): Passing null to parameter #1 LayoutBuilderUiCacheContext.php on line 28":"https://git.drupalcode.org/project/drupal/-/merge_requests/3143.patch","3328187 - PHP Deprecated: strpos(): Passing null to parameter #1 ($haystack) of type string is deprecated in docroot/core/lib/Drupal/Core/Mail/Plugin/Mail/PhpMail.php on line 112":"https://git.drupalcode.org/project/drupal/-/merge_requests/3142.patch"}}'
+composer config --json extra.patches '{"drupal/core":{"3328187 - PHP Deprecated: strpos(): Passing null to parameter #1 ($haystack) of type string is deprecated in docroot/core/lib/Drupal/Core/Mail/Plugin/Mail/PhpMail.php on line 112":"https://git.drupalcode.org/project/drupal/-/merge_requests/3142.patch"}}'
 
 # Allow acquia_cms as allowed package dependencies, so that composer scaffolds acquia_cms files.
 # This is important for now, otherwise PHPUnit tests: MaintenancePageTest will fail.


### PR DESCRIPTION
**Motivation**
Fixes #ACMS-1746

**Proposed changes**
Moved contrib modules from ACMS common to ACMS module:
acquia_search, google_analytics, google_tag, honeypot, recaptcha, reroute_email, shield, nnnick/chartjs

**Alternatives considered**
NA

**Testing steps**
CI should Pass

**Merge requirements**
- [ ] _Major change_, _Minor change_, _Bug_, _Enhancement_, and/or _Chore_ label applied
- [ ] Manual testing by a reviewer
