### PR TITLE
ACMS-1831: add patch for metatag to enable SEO for Next JS.

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -2430,7 +2430,7 @@
             "dist": {
                 "type": "path",
                 "url": "./modules/acquia_cms_common",
-                "reference": "63e20d8ad15b416c778143b828aaeda609ffbc89"
+                "reference": "8a3a9c380120c5fdfef6804bac48f42028075c4a"
             },
             "require": {
                 "acquia/drupal-environment-detector": "^1.5",
@@ -2496,6 +2496,9 @@
                     "drupal/core": {
                         "3059955 - It is possible to overflow the number of items allowed in Media Library": "https://www.drupal.org/files/issues/2019-12-28/3082690-80.patch",
                         "3301692: Passing null to parameter to mb_strtolower() is deprecated with PHP 8.1": "https://git.drupalcode.org/project/drupal/-/merge_requests/2598.patch"
+                    },
+                    "drupal/metatag": {
+                        "2945817 - Support JSON API, REST, GraphQL and custom normalizations via new computed field": "https://www.drupal.org/files/issues/2020-02-23/2945817-87.patch"
                     }
                 }
             },
@@ -6100,17 +6103,17 @@
         },
         {
             "name": "drupal/metatag",
-            "version": "1.22.0",
+            "version": "1.25.0",
             "source": {
                 "type": "git",
                 "url": "https://git.drupalcode.org/project/metatag.git",
-                "reference": "8.x-1.22"
+                "reference": "8.x-1.25"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://ftp.drupal.org/files/projects/metatag-8.x-1.22.zip",
-                "reference": "8.x-1.22",
-                "shasum": "045cd6a4aa5048bfd6d47584eae1210eab9ba1fa"
+                "url": "https://ftp.drupal.org/files/projects/metatag-8.x-1.25.zip",
+                "reference": "8.x-1.25",
+                "shasum": "8603d84df3b93dd02dae601d57a6347598829e56"
             },
             "require": {
                 "drupal/core": "^9.3 || ^10",
@@ -6121,7 +6124,7 @@
                 "drupal/hal": "^9 || ^1 || ^2",
                 "drupal/metatag_dc": "*",
                 "drupal/metatag_open_graph": "*",
-                "drupal/page_manager": "^4.0",
+                "drupal/page_manager": "*",
                 "drupal/panelizer": "^4.0",
                 "drupal/redirect": "^1.0",
                 "drupal/webprofiler": "^9 || ^10",
@@ -6130,8 +6133,8 @@
             "type": "drupal-module",
             "extra": {
                 "drupal": {
-                    "version": "8.x-1.22",
-                    "datestamp": "1664472988",
+                    "version": "8.x-1.25",
+                    "datestamp": "1685541226",
                     "security-coverage": {
                         "status": "covered",
                         "message": "Covered by Drupal's security advisory policy"

--- a/modules/acquia_cms_common/composer.json
+++ b/modules/acquia_cms_common/composer.json
@@ -78,6 +78,9 @@
             "drupal/core": {
                 "3059955 - It is possible to overflow the number of items allowed in Media Library": "https://www.drupal.org/files/issues/2019-12-28/3082690-80.patch",
                 "3301692: Passing null to parameter to mb_strtolower() is deprecated with PHP 8.1": "https://git.drupalcode.org/project/drupal/-/merge_requests/2598.patch"
+            },
+            "drupal/metatag": {
+                "2945817 - Support JSON API, REST, GraphQL and custom normalizations via new computed field": "https://www.drupal.org/files/issues/2020-02-23/2945817-87.patch"
             }
         }
     },


### PR DESCRIPTION
**Motivation**
Fixes #ACMS-1831

**Proposed changes**
add patch for metatag to enable SEO for Next JS.

**Alternatives considered**
NA

**Testing steps**
Follow steps fron ticket

**Merge requirements**
- [ ] _Major change_, _Minor change_, _Bug_, _Enhancement_, and/or _Chore_ label applied
- [ ] Manual testing by a reviewer
