### PR TITLE
ACMS-3472: Add Acquia CMS Common matrix for Drupal Core version download in CI.

### DIFF
--- a/.github/workflows/acquia_cms_ci.workflow.yml
+++ b/.github/workflows/acquia_cms_ci.workflow.yml
@@ -235,6 +235,7 @@ jobs:
         orca-job:
           - INTEGRATED_TEST_ON_PREVIOUS_MINOR
           - ISOLATED_TEST_ON_CURRENT
+          - INTEGRATED_TEST_ON_LATEST_LTS
         php-version:
           - 8.1
           - 8.3
@@ -276,6 +277,22 @@ jobs:
           if [ "${ORCA_JOB}" = "INTEGRATED_TEST_ON_PREVIOUS_MINOR" ]; then
             # Update drupal/core patch as per Drupal Core version.
             sed -i 's/2024-01-18\/3370946-page-title-backport-10-2-2_0.patch/2024-01-18\/3370946-page-title-backport-10-1-8.patch/g' modules/acquia_cms_common/composer.json
+          fi
+
+          # One of the patch is failing on Drupal Core 9.5. So remove that patch.
+          if [ "${ORCA_JOB}" = "INTEGRATED_TEST_ON_LATEST_LTS" ]; then
+            # Remove the failing php on Drupal Core 9.5.
+            # NEW_JSON=$(composer config extra.patches."drupal/core" | sed -r 's/,?"3328187.*3142.patch"//')
+
+            # Remove drupal/core patch as it's needed for latest Drupal Core only.
+            composer config extra.patches.drupal/core {} --json
+            sed -i 's/2598.patch",/2598.patch"/' modules/acquia_cms_common/composer.json
+            sed -i '/3356894-mr_3896.patch/d' modules/acquia_cms_common/composer.json
+            sed -i '/3370946-page-title-backport-10-2-2_0.patch/d' modules/acquia_cms_common/composer.json
+
+            # Update development branch to 2.x
+            sed -i 's/^"dev-develop": "3.x-dev"/"dev-develop": "2.x-dev"/' modules/acquia_cms_common/composer.json
+            sed -i 's/^"url": ".\/modules\/acquia_cms_common",/"url": ".\/modules\/acquia_cms_common",\n"canonical": false,/' composer.json
           fi
 
           ../orca/bin/ci/before_install.sh

--- a/.github/workflows/acquia_cms_cron.yml
+++ b/.github/workflows/acquia_cms_cron.yml
@@ -122,6 +122,10 @@ jobs:
             sed -i 's/2598.patch",/2598.patch"/' modules/acquia_cms_common/composer.json
             sed -i '/3356894-mr_3896.patch/d' modules/acquia_cms_common/composer.json
             sed -i '/3370946-page-title-backport-10-2-2_0.patch/d' modules/acquia_cms_common/composer.json
+
+            # Update development branch to 2.x
+            sed -i 's/^"dev-develop": "3.x-dev"/"dev-develop": "2.x-dev"/' modules/acquia_cms_common/composer.json
+            sed -i 's/^"url": ".\/modules\/acquia_cms_common",/"url": ".\/modules\/acquia_cms_common",\n"canonical": false,/' composer.json
           fi
 
           # Remove all PHPUnit tests from individual modules, except the integrated & ExistingSite tests.

--- a/tests/packages_alter.yml
+++ b/tests/packages_alter.yml
@@ -17,3 +17,47 @@ drupal/lightning_media: ~
 # as it's not yet Drupal Core 10 supported.
 drupal/acquia_dam_integration_links: ~
 drupal/acquia_contenthub_dashboard: ~
+
+# Download Acquia CMS Common version based on Drupal Core version.
+drupal/acquia_cms_common:
+  core_matrix:
+    '>=10.2.2':
+      version: 3.3.x
+      version_dev: 3.x-dev
+    10.1.x:
+      version: 3.2.x
+      version_dev: 3.2.x-dev
+    '>=10.0.9 <10.1':
+      version: 3.1.x
+      version_dev: 3.1.x-dev
+    '>=9.5.10 <10.0.9':
+      version: 2.x
+      version_dev: 2.x-dev
+drupal/acquia_cms_development:
+  core_matrix:
+    '>=10.2.2':
+      version: 3.3.x
+      version_dev: 3.x-dev
+    10.1.x:
+      version: 3.2.x
+      version_dev: 3.2.x-dev
+    '>=10.0.9 <10.1':
+      version: 3.1.x
+      version_dev: 3.1.x-dev
+    '>=9.5.10 <10.0.9':
+      version: 2.x
+      version_dev: 2.x-dev
+drupal/acquia_cms_support:
+  core_matrix:
+    '>=10.2.2':
+      version: 3.3.x
+      version_dev: 3.x-dev
+    10.1.x:
+      version: 3.2.x
+      version_dev: 3.2.x-dev
+    '>=10.0.9 <10.1':
+      version: 3.1.x
+      version_dev: 3.1.x-dev
+    '>=9.5.10 <10.0.9':
+      version: 2.x
+      version_dev: 2.x-dev


### PR DESCRIPTION
**Motivation**
Fixes #[ACMS-3472](https://acquia.atlassian.net/browse/ACMS-3472)

**Proposed changes**
Add Acquia CMS COmmon matrix to download required version as per Drupal Core version.

**Alternatives considered**
NA

**Testing steps**
<!-- How can we replicate the issue and verify that this PR fixes it? -->

**Merge requirements**
- [ ] _Major change_, _Minor change_, _Bug_, _Enhancement_, and/or _Chore_ label applied
- [ ] Manual testing by a reviewer
