### PR TITLE
ACMS-1636: View Search Fallback is broken on ACMS install.

### DIFF
--- a/modules/acquia_cms_search/config/pack_acquia_cms_search/cohesion_templates.cohesion_view_templates.view_tpl_search_fallback.yml
+++ b/modules/acquia_cms_search/config/pack_acquia_cms_search/cohesion_templates.cohesion_view_templates.view_tpl_search_fallback.yml
@@ -3,6 +3,8 @@ langcode: en
 status: true
 dependencies:
   config:
+    - cohesion_custom_styles.cohesion_custom_style.2b79314d
+    - cohesion_custom_styles.cohesion_custom_style.668f9bd0
     - cohesion_custom_styles.cohesion_custom_style.e01b8004
     - views.view.search_fallback
   enforced:
@@ -39,7 +41,7 @@ json_values: |
                               "uid": "drupal-view-contents",
                               "title": "View content",
                               "status": {
-                                  "collapsed": true
+                                  "collapsed": false
                               },
                               "uuid": "3ef69905-1dc8-42f3-8600-23a13f49940a",
                               "parentUid": "drupal-view",
@@ -64,27 +66,34 @@ json_values: |
                                       "title": "Pattern repeater",
                                       "mimicParent": true,
                                       "status": {
-                                          "collapsed": true,
-                                          "collapsedParents": [
-                                              "3ef69905-1dc8-42f3-8600-23a13f49940a"
-                                          ]
+                                          "collapsed": false
                                       },
                                       "uuid": "b7960f74-ca61-4b06-85f6-92103ee967c6",
                                       "parentUid": "drupal-view-contents",
                                       "children": [
                                           {
-                                              "type": "item",
-                                              "uid": "drupal-view-item",
-                                              "title": "View item",
+                                              "type": "container",
+                                              "uid": "container",
+                                              "title": "Container",
                                               "status": {
-                                                  "collapsed": true,
-                                                  "collapsedParents": [
-                                                      "3ef69905-1dc8-42f3-8600-23a13f49940a"
-                                                  ]
+                                                  "collapsed": false
                                               },
-                                              "uuid": "231570b4-6d8a-4f35-96bb-b9997aa0b6e3",
+                                              "iconColor": "layout",
+                                              "uuid": "b0a14852-7ab9-45bb-870a-bd6168496816",
                                               "parentUid": "pattern-repeater",
-                                              "children": []
+                                              "children": [
+                                                  {
+                                                      "type": "item",
+                                                      "uid": "drupal-view-item",
+                                                      "title": "View item",
+                                                      "status": {
+                                                          "collapsed": true
+                                                      },
+                                                      "uuid": "231570b4-6d8a-4f35-96bb-b9997aa0b6e3",
+                                                      "parentUid": "container",
+                                                      "children": []
+                                                  }
+                                              ]
                                           }
                                       ]
                                   }
@@ -95,7 +104,7 @@ json_values: |
                               "uid": "container",
                               "title": "Container",
                               "status": {
-                                  "collapsed": true
+                                  "collapsed": false
                               },
                               "uuid": "95624278-cfa0-4229-8fe3-9f44e2c0caac",
                               "parentUid": "drupal-view",
@@ -506,7 +515,66 @@ json_values: |
                   "items": []
               }
           },
-          "38ad068b-b86f-4b61-9a3f-dd6c982cc6d9": {}
+          "38ad068b-b86f-4b61-9a3f-dd6c982cc6d9": {},
+          "b0a14852-7ab9-45bb-870a-bd6168496816": {
+              "settings": {
+                  "formDefinition": [
+                      {
+                          "formKey": "container-settings",
+                          "children": [
+                              {
+                                  "formKey": "container-width",
+                                  "breakpoints": [],
+                                  "activeFields": [
+                                      {
+                                          "name": "width",
+                                          "active": true
+                                      }
+                                  ]
+                              },
+                              {
+                                  "formKey": "common-link-animation",
+                                  "breakpoints": [
+                                      {
+                                          "name": "xl"
+                                      }
+                                  ],
+                                  "activeFields": [
+                                      {
+                                          "name": "animationType",
+                                          "active": true
+                                      }
+                                  ]
+                              },
+                              {
+                                  "formKey": "common-link-modifier",
+                                  "breakpoints": [],
+                                  "activeFields": [
+                                      {
+                                          "name": "modifierType",
+                                          "active": true
+                                      }
+                                  ]
+                              },
+                              {
+                                  "formKey": "container-style",
+                                  "breakpoints": [],
+                                  "activeFields": [
+                                      {
+                                          "name": "customStyle",
+                                          "active": true
+                                      }
+                                  ]
+                              }
+                          ]
+                      }
+                  ],
+                  "selectorType": "topLevel",
+                  "form": null,
+                  "items": [],
+                  "title": "Default"
+              }
+          }
       },
       "model": {
           "ecdd48ac-8316-44eb-b8ce-33d3382d4c0b": {
@@ -552,6 +620,17 @@ json_values: |
                   "settings": {
                       "element": "view-variable"
                   }
+              }
+          },
+          "b0a14852-7ab9-45bb-870a-bd6168496816": {
+              "settings": {
+                  "width": "fluid",
+                  "title": "Container",
+                  "customStyle": [
+                      {
+                          "customStyle": "coh-style-search-result-container"
+                      }
+                  ]
               }
           },
           "231570b4-6d8a-4f35-96bb-b9997aa0b6e3": {
@@ -646,7 +725,7 @@ json_values: |
                           "lastTextCustomStyle": ""
                       }
                   },
-                  "customStyle": "coh-style-pagination-list"
+                  "customStyle": "coh-style-view-pagination"
               },
               "context-visibility": {
                   "contextVisibility": {
@@ -665,14 +744,16 @@ json_values: |
           "a8a2cc46-af09-448c-80cc-427f03a7b25f": {},
           "38ad068b-b86f-4b61-9a3f-dd6c982cc6d9": {},
           "95624278-cfa0-4229-8fe3-9f44e2c0caac": {},
-          "ecdd48ac-8316-44eb-b8ce-33d3382d4c0b": {}
+          "ecdd48ac-8316-44eb-b8ce-33d3382d4c0b": {},
+          "b0a14852-7ab9-45bb-870a-bd6168496816": {}
       },
       "variableFields": {
           "231570b4-6d8a-4f35-96bb-b9997aa0b6e3": [],
           "a8a2cc46-af09-448c-80cc-427f03a7b25f": [],
           "38ad068b-b86f-4b61-9a3f-dd6c982cc6d9": [],
           "95624278-cfa0-4229-8fe3-9f44e2c0caac": [],
-          "ecdd48ac-8316-44eb-b8ce-33d3382d4c0b": []
+          "ecdd48ac-8316-44eb-b8ce-33d3382d4c0b": [],
+          "b0a14852-7ab9-45bb-870a-bd6168496816": []
       },
       "meta": {
           "fieldHistory": []


### PR DESCRIPTION
**Motivation**
<!-- What problem does this solve? Why is it important? What's the context? If this fixes an issue, link to it above. -->
Fixes #ACMS-1636

**Proposed changes**
Fixes fallback view for search

**Alternatives considered**
<!-- How else could the original issue / use case be addressed? Why did you choose this solution over any others? -->

**Testing steps**
git clone develop
install site using acquia_cms_enterprise_low_code and set fallback view using commands
./vendor/bin/drush cset views.view.search display.default.display_options.empty.view_fallback.simulate_unavailable TRUE
go to site and search something and see fallback is broken including pagination.

git checkout ACMS-1636
./vendor/bin/drush cset views.view.search display.default.display_options.empty.view_fallback.simulate_unavailable TRUE
now check fallback is working fine.

**For existing users**

- Go to the website and navigate to the "/user/login" page.
- Enter the admin credentials to log in.
- Once logged in, go to the "/admin/cohesion/templates/view_templates/view_tpl_search_fallback/edit" page.
- In the layout canvas, locate the "Container - Pagination" section and double-click on the "Pagination" element.
- Scroll to the bottom of the screen and, in the List style options, select "View Pagination" Click on the "Apply" button.
- Now, drag a "Container" element from the elements panel and place it inside the "Pattern repeater" Wrap it around the "View item" section.
- Double-click on the newly added container and, in the Layout style options, choose "Search result container" Click "Apply".
- Finally, click on the "Save and Continue" button to save your changes.

**Merge requirements**
- [ ] _Major change_, _Minor change_, _Bug_, _Enhancement_, and/or _Chore_ label applied
- [ ] Manual testing by a reviewer
