### PR TITLE
ACMS-3354: Ristrict ACMS Common 3.3.x to drupal core 10.1.x version.

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -2436,7 +2436,7 @@
             "dist": {
                 "type": "path",
                 "url": "./modules/acquia_cms_common",
-                "reference": "f15b4997b2c364944e1c3486445d8063a294e8af"
+                "reference": "8122ceda2326635223cd41841a51e4c9b5b5c767"
             },
             "require": {
                 "acquia/drupal-environment-detector": "^1.5",
@@ -2448,7 +2448,7 @@
                 "drupal/autologout": "^1.4",
                 "drupal/config_ignore": "^3.0@beta",
                 "drupal/config_rewrite": "^1.5",
-                "drupal/core": "^10.1",
+                "drupal/core": "~10.1.6",
                 "drupal/diff": "^1.1",
                 "drupal/entity_clone": "^2.0@beta",
                 "drupal/field_group": "^3.4",
@@ -7705,7 +7705,7 @@
             "extra": {
                 "drupal": {
                     "version": "8.x-1.30",
-                    "datestamp": "1697366291",
+                    "datestamp": "1700925904",
                     "security-coverage": {
                         "status": "covered",
                         "message": "Covered by Drupal's security advisory policy"

--- a/modules/acquia_cms_common/composer.json
+++ b/modules/acquia_cms_common/composer.json
@@ -13,7 +13,7 @@
         "drupal/autologout": "^1.4",
         "drupal/config_ignore": "^3.0@beta",
         "drupal/config_rewrite": "^1.5",
-        "drupal/core": "^10.1",
+        "drupal/core": "~10.1.6",
         "drupal/diff": "^1.1",
         "drupal/entity_clone": "^2.0@beta",
         "drupal/field_group": "^3.4",


### PR DESCRIPTION
**Motivation**
Fixes #[3354](https://acquia.atlassian.net/browse/ACMS-3354)

**Proposed changes**
Remove Drupal core patches as available in 10.2.x core.

**Alternatives considered**
NA

**Testing steps**
- Checkout branch ACMS-3354-1
- Install dependencies using `composer install`
- Try to update drupal core to 10.2.x
- Verify it is not allowing to update
- Verify patches applied successfully.

**Merge requirements**
- [ ] _Major change_, _Minor change_, _Bug_, _Enhancement_, and/or _Chore_ label applied
- [ ] Manual testing by a reviewer
