### PR TITLE
ACMS-1748: Fix Chart Js Library failing ACMS CI jobs.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -138,6 +138,18 @@
         ]
     },
     "repositories": {
+        "chart.js": {
+            "type": "package",
+            "package": {
+                "name": "nnnick/chartjs",
+                "version": "v3.9.1",
+                "type": "drupal-library",
+                "dist": {
+                    "url": "https://github.com/chartjs/Chart.js/releases/download/v3.9.1/chart.js-3.9.1.tgz",
+                    "type": "tar"
+                }
+            }
+        },
         "acquia_cms_article": {
             "type": "path",
             "url": "./modules/acquia_cms_article",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "51a2b6506f41eb07c36ddf77cdf92bda",
+    "content-hash": "da2b9864b6bd706553e7df1780fa393f",
     "packages": [
         {
             "name": "acquia/acquia-cms-starterkit",
@@ -5229,6 +5229,10 @@
                 {
                     "name": "colan",
                     "homepage": "https://www.drupal.org/user/58704"
+                },
+                {
+                    "name": "joevagyok",
+                    "homepage": "https://www.drupal.org/user/2876343"
                 },
                 {
                     "name": "NickDickinsonWilde",
@@ -11556,46 +11560,11 @@
         {
             "name": "nnnick/chartjs",
             "version": "v3.9.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/chartjs/Chart.js.git",
-                "reference": "5ea4b3adffcea61c7ec256ac3976927c5619c17a"
-            },
             "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/chartjs/Chart.js/zipball/5ea4b3adffcea61c7ec256ac3976927c5619c17a",
-                "reference": "5ea4b3adffcea61c7ec256ac3976927c5619c17a",
-                "shasum": ""
+                "type": "tar",
+                "url": "https://github.com/chartjs/Chart.js/releases/download/v3.9.1/chart.js-3.9.1.tgz"
             },
-            "require": {
-                "php": ">=5.3.3"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "release/2.0": "v2.0-dev"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "NICK DOWNIE",
-                    "email": "hello@nickdownie.com"
-                }
-            ],
-            "description": "Simple HTML5 charts using the canvas element.",
-            "homepage": "https://www.chartjs.org/",
-            "keywords": [
-                "JS",
-                "chart"
-            ],
-            "support": {
-                "issues": "https://github.com/chartjs/Chart.js/issues",
-                "source": "https://github.com/chartjs/Chart.js/tree/v3.9.1"
-            },
+            "type": "drupal-library",
             "time": "2022-08-03T12:46:38+00:00"
         },
         {


### PR DESCRIPTION
**Motivation**
<!-- What problem does this solve? Why is it important? What's the context? If this fixes an issue, link to it above. -->
Fixes #[ACMS-1748](https://backlog.acquia.com/browse/ACMS-1748)

**Proposed changes**
Fix failing CI jobs due to the recent change in chartjs library.

**Alternatives considered**
NA

**Testing steps**
<!-- How can we replicate the issue and verify that this PR fixes it? -->

**Merge requirements**
- [ ] _Major change_, _Minor change_, _Bug_, _Enhancement_, and/or _Chore_ label applied
- [ ] Manual testing by a reviewer
