### PR TITLE
ACMS-1843: Update Google Tag to support 1.x and 2.x version.

### DIFF
--- a/acquia_cms.info.yml
+++ b/acquia_cms.info.yml
@@ -14,7 +14,6 @@ dependencies:
   - acquia_cms_toolbar:acquia_cms_toolbar
   - acquia_cms_tour:acquia_cms_tour
   - acquia_cms_video:acquia_cms_video
-  - google_analytics:google_analytics
   - google_tag:google_tag
   - drupal:history
   - honeypot:honeypot

--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
         "drupal/acquia_cms_toolbar": "^1.4",
         "drupal/acquia_cms_tour": "^2.1",
         "drupal/google_analytics": "^4.0",
-        "drupal/google_tag": "^1.6",
+        "drupal/google_tag": "^1.6 || ^2.0",
         "drupal/honeypot": "^2.1",
         "drupal/recaptcha": "^3.1",
         "drupal/reroute_email": "^2.2",


### PR DESCRIPTION
**Motivation**
Fixes #ACMS-1843

**Proposed changes**
- Update Google Tag to support 1.x and 2.x version.
- Remove google analytics from module dependency list.

**Alternatives considered**
NA

**Testing steps**
Follow from ticket.

**Merge requirements**
- [ ] _Major change_, _Minor change_, _Bug_, _Enhancement_, and/or _Chore_ label applied
- [ ] Manual testing by a reviewer
