### PR TITLE
ACMS-3337: Fix Simple Sitemap 4.1.7 version breaks site install on php 7 version.

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -2436,7 +2436,7 @@
             "dist": {
                 "type": "path",
                 "url": "./modules/acquia_cms_common",
-                "reference": "225087ef80a856c795db8f513d66ef236f6b5520"
+                "reference": "8e4380a9e1b8476e6db2e38be5b06e132c2ca854"
             },
             "require": {
                 "acquia/drupal-environment-detector": "^1.5",
@@ -2507,7 +2507,7 @@
                         "3347291: - Combine field storage and field instance forms": "https://www.drupal.org/files/issues/2023-09-13/10.1-3347291-combine-mega-e.patch"
                     },
                     "drupal/simple_sitemap": {
-                        "3398996 - Declare min PHP version": "https://git.drupalcode.org/project/simple_sitemap/-/merge_requests/82.patch"
+                        "3398996 - Declare min PHP version": "https://www.drupal.org/files/issues/2023-11-06/simple-sitemap-3398996-php-compatibility-16.patch"
                     }
                 }
             },

--- a/modules/acquia_cms_common/composer.json
+++ b/modules/acquia_cms_common/composer.json
@@ -83,7 +83,7 @@
                 "3347291: - Combine field storage and field instance forms": "https://www.drupal.org/files/issues/2023-09-13/10.1-3347291-combine-mega-e.patch"
             },
             "drupal/simple_sitemap": {
-                "3398996 - Declare min PHP version": "https://git.drupalcode.org/project/simple_sitemap/-/merge_requests/82.patch"
+                "3398996 - Declare min PHP version": "https://www.drupal.org/files/issues/2023-11-06/simple-sitemap-3398996-php-compatibility-16.patch"
             }
         }
     },


### PR DESCRIPTION
**Motivation**
Fixes #[ACMS-3337](https://acquia.atlassian.net/browse/ACMS-3337)

**Proposed changes**
Update Simple Sitemap facade as per latest version(i.e. 4.1.7).

**Alternatives considered**
NA

**Testing steps**
Follow from ticket

**Merge requirements**
- [ ] _Major change_, _Minor change_, _Bug_, _Enhancement_, and/or _Chore_ label applied
- [ ] Manual testing by a reviewer
