### PR TITLE
ACMS-1820: Remove patches as Acquia DAM module 1.0.7 released.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -127,10 +127,6 @@
             "drupal/core": "-p2"
         },
         "patches": {
-            "drupal/acquia_dam": {
-                "3349130 - PJavascript error in Drupal 10 - migrate poperjs to FloatingUI": "https://git.drupalcode.org/project/acquia_dam/-/merge_requests/10.patch",
-                "3354625 - Acquia DAM + Site Studio throw JS warning": "https://git.drupalcode.org/project/acquia_dam/-/merge_requests/11.patch"
-            },
             "drupal/core": {
                 "3328187 - PHP Deprecated: strpos(): Passing null to parameter #1 ($haystack) of type string is deprecated in docroot/core/lib/Drupal/Core/Mail/Plugin/Mail/PhpMail.php on line 112": "https://git.drupalcode.org/project/drupal/-/merge_requests/3142.patch"
             },

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "833edb6729b9433f81e18897f56e0d9e",
+    "content-hash": "9d82e564a7a91fe57febfdfd5fa539da",
     "packages": [
         {
             "name": "acquia/acquia-cms-starterkit",


### PR DESCRIPTION
**Motivation**
Fixes #ACMS-1820

**Proposed changes**
Remove patches as Acquia DAM module 1.0.7 released.

**Alternatives considered**
NA

**Testing steps**
Composer should install Acquia CMS DAM dependency without error/warning.

**Merge requirements**
- [ ] _Major change_, _Minor change_, _Bug_, _Enhancement_, and/or _Chore_ label applied
- [ ] Manual testing by a reviewer
