### PR TITLE
ACMS-1863: Cleanup Site Studio configurations containinv invalid data.

### DIFF
--- a/modules/acquia_cms_article/acquia_cms_article.install
+++ b/modules/acquia_cms_article/acquia_cms_article.install
@@ -238,3 +238,33 @@ function acquia_cms_article_update_8007() {
     }
   }
 }
+
+/**
+ * Deletes the Site Studio configurations containing invalid data.
+ *
+ * Implements hook_update_N().
+ */
+function acquia_cms_article_update_8008() {
+  $moduleHandler = \Drupal::service('module_handler');
+  if ($moduleHandler->moduleExists('acquia_cms_site_studio')) {
+    $module_path = \Drupal::service('extension.list.module')->getPath('acquia_cms_article');
+    $directories = [
+      $module_path . '/config/pack_acquia_cms_article',
+      $module_path . '/config/pack_acquia_cms_article_search',
+    ];
+    foreach ($directories as $directory) {
+      if (is_dir($directory)) {
+        $files = \Drupal::service('file_system')->scanDirectory($directory, '/.*\.yml$/');
+        foreach ($files as $file) {
+          $sitestudio_template = \Drupal::configFactory()->getEditable($file->name);
+          if ($sitestudio_template && !$sitestudio_template->isNew() && !$sitestudio_template->get("uuid") && !$sitestudio_template->get("id")) {
+            $sitestudio_template->delete();
+            \Drupal::logger("acquia_cms_article")->notice(
+              sprintf("The configuration `%s` deleted containing invalid data.", $file->name)
+            );
+          }
+        }
+      }
+    }
+  }
+}

--- a/modules/acquia_cms_event/acquia_cms_event.install
+++ b/modules/acquia_cms_event/acquia_cms_event.install
@@ -206,3 +206,33 @@ function acquia_cms_event_update_8005() {
     }
   }
 }
+
+/**
+ * Deletes the Site Studio configurations containing invalid data.
+ *
+ * Implements hook_update_N().
+ */
+function acquia_cms_event_update_8006() {
+  $moduleHandler = \Drupal::service('module_handler');
+  if ($moduleHandler->moduleExists('acquia_cms_site_studio')) {
+    $module_path = \Drupal::service('extension.list.module')->getPath('acquia_cms_event');
+    $directories = [
+      $module_path . '/config/pack_acquia_cms_event',
+      $module_path . '/config/pack_acquia_cms_event_search',
+    ];
+    foreach ($directories as $directory) {
+      if (is_dir($directory)) {
+        $files = \Drupal::service('file_system')->scanDirectory($directory, '/.*\.yml$/');
+        foreach ($files as $file) {
+          $sitestudio_template = \Drupal::configFactory()->getEditable($file->name);
+          if ($sitestudio_template && !$sitestudio_template->isNew() && !$sitestudio_template->get("uuid") && !$sitestudio_template->get("id")) {
+            $sitestudio_template->delete();
+            \Drupal::logger("acquia_cms_event")->notice(
+              sprintf("The configuration `%s` deleted containing invalid data.", $file->name)
+            );
+          }
+        }
+      }
+    }
+  }
+}

--- a/modules/acquia_cms_image/acquia_cms_image.install
+++ b/modules/acquia_cms_image/acquia_cms_image.install
@@ -184,3 +184,33 @@ function acquia_cms_image_update_8004() {
     }
   }
 }
+
+/**
+ * Deletes the Site Studio configurations containing invalid data.
+ *
+ * Implements hook_update_N().
+ */
+function acquia_cms_image_update_8005() {
+  $moduleHandler = \Drupal::service('module_handler');
+  if ($moduleHandler->moduleExists('acquia_cms_site_studio')) {
+    $module_path = \Drupal::service('extension.list.module')->getPath('acquia_cms_image');
+    $directories = [
+      $module_path . '/config/pack_acquia_cms_image',
+      $module_path . '/config/pack_acquia_cms_image_core',
+    ];
+    foreach ($directories as $directory) {
+      if (is_dir($directory)) {
+        $files = \Drupal::service('file_system')->scanDirectory($directory, '/.*\.yml$/');
+        foreach ($files as $file) {
+          $sitestudio_template = \Drupal::configFactory()->getEditable($file->name);
+          if ($sitestudio_template && !$sitestudio_template->isNew() && !$sitestudio_template->get("uuid") && !$sitestudio_template->get("id")) {
+            $sitestudio_template->delete();
+            \Drupal::logger("acquia_cms_image")->notice(
+              sprintf("The configuration `%s` deleted containing invalid data.", $file->name)
+            );
+          }
+        }
+      }
+    }
+  }
+}

--- a/modules/acquia_cms_page/acquia_cms_page.install
+++ b/modules/acquia_cms_page/acquia_cms_page.install
@@ -218,3 +218,32 @@ function acquia_cms_page_update_8005() {
     }
   }
 }
+
+/**
+ * Deletes the Site Studio configurations containing invalid data.
+ *
+ * Implements hook_update_N().
+ */
+function acquia_cms_page_update_8006() {
+  $moduleHandler = \Drupal::service('module_handler');
+  if ($moduleHandler->moduleExists('acquia_cms_site_studio')) {
+    $module_path = \Drupal::service('extension.list.module')->getPath('acquia_cms_page');
+    $directories = [
+      $module_path . '/config/pack_acquia_cms_page',
+    ];
+    foreach ($directories as $directory) {
+      if (is_dir($directory)) {
+        $files = \Drupal::service('file_system')->scanDirectory($directory, '/.*\.yml$/');
+        foreach ($files as $file) {
+          $sitestudio_template = \Drupal::configFactory()->getEditable($file->name);
+          if ($sitestudio_template && !$sitestudio_template->isNew() && !$sitestudio_template->get("uuid") && !$sitestudio_template->get("id")) {
+            $sitestudio_template->delete();
+            \Drupal::logger("acquia_cms_page")->notice(
+              sprintf("The configuration `%s` deleted containing invalid data.", $file->name)
+            );
+          }
+        }
+      }
+    }
+  }
+}

--- a/modules/acquia_cms_person/acquia_cms_person.install
+++ b/modules/acquia_cms_person/acquia_cms_person.install
@@ -157,3 +157,33 @@ function acquia_cms_person_update_8004() {
     }
   }
 }
+
+/**
+ * Deletes the Site Studio configurations containing invalid data.
+ *
+ * Implements hook_update_N().
+ */
+function acquia_cms_person_update_8005() {
+  $moduleHandler = \Drupal::service('module_handler');
+  if ($moduleHandler->moduleExists('acquia_cms_site_studio')) {
+    $module_path = \Drupal::service('extension.list.module')->getPath('acquia_cms_person');
+    $directories = [
+      $module_path . '/config/pack_acquia_cms_person',
+      $module_path . '/config/pack_acquia_cms_person_search',
+    ];
+    foreach ($directories as $directory) {
+      if (is_dir($directory)) {
+        $files = \Drupal::service('file_system')->scanDirectory($directory, '/.*\.yml$/');
+        foreach ($files as $file) {
+          $sitestudio_template = \Drupal::configFactory()->getEditable($file->name);
+          if ($sitestudio_template && !$sitestudio_template->isNew() && !$sitestudio_template->get("uuid") && !$sitestudio_template->get("id")) {
+            $sitestudio_template->delete();
+            \Drupal::logger("acquia_cms_person")->notice(
+              sprintf("The configuration `%s` deleted containing invalid data.", $file->name)
+            );
+          }
+        }
+      }
+    }
+  }
+}

--- a/modules/acquia_cms_place/acquia_cms_place.install
+++ b/modules/acquia_cms_place/acquia_cms_place.install
@@ -187,3 +187,33 @@ function acquia_cms_place_update_8004() {
     }
   }
 }
+
+/**
+ * Deletes the Site Studio configurations containing invalid data.
+ *
+ * Implements hook_update_N().
+ */
+function acquia_cms_place_update_8005() {
+  $moduleHandler = \Drupal::service('module_handler');
+  if ($moduleHandler->moduleExists('acquia_cms_site_studio')) {
+    $module_path = \Drupal::service('extension.list.module')->getPath('acquia_cms_place');
+    $directories = [
+      $module_path . '/config/pack_acquia_cms_place',
+      $module_path . '/config/pack_acquia_cms_place_search',
+    ];
+    foreach ($directories as $directory) {
+      if (is_dir($directory)) {
+        $files = \Drupal::service('file_system')->scanDirectory($directory, '/.*\.yml$/');
+        foreach ($files as $file) {
+          $sitestudio_template = \Drupal::configFactory()->getEditable($file->name);
+          if ($sitestudio_template && !$sitestudio_template->isNew() && !$sitestudio_template->get("uuid") && !$sitestudio_template->get("id")) {
+            $sitestudio_template->delete();
+            \Drupal::logger("acquia_cms_place")->notice(
+              sprintf("The configuration `%s` deleted containing invalid data.", $file->name)
+            );
+          }
+        }
+      }
+    }
+  }
+}

--- a/modules/acquia_cms_search/acquia_cms_search.install
+++ b/modules/acquia_cms_search/acquia_cms_search.install
@@ -64,3 +64,32 @@ function acquia_cms_search_update_8001() {
     }
   }
 }
+
+/**
+ * Deletes the Site Studio configurations containing invalid data.
+ *
+ * Implements hook_update_N().
+ */
+function acquia_cms_search_update_8002() {
+  $moduleHandler = \Drupal::service('module_handler');
+  if ($moduleHandler->moduleExists('acquia_cms_site_studio')) {
+    $module_path = \Drupal::service('extension.list.module')->getPath('acquia_cms_search');
+    $directories = [
+      $module_path . '/config/pack_acquia_cms_search',
+    ];
+    foreach ($directories as $directory) {
+      if (is_dir($directory)) {
+        $files = \Drupal::service('file_system')->scanDirectory($directory, '/.*\.yml$/');
+        foreach ($files as $file) {
+          $sitestudio_template = \Drupal::configFactory()->getEditable($file->name);
+          if ($sitestudio_template && !$sitestudio_template->isNew() && !$sitestudio_template->get("uuid") && !$sitestudio_template->get("id")) {
+            $sitestudio_template->delete();
+            \Drupal::logger("acquia_cms_search")->notice(
+              sprintf("The configuration `%s` deleted containing invalid data.", $file->name)
+            );
+          }
+        }
+      }
+    }
+  }
+}

--- a/modules/acquia_cms_site_studio/acquia_cms_site_studio.install
+++ b/modules/acquia_cms_site_studio/acquia_cms_site_studio.install
@@ -400,3 +400,49 @@ function acquia_cms_site_studio_update_8008() {
     }
   }
 }
+
+/**
+ * Deletes the Site Studio configurations containing invalid data.
+ *
+ * Implements hook_update_N().
+ */
+function acquia_cms_site_studio_update_8009() {
+  $module_path = \Drupal::service('extension.list.module')->getPath('acquia_cms_site_studio');
+  $directory = $module_path . '/config/pack_acquia_cms_core';
+  if (is_dir($directory)) {
+    $files = \Drupal::service('file_system')->scanDirectory($directory, '/.*\.yml$/');
+    $base_templates = [
+      'cohesion_base_styles.cohesion_base_styles.blockquote',
+      'cohesion_base_styles.cohesion_base_styles.body',
+      'cohesion_base_styles.cohesion_base_styles.button',
+      'cohesion_base_styles.cohesion_base_styles.description',
+      'cohesion_base_styles.cohesion_base_styles.heading_1',
+      'cohesion_base_styles.cohesion_base_styles.heading_2',
+      'cohesion_base_styles.cohesion_base_styles.heading_3',
+      'cohesion_base_styles.cohesion_base_styles.heading_4',
+      'cohesion_base_styles.cohesion_base_styles.heading_5',
+      'cohesion_base_styles.cohesion_base_styles.heading_6',
+      'cohesion_base_styles.cohesion_base_styles.html',
+      'cohesion_base_styles.cohesion_base_styles.link',
+      'cohesion_base_styles.cohesion_base_styles.ordered_list',
+      'cohesion_base_styles.cohesion_base_styles.paragraph',
+      'cohesion_base_styles.cohesion_base_styles.unordered_list',
+      'cohesion_website_settings.cohesion_font_stack.arial',
+      'cohesion_templates.cohesion_master_templates.master_template',
+      'cohesion_website_settings.cohesion_website_settings.base_unit_settings',
+      'cohesion_website_settings.cohesion_website_settings.default_font_settings',
+      'cohesion_website_settings.cohesion_website_settings.responsive_grid_settings',
+    ];
+    foreach ($files as $file) {
+      if (!in_array($file->name, $base_templates)) {
+        $sitestudio_template = \Drupal::configFactory()->getEditable($file->name);
+        if ($sitestudio_template && !$sitestudio_template->isNew() && !$sitestudio_template->get("uuid") && !$sitestudio_template->get("id")) {
+          $sitestudio_template->delete();
+          \Drupal::logger("acquia_cms_site_studio")->notice(
+            sprintf("The configuration `%s` deleted containing invalid data.", $file->name)
+          );
+        }
+      }
+    }
+  }
+}

--- a/modules/acquia_cms_video/acquia_cms_video.install
+++ b/modules/acquia_cms_video/acquia_cms_video.install
@@ -39,3 +39,32 @@ function acquia_cms_video_update_8001() {
     }
   }
 }
+
+/**
+ * Deletes the Site Studio configurations containing invalid data.
+ *
+ * Implements hook_update_N().
+ */
+function acquia_cms_video_update_8002() {
+  $moduleHandler = \Drupal::service('module_handler');
+  if ($moduleHandler->moduleExists('acquia_cms_site_studio')) {
+    $module_path = \Drupal::service('extension.list.module')->getPath('acquia_cms_video');
+    $directories = [
+      $module_path . '/config/pack_acquia_cms_video',
+    ];
+    foreach ($directories as $directory) {
+      if (is_dir($directory)) {
+        $files = \Drupal::service('file_system')->scanDirectory($directory, '/.*\.yml$/');
+        foreach ($files as $file) {
+          $sitestudio_template = \Drupal::configFactory()->getEditable($file->name);
+          if ($sitestudio_template && !$sitestudio_template->isNew() && !$sitestudio_template->get("uuid") && !$sitestudio_template->get("id")) {
+            $sitestudio_template->delete();
+            \Drupal::logger("acquia_cms_video")->notice(
+              sprintf("The configuration `%s` deleted containing invalid data.", $file->name)
+            );
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
**Motivation**
Fixes Site Studio configurations containing invalid data.

**Proposed changes**
Added an update hook to fix site studio configurations containing invalid data.

**Alternatives considered**
N/A

**Testing steps**
Update hook should pass updataing any error and site studio configurations containing invalid data should be deleted.

**Merge requirements**
- [ ]  _Minor change_
- [ ] Manual testing by a reviewer
