### PR TITLE
ACMS-1918: Page title should contextualize the local navigation.

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -2435,7 +2435,7 @@
             "dist": {
                 "type": "path",
                 "url": "./modules/acquia_cms_common",
-                "reference": "982c32cdc1420201fc0660faca5a273ad6bd16e1"
+                "reference": "3f9ebc733172e34ce94d7a0833ca8ecbf3607506"
             },
             "require": {
                 "acquia/drupal-environment-detector": "^1.5",
@@ -2502,7 +2502,8 @@
                         "3301692 - Passing null to parameter to mb_strtolower() is deprecated with PHP 8.1": "https://git.drupalcode.org/project/drupal/-/merge_requests/2598.patch",
                         "3356894 - Make field selection less overwhelming by introducing groups": "https://www.drupal.org/files/issues/2023-06-20/3356894-mr_3896.patch",
                         "296693 - Restrict access to empty top level administration pages": "https://www.drupal.org/files/issues/2023-08-31/296693-10.1.x_0.patch",
-                        "3371005 - Toolbar does not indicate active menu trail for pages not included in Toolbar": "https://git.drupalcode.org/project/drupal/-/commit/3165269bb01a5a8e5f53c1f369135b967c9d5924.patch"
+                        "3371005 - Toolbar does not indicate active menu trail for pages not included in Toolbar": "https://git.drupalcode.org/project/drupal/-/commit/3165269bb01a5a8e5f53c1f369135b967c9d5924.patch",
+                        "3370946 - Page title should contextualize the local navigation": "https://www.drupal.org/files/issues/2023-09-11/3370946-page-title-backport-10-1-x.patch"
                     },
                     "drupal/pathauto": {
                         "3328670 - PHP 8.2 compatibility": "https://git.drupalcode.org/project/pathauto/-/merge_requests/40.patch"

--- a/modules/acquia_cms_common/composer.json
+++ b/modules/acquia_cms_common/composer.json
@@ -79,7 +79,8 @@
                 "3301692 - Passing null to parameter to mb_strtolower() is deprecated with PHP 8.1": "https://git.drupalcode.org/project/drupal/-/merge_requests/2598.patch",
                 "3356894 - Make field selection less overwhelming by introducing groups": "https://www.drupal.org/files/issues/2023-06-20/3356894-mr_3896.patch",
                 "296693 - Restrict access to empty top level administration pages": "https://www.drupal.org/files/issues/2023-08-31/296693-10.1.x_0.patch",
-                "3371005 - Toolbar does not indicate active menu trail for pages not included in Toolbar": "https://git.drupalcode.org/project/drupal/-/commit/3165269bb01a5a8e5f53c1f369135b967c9d5924.patch"
+                "3371005 - Toolbar does not indicate active menu trail for pages not included in Toolbar": "https://git.drupalcode.org/project/drupal/-/commit/3165269bb01a5a8e5f53c1f369135b967c9d5924.patch",
+                "3370946 - Page title should contextualize the local navigation": "https://www.drupal.org/files/issues/2023-09-11/3370946-page-title-backport-10-1-x.patch"
             },
             "drupal/pathauto": {
                 "3328670 - PHP 8.2 compatibility": "https://git.drupalcode.org/project/pathauto/-/merge_requests/40.patch"


### PR DESCRIPTION
**Motivation**
Fixes #[ACMS-1918](https://backlog.acquia.com/browse/ACMS-1918)

**Proposed changes**

1. Few of the test participants navigated to edit fields of an incorrect bundle or even incorrect entity type. When asked, they thought they were editing the entity type or bundle we instructed them to edit. Without knowing the content model of the site, the only indication in the UI that this is not the case is in the breadcrumb
2. Users don't always understand what's the context for the tabs (especially problematic for the second level). For example, on Manage Display there are "Default" and "Teaser" tabs, and users didn't realize they were view modes.

**Alternatives considered**
NA

**Testing steps**

- Checkout [ACMS-1918](https://backlog.acquia.com/browse/ACMS-1918)
- Run composer install
- Install site using acms si
- Run pending update drush updb
- Login into site and validate the changes.

**Merge requirements**
- [ ] _Major change_, _Minor change_, _Bug_, _Enhancement_, and/or _Chore_ label applied
- [ ] Manual testing by a reviewer
