### PR TITLE
ACMS-3469: Support for the Address module version 2.x.

### DIFF
--- a/modules/acquia_cms_place/composer.json
+++ b/modules/acquia_cms_place/composer.json
@@ -5,7 +5,7 @@
     "license": "GPL-2.0-or-later",
     "require": {
         "drupal/acquia_cms_image": "1.x-dev",
-        "drupal/address": "^1.11",
+        "drupal/address": "^1.11 || ^2.0",
         "drupal/geocoder": "^3.35 || ^4.10",
         "drupal/geofield": "^1.47",
         "drupal/scheduler": "^2.0",

--- a/modules/acquia_cms_place/tests/src/Functional/PlaceTest.php
+++ b/modules/acquia_cms_place/tests/src/Functional/PlaceTest.php
@@ -134,7 +134,7 @@ class PlaceTest extends ContentTypeTestBase {
     $assert_session->fieldExists('Country', $group);
     $assert_session->fieldExists('First name', $group);
     $assert_session->fieldExists('Last name', $group);
-    $assert_session->fieldExists('Company', $group);
+    $assert_session->fieldExists('Organization', $group);
     $assert_session->fieldExists('Street address', $group);
     $assert_session->fieldExists('City', $group);
     $assert_session->fieldExists('State', $group);


### PR DESCRIPTION
**Motivation**
<!-- What problem does this solve? Why is it important? What's the context? If this fixes an issue, link to it above. -->
Fixes #ACMS-3469

**Proposed changes**
Added support for Address module version 2.0

**Alternatives considered**
No

**Testing steps**
- git clone acquia_cms
- git checkout ACMS-3469
- ./vendor/bin/acms acms:install 
- install acquia_cms_community
- say yes to demo content
- visit site and check address module version 2.0 is available

**Merge requirements**
- [ ] _Major change_, _Minor change_, _Bug_, _Enhancement_, and/or _Chore_ label applied
- [ ] Manual testing by a reviewer
