### PR TITLE
ACMS-1905: Track Acquia CMS Starterkits in telemetry data.

### DIFF
--- a/acquia_cms.profile
+++ b/acquia_cms.profile
@@ -224,6 +224,15 @@ function acquia_cms_modules_uninstalled(array $modules) {
 function install_acms_finished() {
   $telemetry = Drupal::classResolver(AcquiaTelemetry::class);
   $telemetry->setTime('install_end_time');
+  // Add user selected starter-kit to config as acquia_cms_direct_installations.
+  $acms_common = \Drupal::configFactory()->getEditable('acquia_cms_common.settings');
+  if ($acms_common) {
+    if ($acms_common->get('starter_kit_name') == "no_starter_kit") {
+      $acms_common->set('starter_kit_name', 'acquia_cms_direct_installations')->save(TRUE);
+    }
+  }
+  // Add user selected starter-kit to state as acquia_cms_direct_installations.
+  \Drupal::state()->set('acquia_cms.starter_kit', $acms_common->get('starter_kit_name'));
 }
 
 /**
@@ -371,4 +380,17 @@ function acquia_cms_update_8003() {
   \Drupal::configFactory()->getEditable('acquia_cms.settings')->delete();
   // Clear caches.
   drupal_flush_all_caches();
+}
+
+/**
+ * Set starter-kit name as acquia_cms_existing_site to already installed sites.
+ */
+function acquia_cms_update_8004() {
+  // Add user selected starter-kit to config as acquia_cms_existing_site.
+  $acms_common = \Drupal::configFactory()->getEditable('acquia_cms_common.settings');
+  if ($acms_common) {
+    $acms_common->set('starter_kit_name', 'acquia_cms_existing_site')->save(TRUE);
+  }
+  // Add user selected starter-kit to state as acquia_cms_existing_site.
+  \Drupal::state()->set('acquia_cms.starter_kit', 'acquia_cms_existing_site');
 }

--- a/acquia_cms.profile
+++ b/acquia_cms.profile
@@ -231,8 +231,6 @@ function install_acms_finished() {
       $acms_common->set('starter_kit_name', 'acquia_cms_direct_installations')->save(TRUE);
     }
   }
-  // Add user selected starter-kit to state as acquia_cms_direct_installations.
-  \Drupal::state()->set('acquia_cms.starter_kit', $acms_common->get('starter_kit_name'));
 }
 
 /**
@@ -391,6 +389,4 @@ function acquia_cms_update_8004() {
   if ($acms_common) {
     $acms_common->set('starter_kit_name', 'acquia_cms_existing_site')->save(TRUE);
   }
-  // Add user selected starter-kit to state as acquia_cms_existing_site.
-  \Drupal::state()->set('acquia_cms.starter_kit', 'acquia_cms_existing_site');
 }


### PR DESCRIPTION
**Motivation**
Fixes #ACMS-1905

**Proposed changes**
Track Acquia CMS Starterkits in telemetry data.

**Alternatives considered**
NA

**Testing steps**
Follow from ticket.

**Merge requirements**
- [ ] _Major change_, _Minor change_, _Bug_, _Enhancement_, and/or _Chore_ label applied
- [ ] Manual testing by a reviewer
