### PR TITLE
ACMS-000: Fix failing CI with latest admin_toolbar release.

### DIFF
--- a/modules/acquia_cms_headless/tests/src/Functional/PureHeadlessModeMenuTest.php
+++ b/modules/acquia_cms_headless/tests/src/Functional/PureHeadlessModeMenuTest.php
@@ -93,10 +93,10 @@ class PureHeadlessModeMenuTest extends WebDriverTestBase {
       // Wait for menu items to visible.
       $menuItem = $assertSession->waitForElementVisible('css', '.hover-intent.menu-item');
       $this->assertInstanceOf(NodeElement::class, $menuItem);
-      $childrenMenuItems = $menuItem->findAll("css", "ul.toolbar-menu li.level-2");
+      $childrenMenuItems = $page->findAll("css", ".claro-toolbar-menu > .hover-intent.menu-item >  ul.toolbar-menu:first-of-type > li");
       $this->assertCount(count($children), $childrenMenuItems);
       foreach ($childrenMenuItems as $key => $child) {
-        $this->assertEquals($children[$key], $child->find("css", ".toolbar-box > a")->getText());
+        $this->assertEquals($children[$key], $child->find("css", "a:first-child")->getText());
       }
     }
   }


### PR DESCRIPTION
**Motivation**
Fixes failing PHPUnit tests for acquia_cms_headless module.

**Proposed changes**
PHPUnit tests updated.

**Alternatives considered**
N/A

**Testing steps**
PHPUnit tests should pass for acquia_cms_headless module.

**Merge requirements**
- [ ] _Minor change_
- [ ] Manual testing by a reviewer
