### PR TITLE
ACMS-1986: Add gin theme in Acquia CMS Common module.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,6 @@
         "drupal/acquia_cms_toolbar": "dev-develop",
         "drupal/acquia_cms_tour": "dev-develop",
         "drupal/consumer_image_styles": "^4.0",
-        "drupal/gin": "^3.0@RC",
         "drupal/google_analytics": "^4.0",
         "drupal/google_tag": "^2.0",
         "drupal/honeypot": "^2.1",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "bf181fa47ec3ffe0d0703976689536bf",
+    "content-hash": "6210e97a28303f0bffbaccc47007032f",
     "packages": [
         {
             "name": "acquia/acquia-cms-starterkit",
@@ -2384,7 +2384,7 @@
             "dist": {
                 "type": "path",
                 "url": "./modules/acquia_cms_common",
-                "reference": "565c5b8c0abb97b30d7693d229d1659ede2c84fa"
+                "reference": "9ef9852585a577370e51197a95d524d4d50562f2"
             },
             "require": {
                 "acquia/drupal-environment-detector": "^1.5",
@@ -2400,6 +2400,7 @@
                 "drupal/diff": "^1.1",
                 "drupal/entity_clone": "^2.0@beta",
                 "drupal/field_group": "^3.4",
+                "drupal/gin": "^3.0@RC",
                 "drupal/memcache": "^2.5",
                 "drupal/moderation_dashboard": "^2.1",
                 "drupal/moderation_sidebar": "^1.7",
@@ -20841,7 +20842,6 @@
         "drupal/acquia_cms_starter": 20,
         "drupal/acquia_cms_toolbar": 20,
         "drupal/acquia_cms_tour": 20,
-        "drupal/gin": 5,
         "drupal/sitestudio_config_management": 20
     },
     "prefer-stable": true,

--- a/modules/acquia_cms_common/acquia_cms_common.install
+++ b/modules/acquia_cms_common/acquia_cms_common.install
@@ -27,16 +27,12 @@ function acquia_cms_common_install($is_syncing) {
       'view media',
     ]);
 
-    // Enable gin theme.
-    $themes_list = \Drupal::service('extension.list.theme')->getList();
+    // Enable olivero, gin theme.
     $theme_installer = \Drupal::service('theme_installer');
-    $theme_installer->install(["olivero"]);
+    $theme_installer->install(["olivero", "gin"]);
     $system_theme_config = \Drupal::configFactory()->getEditable('system.theme');
     $system_theme_config->set('default', 'olivero')->save();
-    if (isset($themes_list['gin'])) {
-      $theme_installer->install(["gin"]);
-      $system_theme_config->set('admin', "gin")->save();
-    }
+    $system_theme_config->set('admin', "gin")->save();
 
     // Re-write the content and media view on module install,
     // since we have moved this config in optional directory.
@@ -300,6 +296,25 @@ function acquia_cms_common_update_8009() {
     if (!$config->get('starter_kit_name')) {
       $config->set('starter_kit_name', \Drupal::state()->get('acquia_cms.starter_kit', "acquia_cms_existing_site"))->save(TRUE);
       \Drupal::state()->delete('acquia_cms.starter_kit');
+    }
+  }
+}
+
+/**
+ * Implements hook_update_N().
+ *
+ * Enable Gin and set as admin theme is current admin theme is Acquia Claro.
+ */
+function acquia_cms_common_update_8301() {
+  $config = \Drupal::configFactory()->getEditable('system.theme');
+  if ($config) {
+    if ($config->get('admin') == 'acquia_claro') {
+      $themes_list = \Drupal::service('extension.list.theme')->getList();
+      $theme_installer = \Drupal::service('theme_installer');
+      if (isset($themes_list['gin'])) {
+        $theme_installer->install(["gin"]);
+        $config->set('admin', "gin")->save();
+      }
     }
   }
 }

--- a/modules/acquia_cms_common/composer.json
+++ b/modules/acquia_cms_common/composer.json
@@ -17,6 +17,7 @@
         "drupal/diff": "^1.1",
         "drupal/entity_clone": "^2.0@beta",
         "drupal/field_group": "^3.4",
+        "drupal/gin": "^3.0@RC",
         "drupal/memcache": "^2.5",
         "drupal/moderation_dashboard": "^2.1",
         "drupal/moderation_sidebar": "^1.7",


### PR DESCRIPTION
**Motivation**
Fixes #ACMS-1986

**Proposed changes**
Include gin theme in ACMS Common module.

**Alternatives considered**
NA

**Testing steps**
- Clone acquia/acquia_cms repository using `git clone -b ACMS-2007 git@github.com:acquia/acquia_cms.git acquia_cms_common && cd acquia_cms_common`
- Install dependencies using `composer install`
- Verify that gin theme is downloaded.
- Install site using `./vendor/bin/drush si minimal`
- Install Acquia CMS Common module using `./vendor/bin/drush in acquia_cms_common -y`
- Verify that gin is set as admin theme.

**Merge requirements**
- [ ] _Major change_, _Minor change_, _Bug_, _Enhancement_, and/or _Chore_ label applied
- [ ] Manual testing by a reviewer
