### PR TITLE
ACMS-3657: Update Acquia CMS Ecosystem to make pipeline green.

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -2589,10 +2589,13 @@
             "dist": {
                 "type": "path",
                 "url": "./modules/acquia_cms_document",
-                "reference": "d4ff4d0cd000a6b69d87a8285ba8e77695f20b7d"
+                "reference": "dbb43e60e430a9dbc5eb071a3c5c63a84bfb63b4"
             },
             "require": {
                 "drupal/acquia_cms_common": "^1.9 || ^2.1 || ^3.1"
+            },
+            "require-dev": {
+                "drupal/acquia_claro": "^1.3"
             },
             "type": "drupal-module",
             "extra": {
@@ -2756,10 +2759,13 @@
             "dist": {
                 "type": "path",
                 "url": "./modules/acquia_cms_page",
-                "reference": "4c295aa731fa6ee2a8ab4cf7d2c5cc8d665245b2"
+                "reference": "30a01d467e21bd6aa9d2a1ce3229d334df2610fa"
             },
             "require": {
                 "drupal/acquia_cms_image": "^1.5.10"
+            },
+            "require-dev": {
+                "drupal/acquia_cms_site_studio": "^1.6"
             },
             "type": "drupal-module",
             "extra": {
@@ -2885,7 +2891,7 @@
             "dist": {
                 "type": "path",
                 "url": "./modules/acquia_cms_site_studio",
-                "reference": "cc572caffe0616b3636d9f122d69ec4565363971"
+                "reference": "094ca6e6a8cf6f7fb57a2ecc1a9d9044e8e6aeb3"
             },
             "require": {
                 "acquia/cohesion": "~7.4.0",
@@ -2909,6 +2915,7 @@
                 "drupal/acquia_cms_video": "<1.6"
             },
             "require-dev": {
+                "drupal/acquia_cms_page": "^1",
                 "drupal/acquia_cms_tour": "^2"
             },
             "type": "drupal-module",
@@ -8193,7 +8200,7 @@
             "dist": {
                 "type": "path",
                 "url": "./modules/sitestudio_config_management",
-                "reference": "7e3c72a2a58ab0893f8c4c6ead4a8af3a1d78849"
+                "reference": "4b82feb468b5f5d91df43f09fc8cc7c6972ba6f3"
             },
             "require": {
                 "acquia/cohesion": "~7.4.0",
@@ -21642,5 +21649,5 @@
     "prefer-lowest": false,
     "platform": [],
     "platform-dev": [],
-    "plugin-api-version": "2.6.0"
+    "plugin-api-version": "2.3.0"
 }

--- a/modules/acquia_cms_audio/tests/packages_alter.yml
+++ b/modules/acquia_cms_audio/tests/packages_alter.yml
@@ -2,6 +2,7 @@
 drupal/acquia_cms_audio:
   version_dev: "1.x-dev"
 acquia/acquia_cms: ~
+drupal/acquia_contenthub_s3: ~
 drupal/acquia_cms_common:
   core_matrix:
     '>=10.2.2':

--- a/modules/acquia_cms_common/.gitlab-ci.yml
+++ b/modules/acquia_cms_common/.gitlab-ci.yml
@@ -14,3 +14,9 @@ variables:
   ORCA_SUT_NAME: drupal/acquia_cms_common
   ORCA_SUT_BRANCH: 3.x
   ORCA_PACKAGES_CONFIG_ALTER: $CI_PROJECT_DIR/tests/packages_alter.yml
+
+# 3.x does not support Drupal 9.5 version.
+  SKIP_INTEGRATED_TEST_ON_LATEST_EOL_MAJOR: 1
+  SKIP_INTEGRATED_TEST_ON_LATEST_EOL_MAJOR_PHP8: 1
+  # 3.x does not support Drupal 10.1 version.
+  SKIP_INTEGRATED_TEST_ON_PREVIOUS_MINOR: 1

--- a/modules/acquia_cms_document/composer.json
+++ b/modules/acquia_cms_document/composer.json
@@ -6,6 +6,9 @@
     "require": {
         "drupal/acquia_cms_common": "^1.9 || ^2.1 || ^3.1"
     },
+    "require-dev": {
+        "drupal/acquia_claro": "^1.3"
+    },
     "repositories": {
         "assets": {
             "type": "composer",

--- a/modules/acquia_cms_page/composer.json
+++ b/modules/acquia_cms_page/composer.json
@@ -6,6 +6,9 @@
     "require": {
         "drupal/acquia_cms_image": "^1.5.10"
     },
+    "require-dev": {
+        "drupal/acquia_cms_site_studio": "^1.6"
+    },
     "repositories": {
         "assets": {
             "type": "composer",

--- a/modules/acquia_cms_page/tests/packages_alter.yml
+++ b/modules/acquia_cms_page/tests/packages_alter.yml
@@ -2,6 +2,7 @@
 drupal/acquia_cms_page:
   version_dev: "1.x-dev"
 acquia/acquia_cms: ~
+drupal/acquia_contenthub_s3: ~
 drupal/acquia_cms_common:
   core_matrix:
     '>=10.2.2':

--- a/modules/acquia_cms_page/tests/src/Kernel/PageWithLayoutCanvasFieldTest.php
+++ b/modules/acquia_cms_page/tests/src/Kernel/PageWithLayoutCanvasFieldTest.php
@@ -21,8 +21,8 @@ class PageWithLayoutCanvasFieldTest extends FieldKernelTestBase {
     'node',
     'media',
     'acquia_cms_page',
-    'cohesion_elements',
     'acquia_cms_site_studio',
+    'cohesion_elements',
     'entity_reference_revisions',
   ];
 
@@ -52,7 +52,7 @@ class PageWithLayoutCanvasFieldTest extends FieldKernelTestBase {
   /**
    * Tests facet facade to verify facet entity.
    */
-  public function testPageContentTypeWithFields() {
+  public function testPageContentTypeWithFields(): void {
     $expected_fields = [
       'title',
       'body',


### PR DESCRIPTION
**Motivation**
Fixes #[ACMS-3657](https://acquia.atlassian.net/browse/ACMS-3657)

**Proposed changes**
Acquia CMS Common: Update GitLab CI pipeline to ignore LATEST_EOL_MAJOR and PREVIOUS_MINOR.
Acquia CMS Page: Add require-dev section in composer.json file to acquia_cms_site_studio. And updated kernelTest to change the order of cohesion_elements module and method return type.
Acquia CMS Document: Add require-dev section in composer.json file to include acquia_claro.
Acquia CMS Audio: Package alter changes to exclude drupal/acquia_contenthub_s3

**Alternatives considered**
NA

**Testing steps**
<!-- How can we replicate the issue and verify that this PR fixes it? -->

**Merge requirements**
- [ ] _Major change_, _Minor change_, _Bug_, _Enhancement_, and/or _Chore_ label applied
- [ ] Manual testing by a reviewer
