### PR TITLE
ACMS-1960: Remove JSONAPI Extras patch as it is failing with latest version 3.24.

### DIFF
--- a/.github/workflows/acquia_cms_ci.workflow.yml
+++ b/.github/workflows/acquia_cms_ci.workflow.yml
@@ -164,8 +164,6 @@ jobs:
           # Update the CI by adding patches without pinning the following modules.
           composer require "drupal/facets:^2.0.6" --no-update --no-install -d modules/acquia_cms_search
           composer require "drupal/pathauto:^1.11" --no-update --no-install -d modules/acquia_cms_common
-          composer require "drupal/jsonapi_extras:^3.23" --no-update --no-install -d modules/acquia_cms_headless
-          composer require "drupal/jsonapi_extras:^3.23" --no-update --no-install -d modules/acquia_cms_component
 
           # Added below in CI to test acquia_cms on Drupal Core >=9.5.
           composer require "drupal/core:>=9.5" --no-update --no-install -d modules/acquia_cms_common

--- a/composer.json
+++ b/composer.json
@@ -129,6 +129,9 @@
             "drupal/core": "-p2"
         },
         "patches": {
+            "acquia/cohesion": {
+                "ACO-2515 - Fix missing schema for global js settings": "https://gist.githubusercontent.com/rajeshreeputra/236387fbc315ec047990c53ffc86f74d/raw/6c8e5279e1dbe2b8245c836a4be0624c32628907/sitestudio-7.3.0-missing-schema-issue-fix.patch"
+            },
             "drupal/core": {
                 "3328187 - PHP Deprecated: strpos(): Passing null to parameter #1 ($haystack) of type string is deprecated in docroot/core/lib/Drupal/Core/Mail/Plugin/Mail/PhpMail.php on line 112": "https://git.drupalcode.org/project/drupal/-/merge_requests/3142.patch",
                 "Fix failing test for site studio due to missing file": "https://gist.githubusercontent.com/chandan-singh7929/978c8c3c8b6f1e2de23492e7e562c0c3/raw/f0e7770d94be862e5495ca25662a0a0d5672b785/bypass-library-version-core.patch"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "483454b9e27db3dfdc17ecd86543cd1b",
+    "content-hash": "8029e300dd4f3926a66e28d6c784cfa3",
     "packages": [
         {
             "name": "acquia/acquia-cms-starterkit",
@@ -83,16 +83,16 @@
         },
         {
             "name": "acquia/cohesion",
-            "version": "7.2.1",
+            "version": "7.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/acquia/cohesion.git",
-                "reference": "9278697b9dcbeb78316c1342af0d21c732d70c57"
+                "reference": "6e4f7d5e75d709f08c5b388ade1b22347f0e70af"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/acquia/cohesion/zipball/9278697b9dcbeb78316c1342af0d21c732d70c57",
-                "reference": "9278697b9dcbeb78316c1342af0d21c732d70c57",
+                "url": "https://api.github.com/repos/acquia/cohesion/zipball/6e4f7d5e75d709f08c5b388ade1b22347f0e70af",
+                "reference": "6e4f7d5e75d709f08c5b388ade1b22347f0e70af",
                 "shasum": ""
             },
             "require": {
@@ -145,9 +145,9 @@
             ],
             "description": "Site Studio",
             "support": {
-                "source": "https://github.com/acquia/cohesion/tree/7.2.1"
+                "source": "https://github.com/acquia/cohesion/tree/7.3.0"
             },
-            "time": "2023-07-24T12:55:45+00:00"
+            "time": "2023-09-01T15:41:35+00:00"
         },
         {
             "name": "acquia/cohesion-theme",
@@ -4991,6 +4991,10 @@
                 {
                     "name": "All contributors",
                     "homepage": "https://www.drupal.org/node/2625160/committers"
+                },
+                {
+                    "name": "phenaproxima",
+                    "homepage": "https://www.drupal.org/user/205645"
                 },
                 {
                     "name": "StryKaizer",

--- a/composer.lock
+++ b/composer.lock
@@ -2522,12 +2522,12 @@
             "dist": {
                 "type": "path",
                 "url": "./modules/acquia_cms_component",
-                "reference": "4fa29348b3b4820084852908cefc24d65598fb5b"
+                "reference": "0953301c97148102dde5605639008b2b0bc76701"
             },
             "require": {
                 "drupal/acquia_cms_common": "1.x-dev || 2.x-dev || 3.x-dev",
                 "drupal/component": "^1.0",
-                "drupal/jsonapi_extras": "3.23"
+                "drupal/jsonapi_extras": "^3.24"
             },
             "type": "drupal-module",
             "extra": {
@@ -2535,11 +2535,7 @@
                     "dev-develop": "1.x-dev"
                 },
                 "enable-patching": true,
-                "patches": {
-                    "drupal/jsonapi_extras": {
-                        "3357832 - PHP 8.2 compatibility": "https://git.drupalcode.org/project/jsonapi_extras/-/merge_requests/30.patch"
-                    }
-                }
+                "patches": []
             },
             "license": [
                 "GPL-2.0-or-later"
@@ -2642,11 +2638,11 @@
             "dist": {
                 "type": "path",
                 "url": "./modules/acquia_cms_headless",
-                "reference": "e7ccbe4cdf3cb0e675fbf14cb4f141c5b98359bb"
+                "reference": "94c2e662c3f8af05dfe79ea0f003685312ad75ca"
             },
             "require": {
                 "drupal/acquia_cms_tour": "2.x-dev",
-                "drupal/jsonapi_extras": "3.23",
+                "drupal/jsonapi_extras": "^3.24",
                 "drupal/jsonapi_menu_items": "^1.2",
                 "drupal/next": "^1.6",
                 "drupal/openapi_jsonapi": "^3.0",
@@ -2699,9 +2695,6 @@
                 "patches": {
                     "drupal/decoupled_router": {
                         "3111456 - Unable to resolve path on node in other language than default": "https://www.drupal.org/files/issues/2022-11-30/decouple_router-3111456-resolve-language-issue-58.patch"
-                    },
-                    "drupal/jsonapi_extras": {
-                        "3357832 - PHP 8.2 compatibility": "https://git.drupalcode.org/project/jsonapi_extras/-/merge_requests/30.patch"
                     },
                     "drupal/subrequests": {
                         "3049395 - Page Cache causes different subrequests to return the same responses": "https://www.drupal.org/files/issues/2019-07-18/change_request_type-63049395-09.patch"
@@ -5828,30 +5821,27 @@
         },
         {
             "name": "drupal/jsonapi_extras",
-            "version": "3.23.0",
+            "version": "3.24.0",
             "source": {
                 "type": "git",
                 "url": "https://git.drupalcode.org/project/jsonapi_extras.git",
-                "reference": "8.x-3.23"
+                "reference": "8.x-3.24"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://ftp.drupal.org/files/projects/jsonapi_extras-8.x-3.23.zip",
-                "reference": "8.x-3.23",
-                "shasum": "2f3518bc1372f01a1ccebcffaa4e7e08478103e0"
+                "url": "https://ftp.drupal.org/files/projects/jsonapi_extras-8.x-3.24.zip",
+                "reference": "8.x-3.24",
+                "shasum": "5031650d17b62f5da5586d3a2c551ac071dbd294"
             },
             "require": {
                 "drupal/core": "^9.2 || ^10",
                 "e0ipso/shaper": "^1"
             },
-            "require-dev": {
-                "drupal/jsonapi": "*"
-            },
             "type": "drupal-module",
             "extra": {
                 "drupal": {
-                    "version": "8.x-3.23",
-                    "datestamp": "1669374477",
+                    "version": "8.x-3.24",
+                    "datestamp": "1694442796",
                     "security-coverage": {
                         "status": "covered",
                         "message": "Covered by Drupal's security advisory policy"

--- a/modules/acquia_cms_component/composer.json
+++ b/modules/acquia_cms_component/composer.json
@@ -6,7 +6,7 @@
     "require": {
         "drupal/acquia_cms_common": "1.x-dev || 2.x-dev || 3.x-dev",
         "drupal/component": "^1.0",
-        "drupal/jsonapi_extras": "3.23"
+        "drupal/jsonapi_extras": "^3.24"
     },
     "config": {
         "allow-plugins": {
@@ -25,11 +25,7 @@
             "dev-develop": "1.x-dev"
         },
         "enable-patching": true,
-        "patches": {
-            "drupal/jsonapi_extras": {
-                "3357832 - PHP 8.2 compatibility": "https://git.drupalcode.org/project/jsonapi_extras/-/merge_requests/30.patch"
-            }
-        }
+        "patches": {}
     },
     "repositories": {
         "assets": {

--- a/modules/acquia_cms_headless/composer.json
+++ b/modules/acquia_cms_headless/composer.json
@@ -5,7 +5,7 @@
     "license": "GPL-2.0-or-later",
     "require": {
         "drupal/acquia_cms_tour": "2.x-dev",
-        "drupal/jsonapi_extras": "3.23",
+        "drupal/jsonapi_extras": "^3.24",
         "drupal/jsonapi_menu_items": "^1.2",
         "drupal/next": "^1.6",
         "drupal/openapi_jsonapi": "^3.0",
@@ -69,9 +69,6 @@
         "patches": {
             "drupal/decoupled_router": {
                 "3111456 - Unable to resolve path on node in other language than default": "https://www.drupal.org/files/issues/2022-11-30/decouple_router-3111456-resolve-language-issue-58.patch"
-            },
-            "drupal/jsonapi_extras": {
-                "3357832 - PHP 8.2 compatibility": "https://git.drupalcode.org/project/jsonapi_extras/-/merge_requests/30.patch"
             },
             "drupal/subrequests": {
                 "3049395 - Page Cache causes different subrequests to return the same responses": "https://www.drupal.org/files/issues/2019-07-18/change_request_type-63049395-09.patch"


### PR DESCRIPTION
**Motivation**
Fixes #[ACMS-1960](https://backlog.acquia.com/browse/ACMS-1960)

**Proposed changes**
Remove JSONAPI Extras patch as it is failing with latest version 3.24.

**Alternatives considered**
NA

**Testing steps**
Follow from ticket.

**Merge requirements**
- [ ] _Major change_, _Minor change_, _Bug_, _Enhancement_, and/or _Chore_ label applied
- [ ] Manual testing by a reviewer
