### PR TITLE
ACMS-3354: Update tests wrt 10.2 changes.

### DIFF
--- a/modules/acquia_cms_common/config/rewrite/system.performance.yml
+++ b/modules/acquia_cms_common/config/rewrite/system.performance.yml
@@ -12,4 +12,3 @@ fast_404:
 js:
   preprocess: true
   gzip: true
-stale_file_threshold: 2592000

--- a/modules/acquia_cms_headless/src/Plugin/AcquiaCmsHeadless/HeadlessApiKeys.php
+++ b/modules/acquia_cms_headless/src/Plugin/AcquiaCmsHeadless/HeadlessApiKeys.php
@@ -5,6 +5,8 @@ namespace Drupal\acquia_cms_headless\Plugin\AcquiaCmsHeadless;
 use Drupal\acquia_cms_headless\Service\StarterkitNextjsService;
 use Drupal\acquia_cms_tour\Form\AcquiaCmsDashboardBase;
 use Drupal\Component\Serialization\Json;
+use Drupal\Core\Config\ConfigFactoryInterface;
+use Drupal\Core\Config\TypedConfigManagerInterface;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Extension\InfoParserInterface;
 use Drupal\Core\Extension\ModuleHandlerInterface;
@@ -78,8 +80,8 @@ class HeadlessApiKeys extends AcquiaCmsDashboardBase {
   /**
    * {@inheritdoc}
    */
-  public function __construct(StateInterface $state, ModuleHandlerInterface $module_handler, LinkGeneratorInterface $link_generator, InfoParserInterface $info_parser, EntityTypeManagerInterface $entity_type_manager, StarterkitNextjsService $starterkit_nextjs_service) {
-    parent::__construct($state, $module_handler, $link_generator, $info_parser);
+  public function __construct(StateInterface $state, ModuleHandlerInterface $module_handler, LinkGeneratorInterface $link_generator, InfoParserInterface $info_parser, EntityTypeManagerInterface $entity_type_manager, StarterkitNextjsService $starterkit_nextjs_service, ConfigFactoryInterface $config_factory, ?TypedConfigManagerInterface $typedConfigManager) {
+    parent::__construct($state, $module_handler, $link_generator, $info_parser, $config_factory, $typedConfigManager);
     $this->entityTypeManager = $entity_type_manager;
     $this->starterKitNextjsService = $starterkit_nextjs_service;
   }
@@ -94,7 +96,9 @@ class HeadlessApiKeys extends AcquiaCmsDashboardBase {
       $container->get('link_generator'),
       $container->get('info_parser'),
       $container->get('entity_type.manager'),
-      $container->get('acquia_cms_headless.starterkit_nextjs')
+      $container->get('acquia_cms_headless.starterkit_nextjs'),
+      $container->get("config.factory"),
+      $container->has('config.typed') ? $container->get('config.typed') : NULL,
     );
   }
 

--- a/modules/acquia_cms_headless/src/Plugin/AcquiaCmsHeadless/HeadlessApiUsers.php
+++ b/modules/acquia_cms_headless/src/Plugin/AcquiaCmsHeadless/HeadlessApiUsers.php
@@ -4,6 +4,8 @@ namespace Drupal\acquia_cms_headless\Plugin\AcquiaCmsHeadless;
 
 use Drupal\acquia_cms_headless\Service\StarterkitNextjsService;
 use Drupal\acquia_cms_tour\Form\AcquiaCmsDashboardBase;
+use Drupal\Core\Config\ConfigFactoryInterface;
+use Drupal\Core\Config\TypedConfigManagerInterface;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Extension\InfoParserInterface;
 use Drupal\Core\Extension\ModuleHandlerInterface;
@@ -84,8 +86,8 @@ class HeadlessApiUsers extends AcquiaCmsDashboardBase {
   /**
    * {@inheritdoc}
    */
-  public function __construct(StateInterface $state, ModuleHandlerInterface $module_handler, LinkGeneratorInterface $link_generator, InfoParserInterface $info_parser, EntityTypeManagerInterface $entity_type_manager, StarterkitNextjsService $starterkit_nextjs_service) {
-    parent::__construct($state, $module_handler, $link_generator, $info_parser);
+  public function __construct(StateInterface $state, ModuleHandlerInterface $module_handler, LinkGeneratorInterface $link_generator, InfoParserInterface $info_parser, EntityTypeManagerInterface $entity_type_manager, StarterkitNextjsService $starterkit_nextjs_service, ConfigFactoryInterface $config_factory, ?TypedConfigManagerInterface $typedConfigManager) {
+    parent::__construct($state, $module_handler, $link_generator, $info_parser, $config_factory, $typedConfigManager);
     $this->entityTypeManager = $entity_type_manager;
     $this->headlessRoleLabel = $entity_type_manager->getStorage('user_role')->load('headless')->label();
     $this->starterKitNextjsService = $starterkit_nextjs_service;
@@ -101,7 +103,9 @@ class HeadlessApiUsers extends AcquiaCmsDashboardBase {
       $container->get('link_generator'),
       $container->get('info_parser'),
       $container->get('entity_type.manager'),
-      $container->get('acquia_cms_headless.starterkit_nextjs')
+      $container->get('acquia_cms_headless.starterkit_nextjs'),
+      $container->get("config.factory"),
+      $container->has('config.typed') ? $container->get('config.typed') : NULL,
     );
   }
 

--- a/modules/acquia_cms_headless/src/Plugin/AcquiaCmsHeadless/HeadlessNextEntityTypes.php
+++ b/modules/acquia_cms_headless/src/Plugin/AcquiaCmsHeadless/HeadlessNextEntityTypes.php
@@ -4,6 +4,8 @@ namespace Drupal\acquia_cms_headless\Plugin\AcquiaCmsHeadless;
 
 use Drupal\acquia_cms_headless\Service\StarterkitNextjsService;
 use Drupal\acquia_cms_tour\Form\AcquiaCmsDashboardBase;
+use Drupal\Core\Config\ConfigFactoryInterface;
+use Drupal\Core\Config\TypedConfigManagerInterface;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Extension\InfoParserInterface;
 use Drupal\Core\Extension\ModuleHandlerInterface;
@@ -77,8 +79,8 @@ class HeadlessNextEntityTypes extends AcquiaCmsDashboardBase {
   /**
    * {@inheritdoc}
    */
-  public function __construct(StateInterface $state, ModuleHandlerInterface $module_handler, LinkGeneratorInterface $link_generator, InfoParserInterface $info_parser, EntityTypeManagerInterface $entity_type_manager, StarterkitNextjsService $starterKitNextjsService) {
-    parent::__construct($state, $module_handler, $link_generator, $info_parser);
+  public function __construct(StateInterface $state, ModuleHandlerInterface $module_handler, LinkGeneratorInterface $link_generator, InfoParserInterface $info_parser, EntityTypeManagerInterface $entity_type_manager, StarterkitNextjsService $starterKitNextjsService, ConfigFactoryInterface $config_factory, ?TypedConfigManagerInterface $typedConfigManager) {
+    parent::__construct($state, $module_handler, $link_generator, $info_parser, $config_factory, $typedConfigManager);
     $this->entityTypeManager = $entity_type_manager;
     $this->starterKitNextjsService = $starterKitNextjsService;
   }
@@ -93,7 +95,9 @@ class HeadlessNextEntityTypes extends AcquiaCmsDashboardBase {
       $container->get('link_generator'),
       $container->get('info_parser'),
       $container->get('entity_type.manager'),
-      $container->get('acquia_cms_headless.starterkit_nextjs')
+      $container->get('acquia_cms_headless.starterkit_nextjs'),
+      $container->get("config.factory"),
+      $container->has('config.typed') ? $container->get('config.typed') : NULL,
     );
   }
 

--- a/modules/acquia_cms_headless/src/Plugin/AcquiaCmsHeadless/HeadlessNextSites.php
+++ b/modules/acquia_cms_headless/src/Plugin/AcquiaCmsHeadless/HeadlessNextSites.php
@@ -5,6 +5,8 @@ namespace Drupal\acquia_cms_headless\Plugin\AcquiaCmsHeadless;
 use Drupal\acquia_cms_headless\Service\StarterkitNextjsService;
 use Drupal\acquia_cms_tour\Form\AcquiaCmsDashboardBase;
 use Drupal\Component\Serialization\Json;
+use Drupal\Core\Config\ConfigFactoryInterface;
+use Drupal\Core\Config\TypedConfigManagerInterface;
 use Drupal\Core\Database\Connection;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Extension\InfoParserInterface;
@@ -86,8 +88,8 @@ class HeadlessNextSites extends AcquiaCmsDashboardBase {
   /**
    * {@inheritdoc}
    */
-  public function __construct(StateInterface $state, ModuleHandlerInterface $module_handler, LinkGeneratorInterface $link_generator, InfoParserInterface $info_parser, Connection $connection, EntityTypeManagerInterface $entity_type_manager, StarterkitNextjsService $starterKitNextjsService) {
-    parent::__construct($state, $module_handler, $link_generator, $info_parser);
+  public function __construct(StateInterface $state, ModuleHandlerInterface $module_handler, LinkGeneratorInterface $link_generator, InfoParserInterface $info_parser, Connection $connection, EntityTypeManagerInterface $entity_type_manager, StarterkitNextjsService $starterKitNextjsService, ConfigFactoryInterface $config_factory, ?TypedConfigManagerInterface $typedConfigManager) {
+    parent::__construct($state, $module_handler, $link_generator, $info_parser, $config_factory, $typedConfigManager);
     $this->connection = $connection;
     $this->entityTypeManager = $entity_type_manager;
     $this->starterKitNextjsService = $starterKitNextjsService;
@@ -104,7 +106,9 @@ class HeadlessNextSites extends AcquiaCmsDashboardBase {
       $container->get('info_parser'),
       $container->get('database'),
       $container->get('entity_type.manager'),
-      $container->get('acquia_cms_headless.starterkit_nextjs')
+      $container->get('acquia_cms_headless.starterkit_nextjs'),
+      $container->get("config.factory"),
+      $container->has('config.typed') ? $container->get('config.typed') : NULL,
     );
   }
 

--- a/modules/acquia_cms_tour/src/Form/AcquiaCmsDashboardBase.php
+++ b/modules/acquia_cms_tour/src/Form/AcquiaCmsDashboardBase.php
@@ -2,6 +2,8 @@
 
 namespace Drupal\acquia_cms_tour\Form;
 
+use Drupal\Core\Config\ConfigFactoryInterface;
+use Drupal\Core\Config\TypedConfigManagerInterface;
 use Drupal\Core\Extension\InfoParserInterface;
 use Drupal\Core\Extension\ModuleHandlerInterface;
 use Drupal\Core\Form\ConfigFormBase;
@@ -61,12 +63,17 @@ abstract class AcquiaCmsDashboardBase extends ConfigFormBase implements AcquiaDa
    *   The link generator.
    * @param \Drupal\Core\Extension\InfoParserInterface $info_parser
    *   The info file parser.
+   * @param \Drupal\Core\Config\ConfigFactoryInterface $config_factory
+   *   The factory for configuration objects.
+   * @param \Drupal\Core\Config\TypedConfigManagerInterface|null $typedConfigManager
+   *   The typed config manager.
    */
-  public function __construct(StateInterface $state, ModuleHandlerInterface $module_handler, LinkGeneratorInterface $link_generator, InfoParserInterface $info_parser) {
+  public function __construct(StateInterface $state, ModuleHandlerInterface $module_handler, LinkGeneratorInterface $link_generator, InfoParserInterface $info_parser, ConfigFactoryInterface $config_factory, ?TypedConfigManagerInterface $typedConfigManager = NULL) {
     $this->state = $state;
     $this->moduleHandler = $module_handler;
     $this->linkGenerator = $link_generator;
     $this->infoParser = $info_parser;
+    parent::__construct($config_factory, $typedConfigManager);
   }
 
   /**
@@ -77,7 +84,11 @@ abstract class AcquiaCmsDashboardBase extends ConfigFormBase implements AcquiaDa
       $container->get('state'),
       $container->get('module_handler'),
       $container->get('link_generator'),
-      $container->get('info_parser')
+      $container->get('info_parser'),
+      $container->get("config.factory"),
+      // The service `config.typed` has been introduced in Drupal Core 10.2.x.
+      // @todo Remove below condition,once we drop support for Drupal < 10.2.x.
+      $container->has('config.typed') ? $container->get('config.typed') : NULL
     );
   }
 

--- a/modules/acquia_cms_tour/src/Form/WelcomeModalForm.php
+++ b/modules/acquia_cms_tour/src/Form/WelcomeModalForm.php
@@ -4,7 +4,7 @@ namespace Drupal\acquia_cms_tour\Form;
 
 use Drupal\Core\Config\ConfigFactoryInterface;
 use Drupal\Core\Extension\Exception\UnknownExtensionException;
-use Drupal\Core\Extension\ProfileExtensionList;
+use Drupal\Core\Extension\ModuleExtensionList;
 use Drupal\Core\Form\FormBase;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\State\StateInterface;
@@ -30,11 +30,11 @@ class WelcomeModalForm extends FormBase {
   protected $state;
 
   /**
-   * The profile extension list object.
+   * The module extension list object.
    *
    * @var \Drupal\Core\Extension\ProfileExtensionList
    */
-  protected $profileExtensionList;
+  protected $moduleExtensionList;
 
   /**
    * The config factory service object.
@@ -48,14 +48,14 @@ class WelcomeModalForm extends FormBase {
    *
    * @param \Drupal\Core\State\StateInterface $state
    *   The state service.
-   * @param \Drupal\Core\Extension\ProfileExtensionList $profile_extension_list
+   * @param \Drupal\Core\Extension\ModuleExtensionList $module_extension_list
    *   The profile extension list object.
    * @param \Drupal\Core\Config\ConfigFactoryInterface $config_factory
    *   The config.factory service object.
    */
-  public function __construct(StateInterface $state, ProfileExtensionList $profile_extension_list, ConfigFactoryInterface $config_factory) {
+  public function __construct(StateInterface $state, ModuleExtensionList $module_extension_list, ConfigFactoryInterface $config_factory) {
     $this->state = $state;
-    $this->profileExtensionList = $profile_extension_list;
+    $this->moduleExtensionList = $module_extension_list;
     $this->configFactory = $config_factory;
   }
 
@@ -70,7 +70,7 @@ class WelcomeModalForm extends FormBase {
   public static function create(ContainerInterface $container) {
     return new static(
       $container->get('state'),
-      $container->get('extension.list.profile'),
+      $container->get('extension.list.module'),
       $container->get('config.factory'),
     );
   }
@@ -147,9 +147,9 @@ class WelcomeModalForm extends FormBase {
    * @return string
    *   Returns the logo path.
    */
-  protected function getLogoPath() :string {
+  protected function getLogoPath(): string {
     try {
-      $logo = "/" . $this->profileExtensionList->getPath('acquia_cms') . '/acquia_cms.png';
+      $logo = "/" . $this->moduleExtensionList->getPath('acquia_cms_common') . '/acquia_cms.png';
     }
     catch (UnknownExtensionException $e) {
     }


### PR DESCRIPTION
**Motivation**
Fixes #ACMS-3354

**Proposed changes**
Update tests wrt 10.2 changes, and release in 10.1 to make ACMS 10.2 compatible.

**Alternatives considered**
Please be aware that the Drupal check is failing with Drupal version 10.1.x due to [this](https://github.com/acquia/acquia_cms/pull/1689/files#diff-10fa5bdccd1c1e01cae5c5dd2e2a4f352d9dcfbbad6f345961bc6c8ae1120368R76) change and this is introduced in 10.2.x version.

**Testing steps**
Tests should pass

**Merge requirements**
- [ ] _Major change_, _Minor change_, _Bug_, _Enhancement_, and/or _Chore_ label applied
- [ ] Manual testing by a reviewer
