### PR TITLE
ACMS-3337: Fix Simple Sitemap 4.1.7 version breaks site install.

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -2436,7 +2436,7 @@
             "dist": {
                 "type": "path",
                 "url": "./modules/acquia_cms_common",
-                "reference": "f15b4997b2c364944e1c3486445d8063a294e8af"
+                "reference": "225087ef80a856c795db8f513d66ef236f6b5520"
             },
             "require": {
                 "acquia/drupal-environment-detector": "^1.5",
@@ -2461,7 +2461,7 @@
                 "drupal/scheduler_content_moderation_integration": "^2.0",
                 "drupal/schema_metatag": "^2.4 || ^3.0",
                 "drupal/seckit": "^2.0",
-                "drupal/simple_sitemap": "^4.1",
+                "drupal/simple_sitemap": "4.1.7",
                 "drupal/smart_trim": "^2.0",
                 "drupal/social_media_links": "^2.9",
                 "drupal/username_enumeration_prevention": "^1.3",
@@ -2505,6 +2505,9 @@
                         "3371005 - Toolbar does not indicate active menu trail for pages not included in Toolbar": "https://git.drupalcode.org/project/drupal/-/commit/3165269bb01a5a8e5f53c1f369135b967c9d5924.patch",
                         "3370946 - Page title should contextualize the local navigation": "https://www.drupal.org/files/issues/2023-09-11/3370946-page-title-backport-10-1-x.patch",
                         "3347291: - Combine field storage and field instance forms": "https://www.drupal.org/files/issues/2023-09-13/10.1-3347291-combine-mega-e.patch"
+                    },
+                    "drupal/simple_sitemap": {
+                        "3398996 - Declare min PHP version": "https://git.drupalcode.org/project/simple_sitemap/-/merge_requests/82.patch"
                     }
                 }
             },
@@ -8098,17 +8101,17 @@
         },
         {
             "name": "drupal/simple_sitemap",
-            "version": "4.1.6",
+            "version": "4.1.7",
             "source": {
                 "type": "git",
                 "url": "https://git.drupalcode.org/project/simple_sitemap.git",
-                "reference": "4.1.6"
+                "reference": "4.1.7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://ftp.drupal.org/files/projects/simple_sitemap-4.1.6.zip",
-                "reference": "4.1.6",
-                "shasum": "5ea5ee97ab4d59b43db86dd6279c3ac5ecbe69b9"
+                "url": "https://ftp.drupal.org/files/projects/simple_sitemap-4.1.7.zip",
+                "reference": "4.1.7",
+                "shasum": "3d55ee386b0ebb81ed4c3461451a9e32a15d93d7"
             },
             "require": {
                 "drupal/core": "^9.3 || ^10",
@@ -8117,8 +8120,8 @@
             "type": "drupal-module",
             "extra": {
                 "drupal": {
-                    "version": "4.1.6",
-                    "datestamp": "1686288643",
+                    "version": "4.1.7",
+                    "datestamp": "1698936269",
                     "security-coverage": {
                         "status": "covered",
                         "message": "Covered by Drupal's security advisory policy"

--- a/modules/acquia_cms_common/composer.json
+++ b/modules/acquia_cms_common/composer.json
@@ -26,7 +26,7 @@
         "drupal/scheduler_content_moderation_integration": "^2.0",
         "drupal/schema_metatag": "^2.4 || ^3.0",
         "drupal/seckit": "^2.0",
-        "drupal/simple_sitemap": "^4.1",
+        "drupal/simple_sitemap": "4.1.7",
         "drupal/smart_trim": "^2.0",
         "drupal/social_media_links": "^2.9",
         "drupal/username_enumeration_prevention": "^1.3",
@@ -81,6 +81,9 @@
                 "3371005 - Toolbar does not indicate active menu trail for pages not included in Toolbar": "https://git.drupalcode.org/project/drupal/-/commit/3165269bb01a5a8e5f53c1f369135b967c9d5924.patch",
                 "3370946 - Page title should contextualize the local navigation": "https://www.drupal.org/files/issues/2023-09-11/3370946-page-title-backport-10-1-x.patch",
                 "3347291: - Combine field storage and field instance forms": "https://www.drupal.org/files/issues/2023-09-13/10.1-3347291-combine-mega-e.patch"
+            },
+            "drupal/simple_sitemap": {
+                "3398996 - Declare min PHP version": "https://git.drupalcode.org/project/simple_sitemap/-/merge_requests/82.patch"
             }
         }
     },

--- a/modules/acquia_cms_common/src/Facade/SitemapFacade.php
+++ b/modules/acquia_cms_common/src/Facade/SitemapFacade.php
@@ -7,7 +7,6 @@ use Drupal\Core\DependencyInjection\ContainerInjectionInterface;
 use Drupal\Core\Logger\LoggerChannelInterface;
 use Drupal\node\NodeTypeInterface;
 use Drupal\simple_sitemap\Manager\EntityManager;
-use Drupal\simple_sitemap\Manager\VariantSetterTrait;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
@@ -19,8 +18,6 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
  *   not use this class!
  */
 final class SitemapFacade implements ContainerInjectionInterface {
-
-  use VariantSetterTrait;
 
   /**
    * The config installer service.
@@ -93,7 +90,7 @@ final class SitemapFacade implements ContainerInjectionInterface {
       return;
     }
     // Check if the entity type is enabled and variant exists for the sitemap.
-    $all_default_variants = $this->getVariants();
+    $all_default_variants = array_keys($this->sitemapManager->getSitemaps());
     if ($this->sitemapManager->entityTypeIsEnabled('node') && in_array($sitemap_variant, $all_default_variants)) {
       $this->sitemapManager->setBundleSettings('node', $node_type->id());
     }


### PR DESCRIPTION
**Motivation**
Fixes #[ACMS-3337](https://acquia.atlassian.net/browse/ACMS-3337)

**Proposed changes**
Update Simple Sitemap facade as per latest version(i.e. 4.1.7).

**Alternatives considered**
NA

**Testing steps**
Follow from ticket

**Merge requirements**
- [ ] _Major change_, _Minor change_, _Bug_, _Enhancement_, and/or _Chore_ label applied
- [ ] Manual testing by a reviewer
