### PR TITLE
ACMS-3475: Managing hard dependency of Acquia CMS site studio module.

### DIFF
--- a/modules/acquia_cms_site_studio/acquia_cms_site_studio.info.yml
+++ b/modules/acquia_cms_site_studio/acquia_cms_site_studio.info.yml
@@ -5,16 +5,11 @@ core_version_requirement: ^9.4 || ^10
 type: module
 dependencies:
   - acquia_cms_common:acquia_cms_common
-  - cohesion
   - cohesion_base_styles
   - cohesion_custom_styles
   - cohesion_elements
   - cohesion_style_helpers
   - cohesion_sync
-  - cohesion_templates
   - cohesion_website_settings
-  - config_ignore:config_ignore
   - collapsiblock:collapsiblock
-  - node_revision_delete:node_revision_delete
   - sitestudio_page_builder
-  - responsive_preview:responsive_preview

--- a/modules/acquia_cms_site_studio/acquia_cms_site_studio.install
+++ b/modules/acquia_cms_site_studio/acquia_cms_site_studio.install
@@ -92,27 +92,6 @@ function acquia_cms_site_studio_install($is_syncing) {
       }
     }
 
-    // Set default configurations for node revision delete module.
-    $config = $config_factory->getEditable('node_revision_delete.settings');
-    if ($config) {
-      $config->set('node_revision_delete_cron', '50')
-        ->set('node_revision_delete_time', '604800')
-        ->save();
-    }
-
-    // Set default node revision delete configuration for Page content type.
-    if ($module_handler->moduleExists('acquia_cms_page')) {
-      $type = NodeType::load('page');
-      // @todo It's failing on acquia_cms profile, need to revisit.
-      $third_party_settings = $type ? $type->get('third_party_settings') : NULL;
-      if ($type && !isset($third_party_settings['node_revision_delete'])) {
-        $type->setThirdPartySetting('node_revision_delete', 'minimum_revisions_to_keep', '30');
-        $type->setThirdPartySetting('node_revision_delete', 'minimum_age_to_delete', '0');
-        $type->setThirdPartySetting('node_revision_delete', 'when_to_delete', '0');
-        $type->save();
-      }
-    }
-
     // Re-write the editor and filter format config from
     // optional directory since we have done some update to it.
     $module_path = $module_handler->getModule('acquia_cms_site_studio')->getPath();
@@ -141,14 +120,36 @@ function acquia_cms_site_studio_install($is_syncing) {
       }
     }
 
+    $module_installer = \Drupal::service('module_installer');
     // Install cohesion_style_guide & sitestudio_config_management module.
     $modules_to_install = [
+      'node_revision_delete',
+      'responsive_preview',
       'cohesion_style_guide',
       'sitestudio_config_management',
     ];
+    $module_installer->install($modules_to_install);
 
-    // Install modules.
-    \Drupal::service('module_installer')->install($modules_to_install);
+    // Set default configurations for node revision delete module.
+    $config = $config_factory->getEditable('node_revision_delete.settings');
+    if ($config) {
+      $config->set('node_revision_delete_cron', '50')
+        ->set('node_revision_delete_time', '604800')
+        ->save();
+    }
+
+    // Set default node revision delete configuration for Page content type.
+    if ($module_handler->moduleExists('acquia_cms_page')) {
+      $type = NodeType::load('page');
+      // @todo It's failing on acquia_cms profile, need to revisit.
+      $third_party_settings = $type ? $type->get('third_party_settings') : NULL;
+      if ($type && !isset($third_party_settings['node_revision_delete'])) {
+        $type->setThirdPartySetting('node_revision_delete', 'minimum_revisions_to_keep', '30');
+        $type->setThirdPartySetting('node_revision_delete', 'minimum_age_to_delete', '0');
+        $type->setThirdPartySetting('node_revision_delete', 'when_to_delete', '0');
+        $type->save();
+      }
+    }
   }
 }
 


### PR DESCRIPTION
**Motivation**
<!-- What problem does this solve? Why is it important? What's the context? If this fixes an issue, link to it above. -->
Fixes ACMS-3475

**Proposed changes**
- Moving out contrib modules from .info.yml
- Upgrading node_revision_delete to ^2.0
- Updated the node_revision_delete.settings with latest changes
- Updated tests accordingly

