### PR TITLE
ACMS-2008: Update scripts and installation hooks to gin theme as admin theme.

### DIFF
--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -291,11 +291,6 @@ The Acquia CMS profile contains both core and module-specific Site Studio Sync P
 
 To update Site Studio configuration, you can run the `drush acms:config-reset` command and follow the instructions. Note that this will overwrite *any* changes you've made to the default ACMS configuration for Site Studio, and may affect your site in unexpected ways. *You should test using this command in a non-production environment before running it in production.*
 
-### Updating Acquia Claro theming
-* Update SCSS as per requirement in Acquia Claro theme.
-* Use `composer install:frontend` and `composer build:frontend` to compile SCSS into CSS.
-* Commit both CSS and SCSS files.
-
 ### Contributing to Acquia CMS
 
 Refer to our [Contributor's guide](/CONTRIBUTING.md).

--- a/acms-run-tests.sh
+++ b/acms-run-tests.sh
@@ -136,11 +136,6 @@ case $OSTYPE in
       ;;
 esac
 
-# Compile scss and run css analysis tests.
-echo -e "${GREEN} Installing npm & analysing css ${NOCOLOR}"
-# Install npm & run front end gulp task test.
-cd docroot/themes/contrib/acquia_claro && npm install && npm run test && cd -
-
 # Run code quality checks.
 vendor/bin/grumphp run
 

--- a/acms/build.yml
+++ b/acms/build.yml
@@ -13,9 +13,7 @@ sites:
       - acquia_cms_tour
       - acquia_cms_video
       - sitestudio_config_management
-      - sitestudio_gin
       - gin_toolbar
-      - acquia_cms_toolbar_gin
     starter_kit: acquia_cms_existing_site
     themes:
       admin: gin
@@ -33,7 +31,6 @@ sites:
       - acquia_cms_video
       - consumer_image_styles
       - gin_toolbar
-      - acquia_cms_toolbar_gin
     starter_kit: acquia_cms_headless
     themes:
       admin: gin
@@ -49,7 +46,6 @@ sites:
       - acquia_cms_tour
       - acquia_cms_video
       - gin_toolbar
-      - acquia_cms_toolbar_gin
     starter_kit: acquia_cms_community
     themes:
       admin: gin

--- a/acms/build.yml
+++ b/acms/build.yml
@@ -13,9 +13,12 @@ sites:
       - acquia_cms_tour
       - acquia_cms_video
       - sitestudio_config_management
+      - sitestudio_gin
+      - gin_toolbar
+      - acquia_cms_toolbar_gin
     starter_kit: acquia_cms_existing_site
     themes:
-      admin: acquia_claro
+      admin: gin
       default: cohesion_theme
   headless:
     modules:
@@ -29,9 +32,11 @@ sites:
       - acquia_cms_tour
       - acquia_cms_video
       - consumer_image_styles
+      - gin_toolbar
+      - acquia_cms_toolbar_gin
     starter_kit: acquia_cms_headless
     themes:
-      admin: acquia_claro
+      admin: gin
       default: olivero
   community:
     modules:
@@ -43,7 +48,9 @@ sites:
       - acquia_cms_toolbar
       - acquia_cms_tour
       - acquia_cms_video
+      - gin_toolbar
+      - acquia_cms_toolbar_gin
     starter_kit: acquia_cms_community
     themes:
-      admin: acquia_claro
+      admin: gin
       default: olivero

--- a/acquia_cms.module
+++ b/acquia_cms.module
@@ -35,7 +35,6 @@ function acquia_cms_form_user_login_form_alter(array &$form) {
  */
 function acquia_cms_preprocess_maintenance_page(array &$variables) {
   $variables['#attached']['library'][] = 'seven/install-page';
-  $variables['#attached']['library'][] = 'acquia_claro/install-page';
   $acquia_cms_path = \Drupal::service('extension.list.module')->getPath('acquia_cms');
   $variables['install_page_logo_path'] = '/' . $acquia_cms_path . '/acquia_cms.png';
 }

--- a/composer.json
+++ b/composer.json
@@ -363,10 +363,6 @@
         "acms:install": [
             "bash install-acms"
         ],
-        "build:frontend": [
-            "Composer\\Config::disableProcessTimeout",
-            "cd docroot/themes/contrib/acquia_claro && npm run build"
-        ],
         "build:local": [
             "cp -f phpunit.xml ./docroot/core"
         ],
@@ -379,10 +375,6 @@
             "rm -rf $TMPDIR/cex"
         ],
         "configure-tarball": "Drupal\\acquia_cms\\Composer\\ConfigureProject::execute",
-        "install:frontend": [
-            "Composer\\Config::disableProcessTimeout",
-            "cd docroot/themes/contrib/acquia_claro && npm install"
-        ],
         "nuke": "rm -r -f docroot vendor"
     }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "6210e97a28303f0bffbaccc47007032f",
+    "content-hash": "7791dff897df75d283973bdff1b657cb",
     "packages": [
         {
             "name": "acquia/acquia-cms-starterkit",

--- a/scripts/acms-split.sh
+++ b/scripts/acms-split.sh
@@ -220,7 +220,6 @@ function add_drupal_remote() {
     exit 0
   fi
   # Adding remote for drupal git branches.
-  remote drupal_acquia_claro git@git.drupal.org:project/acquia_claro.git
   remote drupal_acquia_cms_article git@git.drupal.org:project/acquia_cms_article.git
   remote drupal_acquia_cms_audio git@git.drupal.org:project/acquia_cms_audio.git
   remote drupal_acquia_cms_common git@git.drupal.org:project/acquia_cms_common.git
@@ -251,7 +250,6 @@ function split_drupal_repo() {
     exit 0
   fi
   # Calling split method for mapping drupal remote branches to splits.
-#  split 'themes/acquia_claro' drupal_acquia_claro
   split 'modules/acquia_cms_article' drupal_acquia_cms_article
   split 'modules/acquia_cms_audio' drupal_acquia_cms_audio
   split 'modules/acquia_cms_common' drupal_acquia_cms_common


### PR DESCRIPTION
**Motivation**
Update scripts and installation hooks to gin theme as admin theme.

**Proposed changes**
-  Removed all references for acquia_claro.
- Included gin modules/theme dependencies.

**Alternatives considered**
N/A

**Testing steps**
- Run command `./vendor/bin/acms site:install --yes` and site installation should work as expected, setting gin theme & enable gin modules.

**Merge requirements**
- [ ] _Minor change_
- [ ] Manual testing by a reviewer
