### PR TITLE
ACMS-1843: Update Google Tag to support 1.x and 2.x version. 

### DIFF
--- a/acquia_cms.info.yml
+++ b/acquia_cms.info.yml
@@ -42,7 +42,6 @@ dependencies:
   - entity_clone:entity_clone
   - facets_pretty_paths:facets_pretty_paths
   - focal_point:focal_point
-  - google_analytics:google_analytics
   - google_tag:google_tag
   - honeypot:honeypot
   - metatag:metatag_open_graph

--- a/acquia_cms.profile
+++ b/acquia_cms.profile
@@ -205,7 +205,10 @@ function acquia_cms_modules_installed(array $modules) : void {
   }
 
   if ($module_handler->moduleExists('cohesion_sync')) {
-    $module_handler->invoke('cohesion_sync', 'modules_installed', [$modules]);
+    $module_handler->invoke('cohesion_sync', 'modules_installed', [
+      $modules,
+      FALSE,
+    ]);
   }
 }
 

--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
         "drupal/acquia_cms_toolbar": "1.x-dev",
         "drupal/acquia_cms_tour": "1.3.x-dev",
         "drupal/google_analytics": "^4.0",
-        "drupal/google_tag": "^1.6",
+        "drupal/google_tag": "^1.6 || ^2.0",
         "drupal/honeypot": "^2.1",
         "drupal/recaptcha": "^3.1",
         "drupal/reroute_email": "^2.2",


### PR DESCRIPTION
**Motivation**
Fixes #ACMS-1843

**Proposed changes**
- Update Google Tag to support 1.x and 2.x version.
- Remove google analytics from module dependency list.

**Alternatives considered**
NA

**Testing steps**
Follow from ticket.

**Merge requirements**
- [ ] _Major change_, _Minor change_, _Bug_, _Enhancement_, and/or _Chore_ label applied
- [ ] Manual testing by a reviewer
