### PR TITLE
ACMS-3650: Support 2.x version for node revision delete.

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -2829,7 +2829,7 @@
             "dist": {
                 "type": "path",
                 "url": "./modules/acquia_cms_site_studio",
-                "reference": "d205c7bb5782b05bc22b2ad671a15511e4d4aeec"
+                "reference": "ee91ede529d6e1eebb3713d6de79c4ba6b627860"
             },
             "require": {
                 "acquia/cohesion": "~7.4.0 || ~7.5.0",
@@ -21671,5 +21671,5 @@
     "prefer-lowest": false,
     "platform": [],
     "platform-dev": [],
-    "plugin-api-version": "2.6.0"
+    "plugin-api-version": "2.3.0"
 }

--- a/composer.lock
+++ b/composer.lock
@@ -2829,14 +2829,14 @@
             "dist": {
                 "type": "path",
                 "url": "./modules/acquia_cms_site_studio",
-                "reference": "ea149022f8d4ca20d19be06c6b175147c99fe523"
+                "reference": "d205c7bb5782b05bc22b2ad671a15511e4d4aeec"
             },
             "require": {
                 "acquia/cohesion": "~7.4.0 || ~7.5.0",
                 "acquia/cohesion-theme": "~7.4.0 || ~7.5.0",
                 "drupal/acquia_cms_common": "^1.9 || ^2.1 || ^3.1",
                 "drupal/collapsiblock": "^4.0",
-                "drupal/node_revision_delete": "^1.0",
+                "drupal/node_revision_delete": "^2.0",
                 "drupal/responsive_preview": "^2.1",
                 "drupal/sitestudio_config_management": "^1.0"
             },
@@ -6429,26 +6429,26 @@
         },
         {
             "name": "drupal/node_revision_delete",
-            "version": "1.0.0-rc7",
+            "version": "2.0.0-rc1",
             "source": {
                 "type": "git",
                 "url": "https://git.drupalcode.org/project/node_revision_delete.git",
-                "reference": "8.x-1.0-rc7"
+                "reference": "2.0.0-rc1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://ftp.drupal.org/files/projects/node_revision_delete-8.x-1.0-rc7.zip",
-                "reference": "8.x-1.0-rc7",
-                "shasum": "e689fd6bc78afe2e26b7871ed4dc56d4dec3abd7"
+                "url": "https://ftp.drupal.org/files/projects/node_revision_delete-2.0.0-rc1.zip",
+                "reference": "2.0.0-rc1",
+                "shasum": "7532c3c7c0f7bbaccf5a2721273a77cdca1b821b"
             },
             "require": {
-                "drupal/core": "^8.7.7 || ^9.0 || ^10"
+                "drupal/core": "^9.0 || ^10"
             },
             "type": "drupal-module",
             "extra": {
                 "drupal": {
-                    "version": "8.x-1.0-rc7",
-                    "datestamp": "1709793226",
+                    "version": "2.0.0-rc1",
+                    "datestamp": "1709827834",
                     "security-coverage": {
                         "status": "not-covered",
                         "message": "RC releases are not covered by Drupal security advisories."
@@ -6484,12 +6484,14 @@
                     "role": "Maintainer"
                 },
                 {
-                    "name": "Robert Ngo",
-                    "homepage": "https://www.drupal.org/user/610230"
+                    "name": "Sean Blommaert (seanB)",
+                    "homepage": "https://www.drupal.org/u/seanB",
+                    "role": "Maintainer"
                 },
                 {
-                    "name": "seanB",
-                    "homepage": "https://www.drupal.org/user/545912"
+                    "name": "Pravin Gaikwad (Rajeshreeputra)",
+                    "homepage": "https://www.drupal.org/u/rajeshreeputra",
+                    "role": "Maintainer"
                 }
             ],
             "description": "Track and prune node revisions.",

--- a/modules/acquia_cms_common/src/Facade/ConfigHandlerFacade.php
+++ b/modules/acquia_cms_common/src/Facade/ConfigHandlerFacade.php
@@ -1,0 +1,123 @@
+<?php
+
+namespace Drupal\acquia_cms_common\Facade;
+
+use Drupal\Core\Config\ConfigFactoryInterface;
+use Drupal\Core\DependencyInjection\ContainerInjectionInterface;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * Handles the configuration and settings for ACMS.
+ *
+ * @internal
+ *   This is a totally internal part of Acquia CMS and may be changed in any
+ *   way, or removed outright, at any time without warning. External code should
+ *   not use this class!
+ */
+final class ConfigHandlerFacade implements ContainerInjectionInterface {
+
+  /**
+   * The config factory.
+   *
+   * @var \Drupal\Core\Config\ConfigFactoryInterface
+   */
+  protected $configFactory;
+
+  /**
+   * The EntityTypeManager service.
+   *
+   * @var \Drupal\Core\Entity\EntityTypeManagerInterface
+   */
+  protected $entityTypeManager;
+
+  /**
+   * The Module name.
+   *
+   * @var string
+   */
+  protected string $moduleName;
+
+  /**
+   * ConfigHandlerFacade constructor.
+   *
+   * @param \Drupal\Core\Config\ConfigFactoryInterface $config_factory
+   *   The config factory.
+   * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager
+   *   Used to obtain data from various entity types.
+   */
+  public function __construct(ConfigFactoryInterface $config_factory, EntityTypeManagerInterface $entity_type_manager) {
+    $this->configFactory = $config_factory;
+    $this->entityTypeManager = $entity_type_manager;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container) {
+    return new static(
+      $container->get('config.factory'),
+      $container->get('entity_type.manager')
+    );
+  }
+
+  /**
+   * Set module name.
+   *
+   * @param string $name
+   *   Module name.
+   *
+   * @return void
+   *   Setting the module name.
+   */
+  public function setModuleName(string $name): void {
+    $this->moduleName = $name;
+  }
+
+  /**
+   * Function to add default settings of node revision delete.
+   *
+   * @param array $settings
+   *   Config settings data.
+   *
+   * @return void
+   *   Saving the default settings.
+   */
+  public function processConfigSettings(array $settings): void {
+    $config = $this->configFactory->getEditable("$this->moduleName.settings");
+    foreach ($settings as $key => $value) {
+      $config->set($key, $value);
+    }
+    $config->save();
+  }
+
+  /**
+   * Set third party settings for entity.
+   *
+   * @param array $entity
+   *   Entity data.
+   * @param array $settings
+   *   Third party setting data.
+   *
+   * @return void
+   *   Saving the third party settings.
+   */
+  public function processThirdPartySettings(array $entity, array $settings): void {
+    if ($entity) {
+      // Get the entity storage with respective entity_type.
+      $type = $this->entityTypeManager->getStorage($entity['entity_type']);
+      $entityLoad = $type->load($entity['bundle']);
+      // @phpstan-ignore-next-line
+      $getThirdPartySettings = $entityLoad ? $entityLoad->get('third_party_settings') : NULL;
+      // Set the third party settings.
+      if (!empty($entityLoad) && !isset($getThirdPartySettings[$this->moduleName])) {
+        foreach ($settings as $key => $value) {
+          // @phpstan-ignore-next-line
+          $entityLoad->setThirdPartySetting($this->moduleName, $key, $value);
+        }
+        $entityLoad->save();
+      }
+    }
+  }
+
+}

--- a/modules/acquia_cms_common/tests/src/Kernel/ConfigHandlerFacadeTest.php
+++ b/modules/acquia_cms_common/tests/src/Kernel/ConfigHandlerFacadeTest.php
@@ -1,0 +1,111 @@
+<?php
+
+namespace Drupal\Tests\acquia_cms_common\Kernel;
+
+use Drupal\acquia_cms_common\Facade\ConfigHandlerFacade;
+use Drupal\KernelTests\KernelTestBase;
+
+/**
+ * Test the configuration and settings handling.
+ *
+ * @coversDefaultClass Drupal\acquia_cms_common\Facade\ConfigHandlerFacade
+ */
+class ConfigHandlerFacadeTest extends KernelTestBase {
+
+
+  /**
+   * {@inheritdoc}
+   */
+  protected static $modules = [
+    "node",
+    "acquia_cms_common",
+    "node_revision_delete",
+    "reroute_email",
+  ];
+
+  /**
+   * The configHandlerFacade object.
+   *
+   * @var \Drupal\acquia_cms_common\Facade\ConfigHandlerFacade
+   */
+  protected $configHandler;
+
+  /**
+   * The config factory service.
+   *
+   * @var \Drupal\Core\Config\ConfigFactoryInterface
+   */
+  protected $configFactory;
+
+  /**
+   * The entity type manager service.
+   *
+   * @var \Drupal\Core\Entity\EntityTypeManagerInterface
+   */
+  protected $entityTypeManager;
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp(): void {
+    parent::setUp();
+
+    $this->configFactory = $this->container->get("config.factory");
+    $this->entityTypeManager = $this->container->get("entity_type.manager");
+    $this->configHandler = new ConfigHandlerFacade(
+      $this->configFactory,
+      $this->entityTypeManager,
+    );
+  }
+
+  /**
+   * Tests config settings.
+   *
+   * @covers ::processConfigSettings
+   * @dataProvider configSettingDataProvider
+   */
+  public function testConfigSettings($module, $settings): void {
+    $this->configHandler->setModuleName($module);
+    $this->configHandler->processConfigSettings($settings);
+    $configData = $this->configFactory->getEditable("$module.settings");
+    foreach ($settings as $key => $value) {
+      $this->assertEquals($value, $configData->get($key));
+    }
+  }
+
+  /**
+   * @return array[]
+   *   Sets of arguments to pass to the test method.
+   */
+  public function configSettingDataProvider(): array {
+    return [
+      ['acquia_cms_common',
+        [
+          'starter_kit_name' => 'community',
+        ],
+      ],
+      ['node_revision_delete',
+        [
+          'defaults' => [
+            'amount' => [
+              'status' => TRUE,
+              'settings' => [
+                'amount' => 50,
+              ],
+            ],
+          ],
+        ],
+      ],
+      [
+        'reroute_email',
+        [
+          'enable' => TRUE,
+          'roles' => [
+            'content_editor',
+          ],
+        ],
+      ],
+    ];
+  }
+
+}

--- a/modules/acquia_cms_page/acquia_cms_page.install
+++ b/modules/acquia_cms_page/acquia_cms_page.install
@@ -18,9 +18,21 @@ function acquia_cms_page_install($is_syncing) {
     if ($moduleHandler->moduleExists('node_revision_delete')) {
       $type = NodeType::load('page');
       if ($type) {
-        $type->setThirdPartySetting('node_revision_delete', 'minimum_revisions_to_keep', '30');
-        $type->setThirdPartySetting('node_revision_delete', 'minimum_age_to_delete', '0');
-        $type->setThirdPartySetting('node_revision_delete', 'when_to_delete', '0');
+        $type->setThirdPartySetting('node_revision_delete', 'amount', [
+          'status' => TRUE,
+          'settings' => [
+            'amount' => 30,
+          ],
+        ]);
+        foreach (['created', 'drafts', 'drafts_only'] as $value) {
+          $type->setThirdPartySetting('node_revision_delete', $value, [
+            'status' => FALSE,
+            'settings' => [
+              'age' => 0,
+            ],
+          ]);
+        }
+
         $type->save();
       }
     }
@@ -84,21 +96,8 @@ function acquia_cms_page_update_8001() {
  * Remove Page:Node Revision Delete settings if site studio is not installed.
  */
 function acquia_cms_page_update_8002() {
-  $moduleHandler = \Drupal::service('module_handler');
-  if (!$moduleHandler->moduleExists('node_revision_delete')) {
-    $node = NodeType::load('page');
-    if ($node) {
-      // Getting the config file.
-      $third_party_settings = $node->get('third_party_settings');
-      // Checking if the config exists.
-      if (isset($third_party_settings['node_revision_delete'])) {
-        // Deleting the value from the array.
-        unset($third_party_settings['node_revision_delete']);
-        // Saving the values in the config.
-        $node->set('third_party_settings', $third_party_settings)->save();
-      }
-    }
-  }
+  // Stale hook_update_n() cause of changes of schema in
+  // 2.x version of node_revision_delete.
 }
 
 /**

--- a/modules/acquia_cms_page/acquia_cms_page.install
+++ b/modules/acquia_cms_page/acquia_cms_page.install
@@ -5,7 +5,7 @@
  * Install, update and uninstall functions for the acquia_cms_page module.
  */
 
-use Drupal\node\Entity\NodeType;
+use Drupal\acquia_cms_common\Facade\ConfigHandlerFacade;
 use Drupal\user\RoleInterface;
 
 /**
@@ -14,27 +14,43 @@ use Drupal\user\RoleInterface;
 function acquia_cms_page_install($is_syncing) {
   if (!$is_syncing) {
     // Set default node revision delete configuration for Page content type.
-    $moduleHandler = \Drupal::service('module_handler');
-    if ($moduleHandler->moduleExists('node_revision_delete')) {
-      $type = NodeType::load('page');
-      if ($type) {
-        $type->setThirdPartySetting('node_revision_delete', 'amount', [
+    $module_handler = \Drupal::service('module_handler');
+    if ($module_handler->moduleExists('node_revision_delete')) {
+      $config_handler = \Drupal::classResolver(ConfigHandlerFacade::class);
+      $config_handler->setModuleName('node_revision_delete');
+      // Node revision third party settings for page content type.
+      $third_party_settings = [
+        'amount' => [
           'status' => TRUE,
           'settings' => [
             'amount' => 30,
           ],
-        ]);
-        foreach (['created', 'drafts', 'drafts_only'] as $value) {
-          $type->setThirdPartySetting('node_revision_delete', $value, [
-            'status' => FALSE,
-            'settings' => [
-              'age' => 0,
-            ],
-          ]);
-        }
-
-        $type->save();
-      }
+        ],
+        'created' => [
+          'status' => FALSE,
+          'settings' => [
+            'age' => 0,
+          ],
+        ],
+        'drafts' => [
+          'status' => FALSE,
+          'settings' => [
+            'age' => 0,
+          ],
+        ],
+        'drafts_only' => [
+          'status' => FALSE,
+          'settings' => [
+            'age' => 0,
+          ],
+        ],
+      ];
+      // Set default node revision delete configuration for Page content type
+      // and entity node_type.
+      $config_handler->processThirdPartySettings([
+        'entity_type' => 'node_type',
+        'bundle' => 'page',
+      ], $third_party_settings);
     }
   }
 }

--- a/modules/acquia_cms_site_studio/acquia_cms_site_studio.install
+++ b/modules/acquia_cms_site_studio/acquia_cms_site_studio.install
@@ -11,7 +11,6 @@ use Drupal\cohesion_sync\EventSubscriber\Import\SiteStudioSyncFilesSubscriber;
 use Drupal\Core\Config\FileStorage;
 use Drupal\Core\Installer\InstallerKernel;
 use Drupal\editor\Entity\Editor;
-use Drupal\node\Entity\NodeType;
 use Drupal\user\Entity\Role;
 
 /**
@@ -60,8 +59,8 @@ function acquia_cms_site_studio_install($is_syncing) {
           ->save();
       }
     }
-    $config_factory = \Drupal::service('config.factory');
 
+    $config_factory = \Drupal::service('config.factory');
     // If module getting install stand alone.
     if (!InstallerKernel::installationAttempted()) {
       // Trigger save on page body field to update it.
@@ -236,7 +235,7 @@ function acquia_cms_site_studio_update_8002() {
  * Install module with default configuration.
  */
 function acquia_cms_site_studio_update_8003() {
-  // Stale.
+  // Stale hook_update_n because of node_revision_delete 2.x release.
 }
 
 /**

--- a/modules/acquia_cms_site_studio/acquia_cms_site_studio.install
+++ b/modules/acquia_cms_site_studio/acquia_cms_site_studio.install
@@ -5,6 +5,7 @@
  * Contains install-time code for the Acquia CMS profile.
  */
 
+use Drupal\acquia_cms_common\Facade\ConfigHandlerFacade;
 use Drupal\cohesion\Controller\AdministrationController;
 use Drupal\cohesion_sync\Event\SiteStudioSyncFilesEvent;
 use Drupal\cohesion_sync\EventSubscriber\Import\SiteStudioSyncFilesSubscriber;
@@ -128,27 +129,6 @@ function acquia_cms_site_studio_install($is_syncing) {
       'sitestudio_config_management',
     ];
     $module_installer->install($modules_to_install);
-
-    // Set default configurations for node revision delete module.
-    $config = $config_factory->getEditable('node_revision_delete.settings');
-    if ($config) {
-      $config->set('node_revision_delete_cron', '50')
-        ->set('node_revision_delete_time', '604800')
-        ->save();
-    }
-
-    // Set default node revision delete configuration for Page content type.
-    if ($module_handler->moduleExists('acquia_cms_page')) {
-      $type = NodeType::load('page');
-      // @todo It's failing on acquia_cms profile, need to revisit.
-      $third_party_settings = $type ? $type->get('third_party_settings') : NULL;
-      if ($type && !isset($third_party_settings['node_revision_delete'])) {
-        $type->setThirdPartySetting('node_revision_delete', 'minimum_revisions_to_keep', '30');
-        $type->setThirdPartySetting('node_revision_delete', 'minimum_age_to_delete', '0');
-        $type->setThirdPartySetting('node_revision_delete', 'when_to_delete', '0');
-        $type->save();
-      }
-    }
   }
 }
 
@@ -433,4 +413,39 @@ function acquia_cms_site_studio_update_8009() {
       }
     }
   }
+}
+
+/**
+ * Install Node Revision Delete module with default configuration.
+ *
+ * Implements hook_update_n()
+ */
+function acquia_cms_site_studio_update_9000() {
+  $config_handler = \Drupal::classResolver(ConfigHandlerFacade::class);
+  $config_handler->setModuleName('node_revision_delete');
+  // Node revision default config settings.
+  $default_settings = [
+    'defaults' => [
+      'amount' => [
+        'status' => TRUE,
+        'settings' => [
+          'amount' => 50,
+        ],
+      ],
+      'created' => [
+        'status' => TRUE,
+        'settings' => [
+          'age' => 12,
+        ],
+      ],
+      'drafts' => [
+        'status' => TRUE,
+        'settings' => [
+          'age' => 12,
+        ],
+      ],
+    ],
+  ];
+  // Set default node revision delete settings shipped by Acquia CMS.
+  $config_handler->processConfigSettings($default_settings);
 }

--- a/modules/acquia_cms_site_studio/acquia_cms_site_studio.install
+++ b/modules/acquia_cms_site_studio/acquia_cms_site_studio.install
@@ -236,25 +236,7 @@ function acquia_cms_site_studio_update_8002() {
  * Install module with default configuration.
  */
 function acquia_cms_site_studio_update_8003() {
-  // Install node revision delete module and set default configurations.
-  \Drupal::service('module_installer')->install(['node_revision_delete']);
-  $config = \Drupal::service('config.factory')->getEditable('node_revision_delete.settings');
-  if ($config) {
-    $config->set('node_revision_delete_cron', '50')
-      ->set('node_revision_delete_time', '604800')
-      ->save();
-  }
-  // Set default node revision delete configuration for Place content type.
-  $module_handler = \Drupal::service('module_handler');
-  if ($module_handler->moduleExists('acquia_cms_page')) {
-    $type = NodeType::load('page');
-    if ($type) {
-      $type->setThirdPartySetting('node_revision_delete', 'minimum_revisions_to_keep', '30');
-      $type->setThirdPartySetting('node_revision_delete', 'minimum_age_to_delete', '0');
-      $type->setThirdPartySetting('node_revision_delete', 'when_to_delete', '0');
-      $type->save();
-    }
-  }
+  // Stale.
 }
 
 /**

--- a/modules/acquia_cms_site_studio/acquia_cms_site_studio.module
+++ b/modules/acquia_cms_site_studio/acquia_cms_site_studio.module
@@ -212,33 +212,30 @@ function acquia_cms_site_studio_modules_installed($modules, $is_syncing) {
       $config = \Drupal::configFactory()->getEditable('node_revision_delete.settings');
       if ($config) {
         $config->set('defaults.amount.status', TRUE)
-          ->set('defaults.amount.settings.amount', '50')
+          ->set('defaults.amount.settings.amount', 50)
           ->set('defaults.created.status', TRUE)
-          // Earlier we are setting duration is 604800 i.e 1 week
-          // but with 2.x version of node_revision_delete,
-          // user can set duration in months only.
-          // Now it should 1 month only.
-          ->set('defaults.created.settings.age', '1')
+          ->set('defaults.created.settings.age', 12)
+          ->set('defaults.drafts.status', TRUE)
+          ->set('defaults.drafts.settings.age', 12)
           ->save();
       }
 
       // Set default node revision delete configuration for Page content type.
       if (\Drupal::service('module_handler')->moduleExists('acquia_cms_page')) {
         $type = NodeType::load('page');
-        // @todo It's failing on acquia_cms profile, need to revisit.
         $third_party_settings = $type ? $type->get('third_party_settings') : NULL;
         if ($type && !isset($third_party_settings['node_revision_delete'])) {
           $type->setThirdPartySetting('node_revision_delete', 'amount', [
             'status' => TRUE,
             'settings' => [
-              'amount' => '30',
+              'amount' => 30,
             ],
           ]);
           foreach (['created', 'drafts', 'drafts_only'] as $value) {
             $type->setThirdPartySetting('node_revision_delete', $value, [
               'status' => FALSE,
               'settings' => [
-                'age' => '0',
+                'age' => 0,
               ],
             ]);
           }

--- a/modules/acquia_cms_site_studio/acquia_cms_site_studio.module
+++ b/modules/acquia_cms_site_studio/acquia_cms_site_studio.module
@@ -5,13 +5,13 @@
  * File for the Site Studio Installation Code.
  */
 
+use Drupal\acquia_cms_common\Facade\ConfigHandlerFacade;
 use Drupal\acquia_cms_site_studio\Facade\CohesionFacade;
 use Drupal\acquia_cms_site_studio\Form\AcquiaCmsSiteStudioSiteConfigureForm;
 use Drupal\acquia_cms_site_studio\Helper\SiteStudioPermissionHelper;
 use Drupal\cohesion\Controller\AdministrationController;
 use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Form\FormStateInterface;
-use Drupal\node\Entity\NodeType;
 use Drupal\user\Entity\Role;
 use Drupal\user\RoleInterface;
 
@@ -208,41 +208,69 @@ function acquia_cms_site_studio_modules_installed($modules, $is_syncing) {
       ]);
     }
     if (in_array('node_revision_delete', $modules)) {
-      // Set default configurations for node revision delete module.
-      $config = \Drupal::configFactory()->getEditable('node_revision_delete.settings');
-      if ($config) {
-        $config->set('defaults.amount.status', TRUE)
-          ->set('defaults.amount.settings.amount', 50)
-          ->set('defaults.created.status', TRUE)
-          ->set('defaults.created.settings.age', 12)
-          ->set('defaults.drafts.status', TRUE)
-          ->set('defaults.drafts.settings.age', 12)
-          ->save();
-      }
-
-      // Set default node revision delete configuration for Page content type.
+      $config_handler = \Drupal::classResolver(ConfigHandlerFacade::class);
+      $config_handler->setModuleName('node_revision_delete');
+      // Node revision default config settings.
+      $default_settings = [
+        'defaults' => [
+          'amount' => [
+            'status' => TRUE,
+            'settings' => [
+              'amount' => 50,
+            ],
+          ],
+          'created' => [
+            'status' => TRUE,
+            'settings' => [
+              'age' => 12,
+            ],
+          ],
+          'drafts' => [
+            'status' => TRUE,
+            'settings' => [
+              'age' => 12,
+            ],
+          ],
+        ],
+      ];
+      // Set default node revision delete settings shipped by Acquia CMS.
+      $config_handler->processConfigSettings($default_settings);
       if (\Drupal::service('module_handler')->moduleExists('acquia_cms_page')) {
-        $type = NodeType::load('page');
-        $third_party_settings = $type ? $type->get('third_party_settings') : NULL;
-        if ($type && !isset($third_party_settings['node_revision_delete'])) {
-          $type->setThirdPartySetting('node_revision_delete', 'amount', [
+        // Node revision third party settings for page content type.
+        $third_party_settings = [
+          'amount' => [
             'status' => TRUE,
             'settings' => [
               'amount' => 30,
             ],
-          ]);
-          foreach (['created', 'drafts', 'drafts_only'] as $value) {
-            $type->setThirdPartySetting('node_revision_delete', $value, [
-              'status' => FALSE,
-              'settings' => [
-                'age' => 0,
-              ],
-            ]);
-          }
-
-          $type->save();
-        }
+          ],
+          'created' => [
+            'status' => FALSE,
+            'settings' => [
+              'age' => 0,
+            ],
+          ],
+          'drafts' => [
+            'status' => FALSE,
+            'settings' => [
+              'age' => 0,
+            ],
+          ],
+          'drafts_only' => [
+            'status' => FALSE,
+            'settings' => [
+              'age' => 0,
+            ],
+          ],
+        ];
+        // Set default node revision delete configuration for Page content type
+        // and entity node_type.
+        $config_handler->processThirdPartySettings([
+          'entity_type' => 'node_type',
+          'bundle' => 'page',
+        ], $third_party_settings);
       }
+
     }
   }
 }

--- a/modules/acquia_cms_site_studio/acquia_cms_site_studio.module
+++ b/modules/acquia_cms_site_studio/acquia_cms_site_studio.module
@@ -11,6 +11,7 @@ use Drupal\acquia_cms_site_studio\Helper\SiteStudioPermissionHelper;
 use Drupal\cohesion\Controller\AdministrationController;
 use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Form\FormStateInterface;
+use Drupal\node\Entity\NodeType;
 use Drupal\user\Entity\Role;
 use Drupal\user\RoleInterface;
 
@@ -205,6 +206,46 @@ function acquia_cms_site_studio_modules_installed($modules, $is_syncing) {
       user_role_grant_permissions('site_builder', [
         'administer style_guide',
       ]);
+    }
+    if (in_array('node_revision_delete', $modules)) {
+      // Set default configurations for node revision delete module.
+      $config = \Drupal::configFactory()->getEditable('node_revision_delete.settings');
+      if ($config) {
+        $config->set('defaults.amount.status', TRUE)
+          ->set('defaults.amount.settings.amount', '50')
+          ->set('defaults.created.status', TRUE)
+          // Earlier we are setting duration is 604800 i.e 1 week
+          // but with 2.x version of node_revision_delete,
+          // user can set duration in months only.
+          // Now it should 1 month only.
+          ->set('defaults.created.settings.age', '1')
+          ->save();
+      }
+
+      // Set default node revision delete configuration for Page content type.
+      if (\Drupal::service('module_handler')->moduleExists('acquia_cms_page')) {
+        $type = NodeType::load('page');
+        // @todo It's failing on acquia_cms profile, need to revisit.
+        $third_party_settings = $type ? $type->get('third_party_settings') : NULL;
+        if ($type && !isset($third_party_settings['node_revision_delete'])) {
+          $type->setThirdPartySetting('node_revision_delete', 'amount', [
+            'status' => TRUE,
+            'settings' => [
+              'amount' => '30',
+            ],
+          ]);
+          foreach (['created', 'drafts', 'drafts_only'] as $value) {
+            $type->setThirdPartySetting('node_revision_delete', $value, [
+              'status' => FALSE,
+              'settings' => [
+                'age' => '0',
+              ],
+            ]);
+          }
+
+          $type->save();
+        }
+      }
     }
   }
 }

--- a/modules/acquia_cms_site_studio/composer.json
+++ b/modules/acquia_cms_site_studio/composer.json
@@ -8,7 +8,7 @@
         "acquia/cohesion-theme": "~7.4.0 || ~7.5.0",
         "drupal/acquia_cms_common": "^1.9 || ^2.1 || ^3.1",
         "drupal/collapsiblock": "^4.0",
-        "drupal/node_revision_delete": "^1.0",
+        "drupal/node_revision_delete": "^2.0",
         "drupal/responsive_preview": "^2.1",
         "drupal/sitestudio_config_management": "^1.0"
     },

--- a/modules/acquia_cms_site_studio/tests/src/ExistingSite/NodeRevisionDeleteConfigTest.php
+++ b/modules/acquia_cms_site_studio/tests/src/ExistingSite/NodeRevisionDeleteConfigTest.php
@@ -35,7 +35,33 @@ class NodeRevisionDeleteConfigTest extends ExistingSiteBase {
     // Check that node revision delete default configs are in place.
     $config = $this->config('node_revision_delete.settings');
     if ($config) {
+      // Total revisions set for delete.
+      $this->assertTrue($config->get('defaults.amount.status'));
+      $this->assertEquals(50, $config->get('defaults.amount.settings.amount'));
+      // Total duration i.e 12 months is minimum to keep revisions.
+      $this->assertTrue($config->get('defaults.created.status'));
+      $this->assertEquals(12, $config->get('defaults.created.settings.age'));
+      $this->assertTrue($config->get('defaults.drafts.status'));
+      $this->assertEquals(12, $config->get('defaults.drafts.settings.age'));
+      // By default it is set to FALSE.
       $this->assertFalse($config->get('disable_automatic_queueing'));
+    }
+  }
+
+  /**
+   * Assert that node revision delete configs available for Page content type.
+   */
+  public function testContentTypeConfig() {
+    // Check node revision delete configs for Page content type are in palce.
+    $config = $this->config('node.type.page');
+    if ($config) {
+      $this->assertTrue($config->get('third_party_settings.node_revision_delete.amount.status'));
+      // Total revisions for Page content type.
+      $this->assertSame(30, $config->get('third_party_settings.node_revision_delete.amount.settings.amount'));
+      // Keep revisions for active and drafts contents.
+      $this->assertSame(0, $config->get('third_party_settings.node_revision_delete.created.settings.age'));
+      $this->assertSame(0, $config->get('third_party_settings.node_revision_delete.drafts.settings.age'));
+      $this->assertSame(0, $config->get('third_party_settings.node_revision_delete.drafts_only.settings.age'));
     }
   }
 

--- a/modules/acquia_cms_site_studio/tests/src/ExistingSite/NodeRevisionDeleteConfigTest.php
+++ b/modules/acquia_cms_site_studio/tests/src/ExistingSite/NodeRevisionDeleteConfigTest.php
@@ -24,7 +24,7 @@ class NodeRevisionDeleteConfigTest extends ExistingSiteBase {
    *   The config object, read-only to discourage this test from making any
    *   changes.
    */
-  private function config(string $name) : ImmutableConfig {
+  private function config(string $name): ImmutableConfig {
     return $this->container->get('config.factory')->get($name);
   }
 
@@ -35,21 +35,7 @@ class NodeRevisionDeleteConfigTest extends ExistingSiteBase {
     // Check that node revision delete default configs are in place.
     $config = $this->config('node_revision_delete.settings');
     if ($config) {
-      $this->assertEquals(50, $config->get('node_revision_delete_cron'));
-      $this->assertEquals(604800, $config->get('node_revision_delete_time'));
-    }
-  }
-
-  /**
-   * Assert that node revision delete configs available for Page content type.
-   */
-  public function testContentTypeConfig() {
-    // Check node revision delete configs for Page content type are in palce.
-    $config = $this->config('node.type.page');
-    if ($config) {
-      $this->assertSame(30, $config->get('third_party_settings.node_revision_delete.minimum_revisions_to_keep'));
-      $this->assertSame(0, $config->get('third_party_settings.node_revision_delete.minimum_age_to_delete'));
-      $this->assertSame(0, $config->get('third_party_settings.node_revision_delete.when_to_delete'));
+      $this->assertFalse($config->get('disable_automatic_queueing'));
     }
   }
 


### PR DESCRIPTION
**Motivation**
<!-- What problem does this solve? Why is it important? What's the context? If this fixes an issue, link to it above. -->
Fixes ACMS-3650

**Proposed changes**
Update acquia_cms_site_studio composer.json with  2.x version of node revision delete.


