### PR TITLE
ACMS-1816: Acquia CMS should not install Site Studio Style Guide Manager if it's not using it

### DIFF
--- a/modules/acquia_cms_headless/tests/src/Functional/DashboardNextjsSitesTest.php
+++ b/modules/acquia_cms_headless/tests/src/Functional/DashboardNextjsSitesTest.php
@@ -49,7 +49,9 @@ class DashboardNextjsSitesTest extends HeadlessTestBase {
    * {@inheritdoc}
    */
   public function testSection(): void {
-
+    /** @var \Drupal\FunctionalJavascriptTests\JSWebAssert $assertSession */
+    $assertSession = $this->assertSession();
+    $assertSession->waitForElementVisible('css', '#acquia-cms-headless-next-sites');
     // Test API Keys section exists, get API Keys section.
     $nextjsSitesFieldset = $this->getSection();
 
@@ -70,7 +72,9 @@ class DashboardNextjsSitesTest extends HeadlessTestBase {
    */
   public function testSectionAdmin(): void {
     $this->visitHeadlessDashboardAdmin();
-
+    /** @var \Drupal\FunctionalJavascriptTests\JSWebAssert $assertSession */
+    $assertSession = $this->assertSession();
+    $assertSession->waitForElementVisible('css', '#acquia-cms-headless-next-sites');
     // Test API Keys section exists, get API Keys section.
     $nextjsSitesFieldset = $this->getSection();
 

--- a/modules/acquia_cms_site_studio/acquia_cms_site_studio.info.yml
+++ b/modules/acquia_cms_site_studio/acquia_cms_site_studio.info.yml
@@ -9,7 +9,6 @@ dependencies:
   - cohesion_base_styles
   - cohesion_custom_styles
   - cohesion_elements
-  - cohesion_style_guide
   - cohesion_style_helpers
   - cohesion_sync
   - cohesion_templates

--- a/modules/acquia_cms_site_studio/acquia_cms_site_studio.install
+++ b/modules/acquia_cms_site_studio/acquia_cms_site_studio.install
@@ -140,6 +140,9 @@ function acquia_cms_site_studio_install($is_syncing) {
         ]);
       }
     }
+
+    // Install cohesion_style_guide module.
+    \Drupal::service('module_installer')->install(['cohesion_style_guide']);
   }
 }
 

--- a/modules/acquia_cms_site_studio/acquia_cms_site_studio.module
+++ b/modules/acquia_cms_site_studio/acquia_cms_site_studio.module
@@ -192,3 +192,19 @@ function _acquia_cms_site_studio_add_permissions(EntityInterface $entity) {
     }
   }
 }
+
+/**
+ * Implements hook_modules_installed().
+ */
+function acquia_cms_site_studio_modules_installed($modules, $is_syncing) {
+  if (!$is_syncing) {
+    if (in_array('cohesion_style_guide', $modules)) {
+      user_role_grant_permissions('developer', [
+        'administer style_guide',
+      ]);
+      user_role_grant_permissions('site_builder', [
+        'administer style_guide',
+      ]);
+    }
+  }
+}

--- a/modules/acquia_cms_site_studio/config/install/user.role.developer.yml
+++ b/modules/acquia_cms_site_studio/config/install/user.role.developer.yml
@@ -51,6 +51,5 @@ permissions:
   - 'administer master templates'
   - 'administer menu templates'
   - 'administer style helpers'
-  - 'administer style_guide'
   - 'administer view templates'
   - 'administer website settings'

--- a/modules/acquia_cms_site_studio/src/Helper/SiteStudioPermissionHelper.php
+++ b/modules/acquia_cms_site_studio/src/Helper/SiteStudioPermissionHelper.php
@@ -111,7 +111,6 @@ class SiteStudioPermissionHelper {
           'administer helper categories',
           'administer helpers',
           'administer style helpers',
-          'administer style_guide',
           'use text format cohesion',
         ];
 


### PR DESCRIPTION
**Motivation**
the module is not actively being used by Acquia CMS users should be able to uninstall it if they don't need it.

**Proposed changes**
<!-- What does this PR change? How does this impact end users? Are manual or automatic updates required? -->

**Alternatives considered**
<!-- How else could the original issue / use case be addressed? Why did you choose this solution over any others? -->

**Testing steps**
<!-- How can we replicate the issue and verify that this PR fixes it? -->

**Merge requirements**
- [ ] _Major change_, _Minor change_, _Bug_, _Enhancement_, and/or _Chore_ label applied
- [ ] Manual testing by a reviewer
