### PR TITLE
ACMS-1985: Display Starter Kit name in status report page.

### DIFF
--- a/modules/acquia_cms_common/acquia_cms_common.module
+++ b/modules/acquia_cms_common/acquia_cms_common.module
@@ -234,11 +234,14 @@ function acquia_cms_common_system_breadcrumb_alter(Breadcrumb &$breadcrumb, Rout
 /**
  * Implements hook_preprocess_template().
  */
-function acquia_cms_common_preprocess_status_report_general_info(&$variables) {
+function acquia_cms_common_preprocess_status_report_general_info(&$variables, $hook, $info) {
   // Check for the starter kit selection.
   if ($starter_kit = \Drupal::service('acquia_cms_common.utility')->getStarterKit()) {
     // Store selected starter kit into the variable.
     $variables['acquia_cms']['starter_kit'] = $starter_kit;
+    $variables['drupal']['description'] = [
+      '#markup' => $variables['drupal']['description'] . '<h3 class="system-status-general-info__item-title">Starter Kit:</h3> ' . $starter_kit,
+    ];
   }
 }
 


### PR DESCRIPTION
**Motivation**
Fixes #[ACMS-1985](https://backlog.acquia.com/browse/ACMS-1985)

**Proposed changes**
Display Starter Kit name in status report page.

**Alternatives considered**
NA

**Testing steps**
Follow from ticket

**Merge requirements**
- [ ] _Major change_, _Minor change_, _Bug_, _Enhancement_, and/or _Chore_ label applied
- [ ] Manual testing by a reviewer
