### PR TITLE
ACMS-2006: Remove failing Geocoder patch as released in 3.35 and 4.10 version.

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -2800,12 +2800,12 @@
             "dist": {
                 "type": "path",
                 "url": "./modules/acquia_cms_place",
-                "reference": "73ced01010f0c77f9b052e8ab9004b83dd7ef8bb"
+                "reference": "0ef7c463dbbc6821095c788a6f57ba599d40c08e"
             },
             "require": {
                 "drupal/acquia_cms_image": "1.x-dev",
                 "drupal/address": "^1.11",
-                "drupal/geocoder": "^3.31 || ^4.4",
+                "drupal/geocoder": "^3.35 || ^4.10",
                 "drupal/geofield": "^1.47",
                 "drupal/scheduler": "^2.0",
                 "geocoder-php/google-maps-provider": "^4.7"
@@ -2814,12 +2814,6 @@
             "extra": {
                 "branch-alias": {
                     "dev-develop": "1.x-dev"
-                },
-                "enable-patching": true,
-                "patches": {
-                    "drupal/geocoder": {
-                        "3224364 - Replace deprecated boolean return in uksort() for PHP 8 compatibility.": "https://www.drupal.org/files/issues/2021-07-19/3224364-2.patch"
-                    }
                 }
             },
             "license": [
@@ -5187,17 +5181,17 @@
         },
         {
             "name": "drupal/geocoder",
-            "version": "4.9.0",
+            "version": "4.10.0",
             "source": {
                 "type": "git",
                 "url": "https://git.drupalcode.org/project/geocoder.git",
-                "reference": "8.x-4.9"
+                "reference": "8.x-4.10"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://ftp.drupal.org/files/projects/geocoder-8.x-4.9.zip",
-                "reference": "8.x-4.9",
-                "shasum": "52d2bc269e82300327f5b33e435b7514d6c68d2b"
+                "url": "https://ftp.drupal.org/files/projects/geocoder-8.x-4.10.zip",
+                "reference": "8.x-4.10",
+                "shasum": "32c0425803f97072dab94e7447ef00aa215439bd"
             },
             "require": {
                 "davedevelopment/stiphle": "^0.9.2",
@@ -5240,8 +5234,8 @@
             "type": "drupal-module",
             "extra": {
                 "drupal": {
-                    "version": "8.x-4.9",
-                    "datestamp": "1682585195",
+                    "version": "8.x-4.10",
+                    "datestamp": "1697825420",
                     "security-coverage": {
                         "status": "covered",
                         "message": "Covered by Drupal's security advisory policy"

--- a/modules/acquia_cms_place/composer.json
+++ b/modules/acquia_cms_place/composer.json
@@ -6,7 +6,7 @@
     "require": {
         "drupal/acquia_cms_image": "1.x-dev",
         "drupal/address": "^1.11",
-        "drupal/geocoder": "^3.31 || ^4.4",
+        "drupal/geocoder": "^3.35 || ^4.10",
         "drupal/geofield": "^1.47",
         "drupal/scheduler": "^2.0",
         "geocoder-php/google-maps-provider": "^4.7"
@@ -26,12 +26,6 @@
     "extra": {
         "branch-alias": {
             "dev-develop": "1.x-dev"
-        },
-        "enable-patching": true,
-        "patches": {
-            "drupal/geocoder": {
-                "3224364 - Replace deprecated boolean return in uksort() for PHP 8 compatibility.": "https://www.drupal.org/files/issues/2021-07-19/3224364-2.patch"
-            }
         }
     },
     "repositories": {


### PR DESCRIPTION
Remove Geocoder patch from Acquia CMS Place

**Motivation**
This will solve failing ACMS Installation
 
**Proposed changes**
Remove geocoder patch


