### PR TITLE
ACMS-617: Report only enabled modules config difference.

### DIFF
--- a/modules/acquia_cms_common/modules/acquia_cms_support/src/Controller/AcquiaCmsConfigSyncOverridden.php
+++ b/modules/acquia_cms_common/modules/acquia_cms_support/src/Controller/AcquiaCmsConfigSyncOverridden.php
@@ -96,8 +96,7 @@ class AcquiaCmsConfigSyncOverridden extends ControllerBase implements ContainerI
         foreach ($configChangeList as $config) {
           $parity = $config['parity'];
           $configName = $config['name'];
-          $moduleName = array_shift(explode('.', $configName));
-          if ($this->moduleHandler->moduleExists($moduleName)) {
+          if ($this->moduleHandler->moduleExists($module->getName()) && $parity > 0) {
             $overriddenConfig[] = [
               'name' => $configName,
               'module' => $module->getName(),


### PR DESCRIPTION
**Motivation**
Fixes #ACMS-617

**Proposed changes**
Report only enabled modules config difference.

**Alternatives considered**
NA

**Testing steps**

- Clone ACMS-617 branch.
- install site and enable acquia_cms_support module
- visit `admin/config/development/acquia-cms-support/overridden-config` and verify if module is enabled for any config which is shown.
- install any acquia_cms module and verify the above scenario again.

**Merge requirements**
- [ ] _Major change_, _Minor change_, _Bug_, _Enhancement_, and/or _Chore_ label applied
- [ ] Manual testing by a reviewer
