### PR TITLE
ACMS-1991: Fix Acquia CMS Common and Acquia CMS profile conflict.

### DIFF
--- a/acquia_cms.info.yml
+++ b/acquia_cms.info.yml
@@ -54,7 +54,6 @@ dependencies:
   - password_policy:password_policy_username
   - pathauto:pathauto
   - purge:purge_processor_cron
-  - purge:purge_processor_lateruntime
   - purge:purge_queuer_coretags
   - purge:purge_ui
   - recaptcha:recaptcha


### PR DESCRIPTION
**Motivation**
Fixes #[ACMS-1991](https://acquia.atlassian.net/browse/ACMS-1991)

**Proposed changes**
Remove purge_processor_lateruntime install dependency from Acquia CMS profile.

**Alternatives considered**
NA

**Testing steps**
- Create project using `composer create-project acquia/drupal-recommended-project:^1 acquia_cms && cd acquia_cms`
- Require Acquia CMS profile using `composer require acquia/acquia_cms:^1.5`
- Update Acquia CMS Common to 2.1.4 or older using `composer update drupal/acquia_cms_common:2.1.4`
- Install site using `./vendor/bin/drush si acquia_cms`
<img width="872" alt="Screenshot 2023-10-09 at 1 55 17 PM" src="https://github.com/acquia/acquia_cms/assets/19570710/6e9c2b94-9e23-4d01-a16c-b91cfdc091c9">

- Update Acquia CMS Common to latest or version greater than 2.1.4 using `composer update drupal/acquia_cms_common:^2.1.5`
- Update database using `./vendor/bin/drush updb` & you will encounter the error.

<img width="1312" alt="Screenshot 2023-10-09 at 1 54 48 PM" src="https://github.com/acquia/acquia_cms/assets/19570710/ea0ae621-5d26-4b00-a1ad-6c7d1c9c20e0">

- Update Acquia CMS profile using `composer require acquia/acquia_cms:dev-ACMS-1991`
- Update database using `./vendor/bin/drush updb`
- Verify update completed successfully & site working fine.

<img width="1315" alt="Screenshot 2023-10-09 at 1 52 12 PM" src="https://github.com/acquia/acquia_cms/assets/19570710/4d7371ce-ed4b-40b4-a534-b3f3550b1f28">
<img width="698" alt="Screenshot 2023-10-09 at 1 52 23 PM" src="https://github.com/acquia/acquia_cms/assets/19570710/c0a2cbeb-0712-4a9d-a8a9-ad0e3b4bdb52">


**Merge requirements**
- [ ] _Major change_, _Minor change_, _Bug_, _Enhancement_, and/or _Chore_ label applied
- [ ] Manual testing by a reviewer
