### PR TITLE
ACMS-3359: Restrict Site Studio to <7.4 version.

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -83,16 +83,16 @@
         },
         {
             "name": "acquia/cohesion",
-            "version": "7.3.1",
+            "version": "7.3.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/acquia/cohesion.git",
-                "reference": "9f2cde2373bb1dd115bcb7c9d74fdcad983d08f8"
+                "reference": "49e64b0035e7e7bdb0f2c63d4372248e7906f251"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/acquia/cohesion/zipball/9f2cde2373bb1dd115bcb7c9d74fdcad983d08f8",
-                "reference": "9f2cde2373bb1dd115bcb7c9d74fdcad983d08f8",
+                "url": "https://api.github.com/repos/acquia/cohesion/zipball/49e64b0035e7e7bdb0f2c63d4372248e7906f251",
+                "reference": "49e64b0035e7e7bdb0f2c63d4372248e7906f251",
                 "shasum": ""
             },
             "require": {
@@ -145,22 +145,22 @@
             ],
             "description": "Site Studio",
             "support": {
-                "source": "https://github.com/acquia/cohesion/tree/7.3.1"
+                "source": "https://github.com/acquia/cohesion/tree/7.3.2"
             },
-            "time": "2023-10-09T11:28:44+00:00"
+            "time": "2023-10-24T19:52:55+00:00"
         },
         {
             "name": "acquia/cohesion-theme",
-            "version": "7.3.1",
+            "version": "7.3.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/acquia/cohesion-theme.git",
-                "reference": "73b97946c6778328807424116263d835b80ae5c7"
+                "reference": "194102cb6751a3a1cf212ec19be2223d4c788002"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/acquia/cohesion-theme/zipball/73b97946c6778328807424116263d835b80ae5c7",
-                "reference": "73b97946c6778328807424116263d835b80ae5c7",
+                "url": "https://api.github.com/repos/acquia/cohesion-theme/zipball/194102cb6751a3a1cf212ec19be2223d4c788002",
+                "reference": "194102cb6751a3a1cf212ec19be2223d4c788002",
                 "shasum": ""
             },
             "type": "drupal-theme",
@@ -178,9 +178,9 @@
             "description": "Site Studio minimal theme",
             "support": {
                 "issues": "https://github.com/acquia/cohesion-theme/issues",
-                "source": "https://github.com/acquia/cohesion-theme/tree/7.3.1"
+                "source": "https://github.com/acquia/cohesion-theme/tree/7.3.2"
             },
-            "time": "2023-10-09T11:28:50+00:00"
+            "time": "2023-10-24T19:53:00+00:00"
         },
         {
             "name": "acquia/drupal-environment-detector",
@@ -2872,11 +2872,11 @@
             "dist": {
                 "type": "path",
                 "url": "./modules/acquia_cms_site_studio",
-                "reference": "95ff688d66d9b70b7f99f8c32e0aa4b0d3d65191"
+                "reference": "292070b51ef7a44436cf894b6836c637c080e7f5"
             },
             "require": {
-                "acquia/cohesion": "^6.9.2 || ^7.0",
-                "acquia/cohesion-theme": "^6.9 || ^7.0",
+                "acquia/cohesion": "^6.9.2 || ~7.3.2",
+                "acquia/cohesion-theme": "^6.9.2 || ~7.3.2",
                 "drupal/acquia_cms_common": "1.x-dev || 2.x-dev || 3.x-dev",
                 "drupal/collapsiblock": "^4.0",
                 "drupal/node_revision_delete": "^1.0",
@@ -8166,10 +8166,10 @@
             "dist": {
                 "type": "path",
                 "url": "./modules/sitestudio_config_management",
-                "reference": "46dc95154a3cb6ad78fc8433269c98f0b6b4382c"
+                "reference": "873425802a3c036de205f5ef3f064394f6082b90"
             },
             "require": {
-                "acquia/cohesion": "^6.9.2 || ^7.0",
+                "acquia/cohesion": "^6.9.2 || ~7.3.2",
                 "drupal/config_filter": "^2.4",
                 "drupal/config_ignore": "^3.0@beta",
                 "drupal/config_split": "^2.0",

--- a/modules/acquia_cms_site_studio/composer.json
+++ b/modules/acquia_cms_site_studio/composer.json
@@ -4,8 +4,8 @@
     "description": "Handles code for Site Studio Installation & Related Configurations.",
     "license": "GPL-2.0-or-later",
     "require": {
-        "acquia/cohesion": "^6.9.2 || ^7.0",
-        "acquia/cohesion-theme": "^6.9 || ^7.0",
+        "acquia/cohesion": "^6.9.2 || ~7.3.2",
+        "acquia/cohesion-theme": "^6.9.2 || ~7.3.2",
         "drupal/acquia_cms_common": "1.x-dev || 2.x-dev || 3.x-dev",
         "drupal/collapsiblock": "^4.0",
         "drupal/node_revision_delete": "^1.0",

--- a/modules/sitestudio_config_management/composer.json
+++ b/modules/sitestudio_config_management/composer.json
@@ -5,7 +5,7 @@
     "license": "GPL-2.0-or-later",
     "require": {
         "php": ">=7.4",
-        "acquia/cohesion": "^6.9.2 || ^7.0",
+        "acquia/cohesion": "^6.9.2 || ~7.3.2",
         "drupal/config_filter": "^2.4",
         "drupal/config_ignore": "^3.0@beta",
         "drupal/config_split": "^2.0"


### PR DESCRIPTION
**Motivation**
Fixes #[ACMS-3359](https://acquia.atlassian.net/browse/ACMS-3359)

**Proposed changes**
Restrict Site Studio to <7.4 version.

**Alternatives considered**
NA

**Testing steps**
- Checkout branch ACMS-3359
- Install dependencies using `composer install`
- Verify site studio version is less than 7.4.

**Merge requirements**
- [ ] _Major change_, _Minor change_, _Bug_, _Enhancement_, and/or _Chore_ label applied
- [ ] Manual testing by a reviewer
