### PR TITLE
ACMS-1730: add config event to create user on config import.

### DIFF
--- a/modules/acquia_cms_headless/acquia_cms_headless.services.yml
+++ b/modules/acquia_cms_headless/acquia_cms_headless.services.yml
@@ -16,9 +16,14 @@ services:
   acquia_cms_headless.preview_link_route_subscriber:
     class: 'Drupal\acquia_cms_headless\Routing\PreviewLinkRouteSubscriber'
     tags:
-      - { name: event_subscriber }  
+      - { name: event_subscriber }
   acquia_cms_headless.preview_link_access:
     class: Drupal\acquia_cms_headless\Access\PreviewLinkAccessCheck
     arguments: ['@current_user']
     tags:
       - { name: access_check, applies_to: _preview_link_access_check }
+  acquia_cms_headless.config_subscriber:
+    class: Drupal\acquia_cms_headless\Config\AcquiaCmsHeadlessConfigSubscriber
+    arguments: ['@acquia_cms_headless.starterkit_nextjs']
+    tags:
+      - { name: event_subscriber }

--- a/modules/acquia_cms_headless/src/Config/AcquiaCmsHeadlessConfigSubscriber.php
+++ b/modules/acquia_cms_headless/src/Config/AcquiaCmsHeadlessConfigSubscriber.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace Drupal\acquia_cms_headless\Config;
+
+use Drupal\acquia_cms_headless\Service\StarterkitNextjsService;
+use Drupal\Core\Config\ConfigEvents;
+use Drupal\Core\Config\ConfigImporterEvent;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+/**
+ * Reacts to configuration events for the Default Content module.
+ */
+class AcquiaCmsHeadlessConfigSubscriber implements EventSubscriberInterface {
+
+  /**
+   * Starter-kit service.
+   *
+   * @var \Drupal\acquia_cms_headless\Service\StarterkitNextjsService
+   */
+  protected $starterKitService;
+
+  /**
+   * Constructs a new HeadlessPostConfigEventsSubscriber object.
+   *
+   * @param \Drupal\acquia_cms_headless\Service\StarterkitNextjsService $acms_starter_kit_service
+   *   The acms utility service.
+   */
+  public function __construct(StarterkitNextjsService $acms_starter_kit_service) {
+    $this->starterKitService = $acms_starter_kit_service;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function getSubscribedEvents(): array {
+    return [ConfigEvents::IMPORT => 'onConfigImport'];
+  }
+
+  /**
+   * Creates headless user after config synchronization.
+   *
+   * @param \Drupal\Core\Config\ConfigImporterEvent $event
+   *   The config importer event.
+   *
+   * @throws \Drupal\Core\Entity\EntityStorageException
+   */
+  public function onConfigImport(ConfigImporterEvent $event) {
+    $enabled_extensions = $event->getConfigImporter()->getExtensionChangelist('module', 'install');
+    // Create headless user.
+    if (in_array('acquia_cms_headless', $enabled_extensions)) {
+      $this->starterKitService->createHeadlessUser();
+    }
+  }
+
+}


### PR DESCRIPTION
**Motivation**
Fixes #ACMS-1730

**Proposed changes**
Config event to create user on config import.

**Alternatives considered**
NA

**Testing steps**
Verify headless user creation on config import.
- Use ACMS-1730 branch to install site using `./vendor/bin/drush si minimal --account-pass=admin`
- Install ACMS headless module `./vendor/bin/drush in acquia_cms_headless -y`
- Export config `./vendor/bin/drush cex -y`
- Copy uuid using `./vendor/bin/drush cget system.site uuid` then copy the ID from output
- Install site `./vendor/bin/drush si minimal --account-pass=admin`
- Set site uuid `./vendor/bin/drush cset system.site uuid <copied uuid>`
- Import config `./vendor/bin/drush cim -y && ./vendor/bin/drush cr && ./vendor/bin/drush cim -y`
- Verify Headless user created after cim

**Merge requirements**
- [ ] _Major change_, _Minor change_, _Bug_, _Enhancement_, and/or _Chore_ label applied
- [ ] Manual testing by a reviewer
