### PR TITLE
ACMS-1919: Fix Toolbar does not indicate active menu trail for pages not included in Toolbar.

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -2435,7 +2435,7 @@
             "dist": {
                 "type": "path",
                 "url": "./modules/acquia_cms_common",
-                "reference": "b26fadf09c5d03f2731ae427febff50ba3bca9db"
+                "reference": "df6410fda9f9d50727912674bcaa32d71a5edc10"
             },
             "require": {
                 "acquia/drupal-environment-detector": "^1.5",
@@ -2501,7 +2501,8 @@
                     "drupal/core": {
                         "3301692: - Passing null to parameter to mb_strtolower() is deprecated with PHP 8.1": "https://git.drupalcode.org/project/drupal/-/merge_requests/2598.patch",
                         "3356894: - Make field selection less overwhelming by introducing groups": "https://www.drupal.org/files/issues/2023-06-20/3356894-mr_3896.patch",
-                        "296693: - Restrict access to empty top level administration pages": "https://www.drupal.org/files/issues/2023-08-31/296693-10.1.x_0.patch"
+                        "296693: - Restrict access to empty top level administration pages": "https://www.drupal.org/files/issues/2023-08-31/296693-10.1.x_0.patch",
+                        "3371005 - Toolbar does not indicate active menu trail for pages not included in Toolbar": "https://git.drupalcode.org/project/drupal/-/commit/3165269bb01a5a8e5f53c1f369135b967c9d5924.patch"
                     },
                     "drupal/pathauto": {
                         "3328670 - PHP 8.2 compatibility": "https://git.drupalcode.org/project/pathauto/-/merge_requests/40.patch"
@@ -2977,7 +2978,7 @@
             "dist": {
                 "type": "path",
                 "url": "./modules/acquia_cms_toolbar",
-                "reference": "820531e9d963a39bce7209047ac2246af4d2e13f"
+                "reference": "ff8fe4ffb2b7c0d87aaeecc8c4626ea79c93a433"
             },
             "require": {
                 "drupal/acquia_cms_common": "1.x-dev || 2.x-dev || 3.x-dev",
@@ -2987,12 +2988,6 @@
             "extra": {
                 "branch-alias": {
                     "dev-develop": "1.x-dev"
-                },
-                "enable-patching": true,
-                "patches": {
-                    "drupal/core": {
-                        "3371005 - Toolbar does not indicate active menu trail for pages not included in Toolbar": "https://git.drupalcode.org/project/drupal/-/commit/3165269bb01a5a8e5f53c1f369135b967c9d5924.patch"
-                    }
                 }
             },
             "license": [

--- a/composer.lock
+++ b/composer.lock
@@ -2977,7 +2977,7 @@
             "dist": {
                 "type": "path",
                 "url": "./modules/acquia_cms_toolbar",
-                "reference": "ff8fe4ffb2b7c0d87aaeecc8c4626ea79c93a433"
+                "reference": "820531e9d963a39bce7209047ac2246af4d2e13f"
             },
             "require": {
                 "drupal/acquia_cms_common": "1.x-dev || 2.x-dev || 3.x-dev",
@@ -2987,6 +2987,12 @@
             "extra": {
                 "branch-alias": {
                     "dev-develop": "1.x-dev"
+                },
+                "enable-patching": true,
+                "patches": {
+                    "drupal/core": {
+                        "3371005 - Toolbar does not indicate active menu trail for pages not included in Toolbar": "https://git.drupalcode.org/project/drupal/-/commit/3165269bb01a5a8e5f53c1f369135b967c9d5924.patch"
+                    }
                 }
             },
             "license": [

--- a/composer.lock
+++ b/composer.lock
@@ -2435,7 +2435,7 @@
             "dist": {
                 "type": "path",
                 "url": "./modules/acquia_cms_common",
-                "reference": "df6410fda9f9d50727912674bcaa32d71a5edc10"
+                "reference": "982c32cdc1420201fc0660faca5a273ad6bd16e1"
             },
             "require": {
                 "acquia/drupal-environment-detector": "^1.5",
@@ -2499,9 +2499,9 @@
                 "enable-patching": true,
                 "patches": {
                     "drupal/core": {
-                        "3301692: - Passing null to parameter to mb_strtolower() is deprecated with PHP 8.1": "https://git.drupalcode.org/project/drupal/-/merge_requests/2598.patch",
-                        "3356894: - Make field selection less overwhelming by introducing groups": "https://www.drupal.org/files/issues/2023-06-20/3356894-mr_3896.patch",
-                        "296693: - Restrict access to empty top level administration pages": "https://www.drupal.org/files/issues/2023-08-31/296693-10.1.x_0.patch",
+                        "3301692 - Passing null to parameter to mb_strtolower() is deprecated with PHP 8.1": "https://git.drupalcode.org/project/drupal/-/merge_requests/2598.patch",
+                        "3356894 - Make field selection less overwhelming by introducing groups": "https://www.drupal.org/files/issues/2023-06-20/3356894-mr_3896.patch",
+                        "296693 - Restrict access to empty top level administration pages": "https://www.drupal.org/files/issues/2023-08-31/296693-10.1.x_0.patch",
                         "3371005 - Toolbar does not indicate active menu trail for pages not included in Toolbar": "https://git.drupalcode.org/project/drupal/-/commit/3165269bb01a5a8e5f53c1f369135b967c9d5924.patch"
                     },
                     "drupal/pathauto": {
@@ -4999,6 +4999,10 @@
                 {
                     "name": "All contributors",
                     "homepage": "https://www.drupal.org/node/2625160/committers"
+                },
+                {
+                    "name": "phenaproxima",
+                    "homepage": "https://www.drupal.org/user/205645"
                 },
                 {
                     "name": "StryKaizer",

--- a/modules/acquia_cms_common/composer.json
+++ b/modules/acquia_cms_common/composer.json
@@ -78,7 +78,8 @@
             "drupal/core": {
                 "3301692: - Passing null to parameter to mb_strtolower() is deprecated with PHP 8.1": "https://git.drupalcode.org/project/drupal/-/merge_requests/2598.patch",
                 "3356894: - Make field selection less overwhelming by introducing groups": "https://www.drupal.org/files/issues/2023-06-20/3356894-mr_3896.patch",
-                "296693: - Restrict access to empty top level administration pages": "https://www.drupal.org/files/issues/2023-08-31/296693-10.1.x_0.patch"
+                "296693: - Restrict access to empty top level administration pages": "https://www.drupal.org/files/issues/2023-08-31/296693-10.1.x_0.patch",
+                "3371005 - Toolbar does not indicate active menu trail for pages not included in Toolbar": "https://git.drupalcode.org/project/drupal/-/commit/3165269bb01a5a8e5f53c1f369135b967c9d5924.patch"
             },
             "drupal/pathauto": {
                 "3328670 - PHP 8.2 compatibility": "https://git.drupalcode.org/project/pathauto/-/merge_requests/40.patch"

--- a/modules/acquia_cms_common/composer.json
+++ b/modules/acquia_cms_common/composer.json
@@ -76,9 +76,9 @@
         "enable-patching": true,
         "patches": {
             "drupal/core": {
-                "3301692: - Passing null to parameter to mb_strtolower() is deprecated with PHP 8.1": "https://git.drupalcode.org/project/drupal/-/merge_requests/2598.patch",
-                "3356894: - Make field selection less overwhelming by introducing groups": "https://www.drupal.org/files/issues/2023-06-20/3356894-mr_3896.patch",
-                "296693: - Restrict access to empty top level administration pages": "https://www.drupal.org/files/issues/2023-08-31/296693-10.1.x_0.patch",
+                "3301692 - Passing null to parameter to mb_strtolower() is deprecated with PHP 8.1": "https://git.drupalcode.org/project/drupal/-/merge_requests/2598.patch",
+                "3356894 - Make field selection less overwhelming by introducing groups": "https://www.drupal.org/files/issues/2023-06-20/3356894-mr_3896.patch",
+                "296693 - Restrict access to empty top level administration pages": "https://www.drupal.org/files/issues/2023-08-31/296693-10.1.x_0.patch",
                 "3371005 - Toolbar does not indicate active menu trail for pages not included in Toolbar": "https://git.drupalcode.org/project/drupal/-/commit/3165269bb01a5a8e5f53c1f369135b967c9d5924.patch"
             },
             "drupal/pathauto": {

--- a/modules/acquia_cms_toolbar/composer.json
+++ b/modules/acquia_cms_toolbar/composer.json
@@ -22,12 +22,6 @@
     "extra": {
         "branch-alias": {
             "dev-develop": "1.x-dev"
-        },
-        "enable-patching": true,
-        "patches": {
-            "drupal/core": {
-                "3371005 - Toolbar does not indicate active menu trail for pages not included in Toolbar": "https://git.drupalcode.org/project/drupal/-/commit/3165269bb01a5a8e5f53c1f369135b967c9d5924.patch"
-            }
         }
     },
     "repositories": {

--- a/modules/acquia_cms_toolbar/composer.json
+++ b/modules/acquia_cms_toolbar/composer.json
@@ -22,6 +22,12 @@
     "extra": {
         "branch-alias": {
             "dev-develop": "1.x-dev"
+        },
+        "enable-patching": true,
+        "patches": {
+            "drupal/core": {
+                "3371005 - Toolbar does not indicate active menu trail for pages not included in Toolbar": "https://git.drupalcode.org/project/drupal/-/commit/3165269bb01a5a8e5f53c1f369135b967c9d5924.patch"
+            }
         }
     },
     "repositories": {


### PR DESCRIPTION
**Motivation**
Fixes #[ACMS-1919](https://backlog.acquia.com/browse/ACMS-1919)

**Proposed changes**
Fix Toolbar does not indicate active menu trail for pages not included in Toolbar.

**Alternatives considered**
NA

**Testing steps**
Follow from ticket.

**Merge requirements**
- [ ] _Major change_, _Minor change_, _Bug_, _Enhancement_, and/or _Chore_ label applied
- [ ] Manual testing by a reviewer
