### PR TITLE
ACMS-3722: Fix ignoreConfig button throws error on sitestudio form over tour page.

### DIFF
--- a/modules/acquia_cms_site_studio/src/Plugin/AcquiaCmsTour/SiteStudioCoreForm.php
+++ b/modules/acquia_cms_site_studio/src/Plugin/AcquiaCmsTour/SiteStudioCoreForm.php
@@ -130,6 +130,13 @@ class SiteStudioCoreForm extends AcquiaCmsDashboardBase {
   /**
    * {@inheritdoc}
    */
+  public function ignoreConfig(array &$form, FormStateInterface $form_state) {
+    $this->setConfigurationState();
+  }
+
+  /**
+   * {@inheritdoc}
+   */
   public function checkMinConfiguration() {
     $api_key = $this->config('cohesion.settings')->get('api_key');
     $agency_key = $this->config('cohesion.settings')->get('organization_key');

--- a/modules/acquia_cms_tour/css/acquia_cms_tour_dashboard.css
+++ b/modules/acquia_cms_tour/css/acquia_cms_tour_dashboard.css
@@ -81,13 +81,15 @@
 .section-top .help-text {
   width: 80%;
 }
-.section-top .starter-wizard,
-.section-top .wizard {
-  right: 2.5rem;
+.section-top .wizard,
+.section-top .starter-wizard {
   position: absolute;
 }
+.section-top .starter-wizard {
+  right: 2.5rem;
+}
 .section-top .starter-wizard + .wizard {
-  right: 11.5rem;
+  right: 12.5rem;
 }
 
 @media screen and (max-width: 767px) {


### PR DESCRIPTION


**Motivation**
<!-- What problem does this solve? Why is it important? What's the context? If this fixes an issue, link to it above. -->
Fixes ACMS-3722

**Proposed changes**
Fix issue for ignoreConfig button error thrown
Overlapping button on tour page is fixed.

