### PR TITLE
ACMS-3560: Support moderation dashboard major release version 3.x.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -37,7 +37,8 @@
         "drupal/sitestudio_config_management": "dev-develop",
         "drupal/sitestudio_gin": "^1.0",
         "drush/drush": "^10 || ^11 || ^12",
-        "mnsami/composer-custom-directory-installer": "^2.0"
+        "mnsami/composer-custom-directory-installer": "^2.0",
+        "nnnick/chartjs": "^4.4"
     },
     "require-dev": {
         "acquia/coding-standards": "^1.0",
@@ -57,10 +58,10 @@
             "package": {
                 "name": "nnnick/chartjs",
                 "type": "drupal-library",
-                "version": "v3.9.1",
+                "version": "v4.4.1",
                 "dist": {
-                    "type": "tar",
-                    "url": "https://github.com/chartjs/Chart.js/releases/download/v3.9.1/chart.js-3.9.1.tgz"
+                    "type": "file",
+                    "url": "https://cdn.jsdelivr.net/npm/chart.js@4.4.1/dist/chart.umd.min.js"
                 }
             }
         },

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "f54a5627774dedc977d7f622180cd9b0",
+    "content-hash": "1ba6a6750134ed7357151468b42bbbec",
     "packages": [
         {
             "name": "acquia/acquia-cms-starterkit",
@@ -2378,7 +2378,7 @@
             "dist": {
                 "type": "path",
                 "url": "./modules/acquia_cms_common",
-                "reference": "f0d7ecd1c31469eaf5786263bf46d77db88853e2"
+                "reference": "ff86a06d205cbd0d4f97a945c3b016825fe503ee"
             },
             "require": {
                 "acquia/drupal-environment-detector": "^1.5",
@@ -2408,7 +2408,7 @@
                 "drupal/social_media_links": "^2.9",
                 "drupal/username_enumeration_prevention": "^1.3",
                 "drupal/workbench_email": "^3.0",
-                "nnnick/chartjs": "^3.9"
+                "nnnick/chartjs": "^4.4"
             },
             "conflict": {
                 "acquia/acquia_cms": "<1.5.2",
@@ -11069,10 +11069,10 @@
         },
         {
             "name": "nnnick/chartjs",
-            "version": "v3.9.1",
+            "version": "v4.4.1",
             "dist": {
-                "type": "tar",
-                "url": "https://github.com/chartjs/Chart.js/releases/download/v3.9.1/chart.js-3.9.1.tgz"
+                "type": "file",
+                "url": "https://cdn.jsdelivr.net/npm/chart.js@4.4.1/dist/chart.umd.min.js"
             },
             "type": "drupal-library"
         },

--- a/composer.lock
+++ b/composer.lock
@@ -2378,7 +2378,7 @@
             "dist": {
                 "type": "path",
                 "url": "./modules/acquia_cms_common",
-                "reference": "739e86201d6e6f2e4167a25169b05cce290b73f6"
+                "reference": "f0d7ecd1c31469eaf5786263bf46d77db88853e2"
             },
             "require": {
                 "acquia/drupal-environment-detector": "^1.5",
@@ -2395,7 +2395,7 @@
                 "drupal/entity_clone": "^2.0@beta",
                 "drupal/field_group": "^3.4",
                 "drupal/memcache": "^2.5",
-                "drupal/moderation_dashboard": "^2.1",
+                "drupal/moderation_dashboard": "^3.0",
                 "drupal/moderation_sidebar": "^1.7",
                 "drupal/password_policy": "^4.0",
                 "drupal/pathauto": "^1.12",
@@ -6259,26 +6259,26 @@
         },
         {
             "name": "drupal/moderation_dashboard",
-            "version": "2.1.5",
+            "version": "3.0.2",
             "source": {
                 "type": "git",
                 "url": "https://git.drupalcode.org/project/moderation_dashboard.git",
-                "reference": "2.1.5"
+                "reference": "3.0.2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://ftp.drupal.org/files/projects/moderation_dashboard-2.1.5.zip",
-                "reference": "2.1.5",
-                "shasum": "5864fae086ef710cad0615341e6e6214cd2a55a6"
+                "url": "https://ftp.drupal.org/files/projects/moderation_dashboard-3.0.2.zip",
+                "reference": "3.0.2",
+                "shasum": "b425d82d591a4d872d878571df3e9b140f77e0be"
             },
             "require": {
-                "drupal/core": "^9 || ^10"
+                "drupal/core": "^10 || ^11"
             },
             "type": "drupal-module",
             "extra": {
                 "drupal": {
-                    "version": "2.1.5",
-                    "datestamp": "1694008389",
+                    "version": "3.0.2",
+                    "datestamp": "1711391452",
                     "security-coverage": {
                         "status": "covered",
                         "message": "Covered by Drupal's security advisory policy"

--- a/modules/acquia_cms_common/composer.json
+++ b/modules/acquia_cms_common/composer.json
@@ -31,7 +31,7 @@
         "drupal/social_media_links": "^2.9",
         "drupal/username_enumeration_prevention": "^1.3",
         "drupal/workbench_email": "^3.0",
-        "nnnick/chartjs": "^3.9"
+        "nnnick/chartjs": "^4.4"
     },
     "require-dev": {
         "acquia/cohesion": "^7.4",

--- a/modules/acquia_cms_common/composer.json
+++ b/modules/acquia_cms_common/composer.json
@@ -18,7 +18,7 @@
         "drupal/entity_clone": "^2.0@beta",
         "drupal/field_group": "^3.4",
         "drupal/memcache": "^2.5",
-        "drupal/moderation_dashboard": "^2.1",
+        "drupal/moderation_dashboard": "^3.0",
         "drupal/moderation_sidebar": "^1.7",
         "drupal/password_policy": "^4.0",
         "drupal/pathauto": "^1.12",

--- a/tests/ci/install.sh
+++ b/tests/ci/install.sh
@@ -54,7 +54,7 @@ curl "https://unpkg.com/slide-element@2.3.1/dist/index.umd.js" -o ${ORCA_FIXTURE
 
 # Add chartjs library locally
 mkdir -p ${ORCA_FIXTURE_DIR}/docroot/libraries/chartjs/dist/
-curl "https://cdn.jsdelivr.net/npm/chart.js@4.2.0/dist/chart.umd.min.js" -o ${ORCA_FIXTURE_DIR}/docroot/libraries/chartjs/dist/chart.min.js
+curl "https://cdn.jsdelivr.net/npm/chart.js@4.4.1/dist/chart.umd.min.js" -o ${ORCA_FIXTURE_DIR}/docroot/libraries/chartjs/dist/chart.umd.min.js
 
 # Install acquia_cms only for the Integrated & ExistingSite PHPUnit tests.
 if [ -n "${ACMS_JOB}" ]; then


### PR DESCRIPTION
**Motivation**
<!-- What problem does this solve? Why is it important? What's the context? If this fixes an issue, link to it above. -->
Fixes #ACMS-3560

Requirements
3.0.x
D10 ONLY, dropped support for charts v3 that hasn't had a release since 2022.

**Proposed changes**
<!-- What does this PR change? How does this impact end users? Are manual or automatic updates required? -->
update moderation dashboard to version 3.0

