### PR TITLE
ACMS-1998: Remove failing Search API patch as released in 1.30 version.

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -2835,7 +2835,7 @@
             "dist": {
                 "type": "path",
                 "url": "./modules/acquia_cms_search",
-                "reference": "f3c4b4caa559235bc1cf050e880734ce8307506a"
+                "reference": "a6c390f1e9d30bbf658cb9d3be8c276f8b81eb87"
             },
             "require": {
                 "cweagans/composer-patches": "^1.7",
@@ -2844,7 +2844,7 @@
                 "drupal/collapsiblock": "^4.0",
                 "drupal/facets": "2.0.6",
                 "drupal/facets_pretty_paths": "^1.4",
-                "drupal/search_api": "^1.29",
+                "drupal/search_api": "1.30",
                 "drupal/search_api_autocomplete": "^1.7"
             },
             "type": "drupal-module",
@@ -2859,8 +2859,7 @@
                         "3358295 - PHP 8.2 compatibility": "https://git.drupalcode.org/project/facets/-/merge_requests/141.patch"
                     },
                     "drupal/search_api": {
-                        "3151796 - Problems when executing Search API tasks during install, updates": "https://www.drupal.org/files/issues/2022-11-04/search_api-3151796-division-by-zero-error-7.patch",
-                        "3236696 - Call to a member function preExecute() on null in SearchApiTagCache->alterCacheMetadata()": "https://www.drupal.org/files/issues/2022-08-02/3236696-5.patch"
+                        "3151796 - Problems when executing Search API tasks during install, updates": "https://www.drupal.org/files/issues/2022-11-04/search_api-3151796-division-by-zero-error-7.patch"
                     }
                 }
             },
@@ -7672,17 +7671,17 @@
         },
         {
             "name": "drupal/search_api",
-            "version": "1.29.0",
+            "version": "1.30.0",
             "source": {
                 "type": "git",
                 "url": "https://git.drupalcode.org/project/search_api.git",
-                "reference": "8.x-1.29"
+                "reference": "8.x-1.30"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://ftp.drupal.org/files/projects/search_api-8.x-1.29.zip",
-                "reference": "8.x-1.29",
-                "shasum": "4663abbcfe5dfc159ee0886fc6c437e998fc0653"
+                "url": "https://ftp.drupal.org/files/projects/search_api-8.x-1.30.zip",
+                "reference": "8.x-1.30",
+                "shasum": "25bd2cfab6a6332c595fbc8be1c4cfff33a85ce8"
             },
             "require": {
                 "drupal/core": "^9.3 || ^10.0"
@@ -7703,8 +7702,8 @@
             "type": "drupal-module",
             "extra": {
                 "drupal": {
-                    "version": "8.x-1.29",
-                    "datestamp": "1679910252",
+                    "version": "8.x-1.30",
+                    "datestamp": "1697366291",
                     "security-coverage": {
                         "status": "covered",
                         "message": "Covered by Drupal's security advisory policy"
@@ -7712,7 +7711,7 @@
                 },
                 "drush": {
                     "services": {
-                        "drush.services.yml": "^9 || ^10"
+                        "drush.services.yml": "^9 || ^10 || ^11"
                     }
                 }
             },

--- a/modules/acquia_cms_search/composer.json
+++ b/modules/acquia_cms_search/composer.json
@@ -10,7 +10,7 @@
         "drupal/collapsiblock": "^4.0",
         "drupal/facets": "2.0.6",
         "drupal/facets_pretty_paths": "^1.4",
-        "drupal/search_api": "^1.29",
+        "drupal/search_api": "1.30",
         "drupal/search_api_autocomplete": "^1.7"
     },
     "config": {
@@ -36,8 +36,7 @@
                 "3358295 - PHP 8.2 compatibility": "https://git.drupalcode.org/project/facets/-/merge_requests/141.patch"
             },
             "drupal/search_api": {
-                "3151796 - Problems when executing Search API tasks during install, updates": "https://www.drupal.org/files/issues/2022-11-04/search_api-3151796-division-by-zero-error-7.patch",
-                "3236696 - Call to a member function preExecute() on null in SearchApiTagCache->alterCacheMetadata()": "https://www.drupal.org/files/issues/2022-08-02/3236696-5.patch"
+                "3151796 - Problems when executing Search API tasks during install, updates": "https://www.drupal.org/files/issues/2022-11-04/search_api-3151796-division-by-zero-error-7.patch"
             }
         }
     },


### PR DESCRIPTION
**Motivation**
Fixes #[ACMS-1998](https://acquia.atlassian.net/browse/ACMS-1998)

**Proposed changes**
Remove failing search_api patch as merged in 1.30 version.

**Alternatives considered**
NA

**Testing steps**
Follow from ticket.

**Merge requirements**
- [ ] _Major change_, _Minor change_, _Bug_, _Enhancement_, and/or _Chore_ label applied
- [ ] Manual testing by a reviewer
