### PR TITLE
ACMS-1922: Issue with block_content and Acquia CMS Headless.

### DIFF
--- a/modules/acquia_cms_headless/modules/acquia_cms_headless_ui/acquia_cms_headless_ui.module
+++ b/modules/acquia_cms_headless/modules/acquia_cms_headless_ui/acquia_cms_headless_ui.module
@@ -248,6 +248,14 @@ function acquia_cms_headless_ui_local_tasks_alter(array &$local_tasks) {
   // content under content.
   if ($moduleHandler->moduleExists('block_content')) {
     $local_tasks['entity.block_content_type.collection']['title'] = t('Block types');
+
+    // Due to the changes introduced in version:10.1.0
+    // Block management pages have new paths and menu items.
+    // @see https://www.drupal.org/node/3320855
+    if (version_compare(\Drupal::VERSION, '10.1', '<')) {
+      $local_tasks['entity.block_content_type.collection']['base_route'] = 'admin.content_models';
+    }
+
     $local_tasks['entity.block_content_type.collection']['parent_id'] = NULL;
     $local_tasks['entity.block_content_type.collection']['weight'] = 2;
 

--- a/modules/acquia_cms_headless/modules/acquia_cms_headless_ui/acquia_cms_headless_ui.module
+++ b/modules/acquia_cms_headless/modules/acquia_cms_headless_ui/acquia_cms_headless_ui.module
@@ -243,12 +243,11 @@ function acquia_cms_headless_ui_local_tasks_alter(array &$local_tasks) {
   $local_tasks['entity.media_type.collection']['base_route'] = 'admin.content_models';
   $local_tasks['entity.media_type.collection']['weight'] = 3;
 
-  // If the custom blocks module is enabled, complete some addtional local task
+  // If the custom blocks module is enabled, complete some additional local task
   // updates so that we see the block types under content model and block
   // content under content.
   if ($moduleHandler->moduleExists('block_content')) {
     $local_tasks['entity.block_content_type.collection']['title'] = t('Block types');
-    $local_tasks['entity.block_content_type.collection']['base_route'] = 'admin.content_models';
     $local_tasks['entity.block_content_type.collection']['parent_id'] = NULL;
     $local_tasks['entity.block_content_type.collection']['weight'] = 2;
 

--- a/modules/acquia_cms_headless/modules/acquia_cms_headless_ui/acquia_cms_headless_ui.routing.yml
+++ b/modules/acquia_cms_headless/modules/acquia_cms_headless_ui/acquia_cms_headless_ui.routing.yml
@@ -28,7 +28,7 @@ admin.content_models:
     _controller: '\Drupal\system\Controller\SystemController::systemAdminMenuBlockPage'
     _title: Content Models
   requirements:
-    _permission: 'administer site configuration'
+    _permission: 'access block library+administer block content'
 
 admin.cms:
   path: '/admin/cms'

--- a/modules/acquia_cms_headless/modules/acquia_cms_headless_ui/src/Service/PureHeadlessModeInstallHandler.php
+++ b/modules/acquia_cms_headless/modules/acquia_cms_headless_ui/src/Service/PureHeadlessModeInstallHandler.php
@@ -114,7 +114,7 @@ class PureHeadlessModeInstallHandler {
       '/admin/structure/taxonomy' => '/admin/content-models/categories',
       '/admin/config/people/accounts' => '/admin/content-models/users',
       '/admin/structure/block/block-content' => '/admin/content/blocks',
-      '/admin/structure/block/block-content/types' => '/admin/content-models/blocks',
+      '/admin/structure/block-content' => '/admin/content-models/blocks',
     ];
   }
 

--- a/modules/acquia_cms_headless/modules/acquia_cms_headless_ui/src/Service/PureHeadlessModeInstallHandler.php
+++ b/modules/acquia_cms_headless/modules/acquia_cms_headless_ui/src/Service/PureHeadlessModeInstallHandler.php
@@ -103,7 +103,7 @@ class PureHeadlessModeInstallHandler {
    *   Returns an array of path aliases.
    */
   public function headlessAliases(): array {
-    return [
+    $aliases = [
       '/admin/config/people/simple_oauth' => '/admin/access/settings',
       '/admin/config/people/simple_oauth/oauth2_client' => '/admin/access/clients',
       '/admin/people/roles' => '/admin/access/roles',
@@ -114,8 +114,17 @@ class PureHeadlessModeInstallHandler {
       '/admin/structure/taxonomy' => '/admin/content-models/categories',
       '/admin/config/people/accounts' => '/admin/content-models/users',
       '/admin/structure/block/block-content' => '/admin/content/blocks',
-      '/admin/structure/block-content' => '/admin/content-models/blocks',
+      '/admin/structure/block/block-content/types' => '/admin/content-models/blocks',
     ];
+
+    // Due to the changes introduced in version:10.1.0
+    // Block management pages have new paths and menu items.
+    // @see https://www.drupal.org/node/3320855
+    if (version_compare(\Drupal::VERSION, '10.1', '>=')) {
+      unset($aliases['/admin/structure/block/block-content/types']);
+      $aliases['/admin/structure/block-content'] = '/admin/content-models/blocks';
+    }
+    return $aliases;
   }
 
   /**

--- a/modules/acquia_cms_headless/tests/src/Functional/PureHeadlessModeMenuTest.php
+++ b/modules/acquia_cms_headless/tests/src/Functional/PureHeadlessModeMenuTest.php
@@ -80,7 +80,8 @@ class PureHeadlessModeMenuTest extends WebDriverTestBase {
    * @dataProvider providerMenu
    */
   public function testChildMenu(string $selector, string $parentMenuName, array $children): void {
-    if ($this->installModule('acquia_cms_toolbar')) {
+    if ($this->installModule('acquia_cms_toolbar') && $this->installModule('block_content')) {
+
       $this->drupalGet('/admin/headless/dashboard');
       $page = $this->getSession()->getPage();
       $menu = $page->find("css", $selector);
@@ -99,6 +100,12 @@ class PureHeadlessModeMenuTest extends WebDriverTestBase {
         $this->assertEquals($children[$key], $child->find("css", "a:first-child")->getText());
       }
     }
+  }
+
+  public function testContentModelLinks() {
+    // Make sure alias works fine.
+    $this->drupalGet('/admin/content-models');
+    $this->assertSession()->pageTextContains('Content Models');
   }
 
   /**
@@ -142,6 +149,7 @@ class PureHeadlessModeMenuTest extends WebDriverTestBase {
           'Files',
           'Media',
           'Scheduled Media',
+          'Block Content',
         ],
       ],
       [
@@ -160,6 +168,7 @@ class PureHeadlessModeMenuTest extends WebDriverTestBase {
         '.toolbar-icon-admin-content-models',
         'Data model',
         [
+          'Block types',
           'Content types',
           'Media types',
           'Menus',


### PR DESCRIPTION
**Motivation**
Fixes #[ACMS-1922](https://backlog.acquia.com/browse/ACMS-1922)

**Proposed changes**
<!-- What does this PR change? How does this impact end users? Are manual or automatic updates required? -->

**Alternatives considered**
<!-- How else could the original issue / use case be addressed? Why did you choose this solution over any others? -->
Keep core below 10.1

**Testing steps**

- Setup site with headless starterkit

- Enable block_content module

- Visit /admin/content-models page

- You should see the error.

**Merge requirements**
- [ ] _Major change_, _Minor change_, _Bug_, _Enhancement_, and/or _Chore_ label applied
- [ ] Manual testing by a reviewer
