### PR TITLE
ACMS-3680: Allow strictConfigSchema check in tests.

### DIFF
--- a/modules/acquia_cms_article/tests/src/ExistingSite/ArticleImageDamTest.php
+++ b/modules/acquia_cms_article/tests/src/ExistingSite/ArticleImageDamTest.php
@@ -19,10 +19,6 @@ class ArticleImageDamTest extends ExistingSiteBase {
 
   use ConfigurationTraits;
 
-  // @codingStandardsIgnoreStart
-  protected $strictConfigSchema = FALSE;
-  // @codingStandardsIgnoreEnd
-
   /**
    * {@inheritdoc}
    */

--- a/modules/acquia_cms_article/tests/src/Functional/ArticleTest.php
+++ b/modules/acquia_cms_article/tests/src/Functional/ArticleTest.php
@@ -35,21 +35,6 @@ class ArticleTest extends ContentTypeTestBase {
   ];
 
   /**
-   * Disable strict config schema checks in this test.
-   *
-   * Cohesion has a lot of config schema errors, and until they are all fixed,
-   * this test cannot pass unless we disable strict config schema checking
-   * altogether. Since strict config schema isn't critically important in
-   * testing this functionality, it's okay to disable it for now, but it should
-   * be re-enabled (i.e., this property should be removed) as soon as possible.
-   *
-   * @var bool
-   */
-  // @codingStandardsIgnoreStart
-  protected $strictConfigSchema = FALSE;
-  // @codingStandardsIgnoreEnd
-
-  /**
    * {@inheritdoc}
    */
   protected function doTestEditForm() : void {

--- a/modules/acquia_cms_article/tests/src/Functional/BlogTest.php
+++ b/modules/acquia_cms_article/tests/src/Functional/BlogTest.php
@@ -42,21 +42,6 @@ class BlogTest extends BrowserTestBase {
   ];
 
   /**
-   * Disable strict config schema checks in this test.
-   *
-   * Cohesion has a lot of config schema errors, and until they are all fixed,
-   * this test cannot pass unless we disable strict config schema checking
-   * altogether. Since strict config schema isn't critically important in
-   * testing this functionality, it's okay to disable it for now, but it should
-   * be re-enabled (i.e., this property should be removed) as soon as possible.
-   *
-   * @var bool
-   */
-  // @codingStandardsIgnoreStart
-  protected $strictConfigSchema = FALSE;
-  // @codingStandardsIgnoreEnd
-
-  /**
    * {@inheritdoc}
    */
   public function testBlogArticles() {

--- a/modules/acquia_cms_audio/tests/src/Functional/AudioTest.php
+++ b/modules/acquia_cms_audio/tests/src/Functional/AudioTest.php
@@ -21,20 +21,6 @@ class AudioTest extends MediaTypeTestBase {
    */
   protected static $modules = ['acquia_cms_audio'];
 
-  /**
-   * Disable strict config schema checks in this test.
-   *
-   * Cohesion has a lot of config schema errors, and until they are all fixed,
-   * this test cannot pass unless we disable strict config schema checking
-   * altogether. Since strict config schema isn't critically important in
-   * testing this functionality, it's okay to disable it for now, but it should
-   * be re-enabled (i.e., this property should be removed) as soon as possible.
-   *
-   * @var bool
-   */
-  // @codingStandardsIgnoreStart
-  protected $strictConfigSchema = FALSE;
-  // @codingStandardsIgnoreEnd
 
   /**
    * {@inheritdoc}

--- a/modules/acquia_cms_common/modules/acquia_cms_support/tests/src/Functional/AcquiaCmsConfigSyncTest.php
+++ b/modules/acquia_cms_common/modules/acquia_cms_support/tests/src/Functional/AcquiaCmsConfigSyncTest.php
@@ -21,21 +21,6 @@ class AcquiaCmsConfigSyncTest extends BrowserTestBase {
   protected $defaultTheme = 'stark';
 
   /**
-   * Disable strict config schema checks in this test.
-   *
-   * Cohesion has a lot of config schema errors, and until they are all fixed,
-   * this test cannot pass unless we disable strict config schema checking
-   * altogether. Since strict config schema isn't critically important in
-   * testing this functionality, it's okay to disable it for now, but it should
-   * be re-enabled (i.e., this property should be removed) as soon as possible.
-   *
-   * @var bool
-   */
-  // @codingStandardsIgnoreStart
-  protected $strictConfigSchema = FALSE;
-  // @codingStandardsIgnoreEnd
-
-  /**
    * {@inheritdoc}
    */
   protected static $modules = [

--- a/modules/acquia_cms_common/tests/src/Functional/BasicPermissionsTest.php
+++ b/modules/acquia_cms_common/tests/src/Functional/BasicPermissionsTest.php
@@ -32,21 +32,6 @@ class BasicPermissionsTest extends BrowserTestBase {
   ];
 
   /**
-   * Disable strict config schema checks in this test.
-   *
-   * Cohesion has a lot of config schema errors, and until they are all fixed,
-   * this test cannot pass unless we disable strict config schema checking
-   * altogether. Since strict config schema isn't critically important in
-   * testing this functionality, it's okay to disable it for now, but it should
-   * be re-enabled (i.e., this property should be removed) as soon as possible.
-   *
-   * @var bool
-   */
-  // @codingStandardsIgnoreStart
-  protected $strictConfigSchema = FALSE;
-  // @codingStandardsIgnoreEnd
-
-  /**
    * Tests the basic module permissions.
    *
    * @param mixed $modules

--- a/modules/acquia_cms_common/tests/src/Functional/EntityPermissionsTestBase.php
+++ b/modules/acquia_cms_common/tests/src/Functional/EntityPermissionsTestBase.php
@@ -18,21 +18,6 @@ abstract class EntityPermissionsTestBase extends BrowserTestBase {
   protected $defaultTheme = 'stark';
 
   /**
-   * Disable strict config schema checks in this test.
-   *
-   * Cohesion has a lot of config schema errors, and until they are all fixed,
-   * this test cannot pass unless we disable strict config schema checking
-   * altogether. Since strict config schema isn't critically important in
-   * testing this functionality, it's okay to disable it for now, but it should
-   * be re-enabled (i.e., this property should be removed) as soon as possible.
-   *
-   * @var bool
-   */
-  // @codingStandardsIgnoreStart
-  protected $strictConfigSchema = FALSE;
-  // @codingStandardsIgnoreEnd
-
-  /**
    * Defines an array of role which should & shouldn't exist.
    */
   public function providerRoleExistNotExist(): array {

--- a/modules/acquia_cms_common/tests/src/FunctionalJavascript/Ckeditor5ConfigurationTestBase.php
+++ b/modules/acquia_cms_common/tests/src/FunctionalJavascript/Ckeditor5ConfigurationTestBase.php
@@ -32,21 +32,6 @@ abstract class Ckeditor5ConfigurationTestBase extends WebDriverTestBase {
   ];
 
   /**
-   * Disable strict config schema checks in this test.
-   *
-   * Cohesion has a lot of config schema errors, and until they are all fixed,
-   * this test cannot pass unless we disable strict config schema checking
-   * altogether. Since strict config schema isn't critically important in
-   * testing this functionality, it's okay to disable it for now, but it should
-   * be re-enabled (i.e., this property should be removed) as soon as possible.
-   *
-   * @var bool
-   */
-  // @codingStandardsIgnoreStart
-  protected $strictConfigSchema = FALSE;
-  // @codingStandardsIgnoreEnd
-
-  /**
    * {@inheritdoc}
    */
   protected function setUp(): void {

--- a/modules/acquia_cms_document/tests/src/Functional/DocumentTest.php
+++ b/modules/acquia_cms_document/tests/src/Functional/DocumentTest.php
@@ -22,21 +22,6 @@ class DocumentTest extends MediaTypeTestBase {
   protected static $modules = ['acquia_cms_document'];
 
   /**
-   * Disable strict config schema checks in this test.
-   *
-   * Cohesion has a lot of config schema errors, and until they are all fixed,
-   * this test cannot pass unless we disable strict config schema checking
-   * altogether. Since strict config schema isn't critically important in
-   * testing this functionality, it's okay to disable it for now, but it should
-   * be re-enabled (i.e., this property should be removed) as soon as possible.
-   *
-   * @var bool
-   */
-  // @codingStandardsIgnoreStart
-  protected $strictConfigSchema = FALSE;
-  // @codingStandardsIgnoreEnd
-
-  /**
    * {@inheritdoc}
    */
   protected $mediaType = 'document';

--- a/modules/acquia_cms_document/tests/src/FunctionalJavascript/DocumentEmbedTest.php
+++ b/modules/acquia_cms_document/tests/src/FunctionalJavascript/DocumentEmbedTest.php
@@ -21,21 +21,6 @@ class DocumentEmbedTest extends MediaEmbedTestBase {
   protected static $modules = ['acquia_cms_document'];
 
   /**
-   * Disable strict config schema checks in this test.
-   *
-   * Cohesion has a lot of config schema errors, and until they are all fixed,
-   * this test cannot pass unless we disable strict config schema checking
-   * altogether. Since strict config schema isn't critically important in
-   * testing this functionality, it's okay to disable it for now, but it should
-   * be re-enabled (i.e., this property should be removed) as soon as possible.
-   *
-   * @var bool
-   */
-  // @codingStandardsIgnoreStart
-  protected $strictConfigSchema = FALSE;
-  // @codingStandardsIgnoreEnd
-
-  /**
    * {@inheritdoc}
    */
   protected $mediaType = 'document';

--- a/modules/acquia_cms_event/tests/src/ExistingSite/EventImageDamTest.php
+++ b/modules/acquia_cms_event/tests/src/ExistingSite/EventImageDamTest.php
@@ -19,10 +19,6 @@ class EventImageDamTest extends ExistingSiteBase {
 
   use ConfigurationTraits;
 
-  // @codingStandardsIgnoreStart
-  protected $strictConfigSchema = FALSE;
-  // @codingStandardsIgnoreEnd
-
   /**
    * {@inheritdoc}
    */

--- a/modules/acquia_cms_event/tests/src/Functional/EventTest.php
+++ b/modules/acquia_cms_event/tests/src/Functional/EventTest.php
@@ -38,21 +38,6 @@ class EventTest extends ContentTypeTestBase {
   private $defaultTime;
 
   /**
-   * Disable strict config schema checks in this test.
-   *
-   * Cohesion has a lot of config schema errors, and until they are all fixed,
-   * this test cannot pass unless we disable strict config schema checking
-   * altogether. Since strict config schema isn't critically important in
-   * testing this functionality, it's okay to disable it for now, but it should
-   * be re-enabled (i.e., this property should be removed) as soon as possible.
-   *
-   * @var bool
-   */
-  // @codingStandardsIgnoreStart
-  protected $strictConfigSchema = FALSE;
-  // @codingStandardsIgnoreEnd
-
-  /**
    * {@inheritdoc}
    */
   protected function setUp(): void {

--- a/modules/acquia_cms_image/tests/src/Functional/ImageTest.php
+++ b/modules/acquia_cms_image/tests/src/Functional/ImageTest.php
@@ -21,21 +21,6 @@ class ImageTest extends MediaTypeTestBase {
   protected static $modules = ['acquia_cms_image'];
 
   /**
-   * Disable strict config schema checks in this test.
-   *
-   * Cohesion has a lot of config schema errors, and until they are all fixed,
-   * this test cannot pass unless we disable strict config schema checking
-   * altogether. Since strict config schema isn't critically important in
-   * testing this functionality, it's okay to disable it for now, but it should
-   * be re-enabled (i.e., this property should be removed) as soon as possible.
-   *
-   * @var bool
-   */
-  // @codingStandardsIgnoreStart
-  protected $strictConfigSchema = FALSE;
-  // @codingStandardsIgnoreEnd
-
-  /**
    * {@inheritdoc}
    */
   protected $mediaType = 'image';

--- a/modules/acquia_cms_image/tests/src/FunctionalJavascript/ImageEmbedTest.php
+++ b/modules/acquia_cms_image/tests/src/FunctionalJavascript/ImageEmbedTest.php
@@ -21,21 +21,6 @@ class ImageEmbedTest extends MediaEmbedTestBase {
   protected static $modules = ['acquia_cms_common', 'acquia_cms_image', 'focal_point'];
 
   /**
-   * Disable strict config schema checks in this test.
-   *
-   * Cohesion has a lot of config schema errors, and until they are all fixed,
-   * this test cannot pass unless we disable strict config schema checking
-   * altogether. Since strict config schema isn't critically important in
-   * testing this functionality, it's okay to disable it for now, but it should
-   * be re-enabled (i.e., this property should be removed) as soon as possible.
-   *
-   * @var bool
-   */
-  // @codingStandardsIgnoreStart
-  protected $strictConfigSchema = FALSE;
-  // @codingStandardsIgnoreEnd
-
-  /**
    * {@inheritdoc}
    */
   protected $mediaType = 'image';

--- a/modules/acquia_cms_image/tests/src/Kernel/SiteLogoTest.php
+++ b/modules/acquia_cms_image/tests/src/Kernel/SiteLogoTest.php
@@ -64,21 +64,6 @@ class SiteLogoTest extends KernelTestBase {
   protected $siteLogo;
 
   /**
-   * Disable strict config schema checks in this test.
-   *
-   * There are some config schema errors, and until they are all fixed,
-   * this test cannot pass unless we disable strict config schema checking
-   * altogether. Since strict config schema isn't critically important in
-   * testing this functionality, it's okay to disable it for now, but it should
-   * be re-enabled (i.e., this property should be removed) as soon as possible.
-   *
-   * @var bool
-   */
-  // @codingStandardsIgnoreStart
-  protected $strictConfigSchema = FALSE;
-  // @codingStandardsIgnoreEnd
-
-  /**
    * {@inheritdoc}
    */
   protected function setUp(): void {

--- a/modules/acquia_cms_page/tests/src/ExistingSite/PageImageDamTest.php
+++ b/modules/acquia_cms_page/tests/src/ExistingSite/PageImageDamTest.php
@@ -19,10 +19,6 @@ class PageImageDamTest extends ExistingSiteBase {
 
   use ConfigurationTraits;
 
-  // @codingStandardsIgnoreStart
-	protected $strictConfigSchema = FALSE;
-  // @codingStandardsIgnoreEnd
-
   /**
    * {@inheritdoc}
    */

--- a/modules/acquia_cms_page/tests/src/Functional/PageTest.php
+++ b/modules/acquia_cms_page/tests/src/Functional/PageTest.php
@@ -33,21 +33,6 @@ class PageTest extends ContentTypeTestBase {
   ];
 
   /**
-   * Disable strict config schema checks in this test.
-   *
-   * Cohesion has a lot of config schema errors, and until they are all fixed,
-   * this test cannot pass unless we disable strict config schema checking
-   * altogether. Since strict config schema isn't critically important in
-   * testing this functionality, it's okay to disable it for now, but it should
-   * be re-enabled (i.e., this property should be removed) as soon as possible.
-   *
-   * @var bool
-   */
-  // @codingStandardsIgnoreStart
-  protected $strictConfigSchema = FALSE;
-  // @codingStandardsIgnoreEnd
-
-  /**
    * {@inheritdoc}
    */
   protected function doTestEditForm() : void {

--- a/modules/acquia_cms_page/tests/src/Kernel/PageWithLayoutCanvasFieldTest.php
+++ b/modules/acquia_cms_page/tests/src/Kernel/PageWithLayoutCanvasFieldTest.php
@@ -29,9 +29,6 @@ class PageWithLayoutCanvasFieldTest extends FieldKernelTestBase {
   /**
    * {@inheritdoc}
    */
-  // @codingStandardsIgnoreStart
-  protected $strictConfigSchema = FALSE;
-  // @codingStandardsIgnoreEnd
 
   /**
    * The field_config object.

--- a/modules/acquia_cms_person/tests/src/ExistingSite/PersonImageDamTest.php
+++ b/modules/acquia_cms_person/tests/src/ExistingSite/PersonImageDamTest.php
@@ -19,10 +19,6 @@ class PersonImageDamTest extends ExistingSiteBase {
 
   use ConfigurationTraits;
 
-  // @codingStandardsIgnoreStart
-  protected $strictConfigSchema = FALSE;
-  // @codingStandardsIgnoreEnd
-
   /**
    * {@inheritdoc}
    */

--- a/modules/acquia_cms_person/tests/src/Functional/PersonTest.php
+++ b/modules/acquia_cms_person/tests/src/Functional/PersonTest.php
@@ -36,21 +36,6 @@ class PersonTest extends ContentTypeTestBase {
   ];
 
   /**
-   * Disable strict config schema checks in this test.
-   *
-   * Cohesion has a lot of config schema errors, and until they are all fixed,
-   * this test cannot pass unless we disable strict config schema checking
-   * altogether. Since strict config schema isn't critically important in
-   * testing this functionality, it's okay to disable it for now, but it should
-   * be re-enabled (i.e., this property should be removed) as soon as possible.
-   *
-   * @var bool
-   */
-  // @codingStandardsIgnoreStart
-  protected $strictConfigSchema = FALSE;
-  // @codingStandardsIgnoreEnd
-
-  /**
    * {@inheritdoc}
    */
   protected function doTestEditForm() : void {

--- a/modules/acquia_cms_place/tests/src/ExistingSite/PlaceImageDamTest.php
+++ b/modules/acquia_cms_place/tests/src/ExistingSite/PlaceImageDamTest.php
@@ -19,10 +19,6 @@ class PlaceImageDamTest extends ExistingSiteBase {
 
   use ConfigurationTraits;
 
-  // @codingStandardsIgnoreStart
-  protected $strictConfigSchema = FALSE;
-  // @codingStandardsIgnoreEnd
-
   /**
    * {@inheritdoc}
    */

--- a/modules/acquia_cms_place/tests/src/Functional/PlaceTest.php
+++ b/modules/acquia_cms_place/tests/src/Functional/PlaceTest.php
@@ -38,21 +38,6 @@ class PlaceTest extends ContentTypeTestBase {
   ];
 
   /**
-   * Disable strict config schema checks in this test.
-   *
-   * Cohesion has a lot of config schema errors, and until they are all fixed,
-   * this test cannot pass unless we disable strict config schema checking
-   * altogether. Since strict config schema isn't critically important in
-   * testing this functionality, it's okay to disable it for now, but it should
-   * be re-enabled (i.e., this property should be removed) as soon as possible.
-   *
-   * @var bool
-   */
-  // @codingStandardsIgnoreStart
-  protected $strictConfigSchema = FALSE;
-  // @codingStandardsIgnoreEnd
-
-  /**
    * {@inheritdoc}
    */
   protected function doTestEditForm(): void {

--- a/modules/acquia_cms_search/tests/src/Functional/AcquiaConnectorTest.php
+++ b/modules/acquia_cms_search/tests/src/Functional/AcquiaConnectorTest.php
@@ -28,21 +28,6 @@ class AcquiaConnectorTest extends BrowserTestBase {
   ];
 
   /**
-   * Disable strict config schema checks in this test.
-   *
-   * Cohesion has a lot of config schema errors, and until they are all fixed,
-   * this test cannot pass unless we disable strict config schema checking
-   * altogether. Since strict config schema isn't critically important in
-   * testing this functionality, it's okay to disable it for now, but it should
-   * be re-enabled (i.e., this property should be removed) as soon as possible.
-   *
-   * @var bool
-   */
-  // @codingStandardsIgnoreStart
-  protected $strictConfigSchema = FALSE;
-  // @codingStandardsIgnoreEnd
-
-  /**
    * Tests the Acquia CMS Connector form.
    */
   public function testAcquiaConnector() {

--- a/modules/acquia_cms_search/tests/src/Functional/AcquiaSearchIntegrationFromTourPageTest.php
+++ b/modules/acquia_cms_search/tests/src/Functional/AcquiaSearchIntegrationFromTourPageTest.php
@@ -32,21 +32,6 @@ class AcquiaSearchIntegrationFromTourPageTest extends BrowserTestBase {
   ];
 
   /**
-   * Disable strict config schema checks in this test.
-   *
-   * Cohesion has a lot of config schema errors, and until they are all fixed,
-   * this test cannot pass unless we disable strict config schema checking
-   * altogether. Since strict config schema isn't critically important in
-   * testing this functionality, it's okay to disable it for now, but it should
-   * be re-enabled (i.e., this property should be removed) as soon as possible.
-   *
-   * @var bool
-   */
-  // @codingStandardsIgnoreStart
-  protected $strictConfigSchema = FALSE;
-  // @codingStandardsIgnoreEnd
-
-  /**
    * {@inheritdoc}
    */
   protected function setUp(): void {

--- a/modules/acquia_cms_search/tests/src/FunctionalJavascript/AcquiaFacetSearchTest.php
+++ b/modules/acquia_cms_search/tests/src/FunctionalJavascript/AcquiaFacetSearchTest.php
@@ -35,9 +35,6 @@ class AcquiaFacetSearchTest extends BrowserTestBase {
    *
    * @todo Fix config schema for fallback_view & main_listing_pages_view plugin.
    */
-  // @codingStandardsIgnoreStart
-  protected $strictConfigSchema = FALSE;
-  // @codingStandardsIgnoreEnd
 
   /**
    * The module installer object.

--- a/modules/acquia_cms_search/tests/src/Kernel/AcquiaFacetFacadeTest.php
+++ b/modules/acquia_cms_search/tests/src/Kernel/AcquiaFacetFacadeTest.php
@@ -43,9 +43,6 @@ class AcquiaFacetFacadeTest extends KernelTestBase {
    *
    * @todo Fix config schema for fallback_view & main_listing_pages_view plugin.
    */
-  // @codingStandardsIgnoreStart
-  protected $strictConfigSchema = FALSE;
-  // @codingStandardsIgnoreEnd
 
   /**
    * {@inheritdoc}

--- a/modules/acquia_cms_site_studio/tests/src/Functional/FilterFormatFilteredHtmlTest.php
+++ b/modules/acquia_cms_site_studio/tests/src/Functional/FilterFormatFilteredHtmlTest.php
@@ -25,21 +25,6 @@ class FilterFormatFilteredHtmlTest extends BrowserTestBase {
   ];
 
   /**
-   * Disable strict config schema checks in this test.
-   *
-   * Cohesion has a lot of config schema errors, and until they are all fixed,
-   * this test cannot pass unless we disable strict config schema checking
-   * altogether. Since strict config schema isn't critically important in
-   * testing this functionality, it's okay to disable it for now, but it should
-   * be re-enabled (i.e., this property should be removed) as soon as possible.
-   *
-   * @var bool
-   */
-  // @codingStandardsIgnoreStart
-  protected $strictConfigSchema = FALSE;
-  // @codingStandardsIgnoreEnd
-
-  /**
    * Tests the filter black_list_html_tags.
    */
   public function testFilterBlackListHtmlTags() {

--- a/modules/acquia_cms_site_studio/tests/src/Functional/SiteStudioCoreTest.php
+++ b/modules/acquia_cms_site_studio/tests/src/Functional/SiteStudioCoreTest.php
@@ -27,21 +27,6 @@ class SiteStudioCoreTest extends BrowserTestBase {
   ];
 
   /**
-   * Disable strict config schema checks in this test.
-   *
-   * Cohesion has a lot of config schema errors, and until they are all fixed,
-   * this test cannot pass unless we disable strict config schema checking
-   * altogether. Since strict config schema isn't critically important in
-   * testing this functionality, it's okay to disable it for now, but it should
-   * be re-enabled (i.e., this property should be removed) as soon as possible.
-   *
-   * @var bool
-   */
-  // @codingStandardsIgnoreStart
-  protected $strictConfigSchema = FALSE;
-  // @codingStandardsIgnoreEnd
-
-  /**
    * Tests the Site Studio Core Form.
    */
   public function testSiteStudioCore() {

--- a/modules/acquia_cms_site_studio/tests/src/Functional/SiteStudioPermissionsTest.php
+++ b/modules/acquia_cms_site_studio/tests/src/Functional/SiteStudioPermissionsTest.php
@@ -29,21 +29,6 @@ class SiteStudioPermissionsTest extends BrowserTestBase {
   ];
 
   /**
-   * Disable strict config schema checks in this test.
-   *
-   * Cohesion has a lot of config schema errors, and until they are all fixed,
-   * this test cannot pass unless we disable strict config schema checking
-   * altogether. Since strict config schema isn't critically important in
-   * testing this functionality, it's okay to disable it for now, but it should
-   * be re-enabled (i.e., this property should be removed) as soon as possible.
-   *
-   * @var bool
-   */
-  // @codingStandardsIgnoreStart
-  protected $strictConfigSchema = FALSE;
-  // @codingStandardsIgnoreEnd
-
-  /**
    * {@inheritdoc}
    */
   public function getFixtureBasePath(): string {

--- a/modules/acquia_cms_tour/tests/src/Functional/AcquiaGoogleMapsTest.php
+++ b/modules/acquia_cms_tour/tests/src/Functional/AcquiaGoogleMapsTest.php
@@ -28,21 +28,6 @@ class AcquiaGoogleMapsTest extends BrowserTestBase {
   ];
 
   /**
-   * Disable strict config schema checks in this test.
-   *
-   * Cohesion has a lot of config schema errors, and until they are all fixed,
-   * this test cannot pass unless we disable strict config schema checking
-   * altogether. Since strict config schema isn't critically important in
-   * testing this functionality, it's okay to disable it for now, but it should
-   * be re-enabled (i.e., this property should be removed) as soon as possible.
-   *
-   * @var bool
-   */
-  // @codingStandardsIgnoreStart
-  protected $strictConfigSchema = FALSE;
-  // @codingStandardsIgnoreEnd
-
-  /**
    * Tests that the Google Maps API key can be set on the tour page.
    */
   public function testAcquiaGoogleMaps() {

--- a/modules/acquia_cms_tour/tests/src/Functional/GoogleAnalyticsTest.php
+++ b/modules/acquia_cms_tour/tests/src/Functional/GoogleAnalyticsTest.php
@@ -26,21 +26,6 @@ class GoogleAnalyticsTest extends BrowserTestBase {
   ];
 
   /**
-   * Disable strict config schema checks in this test.
-   *
-   * Cohesion has a lot of config schema errors, and until they are all fixed,
-   * this test cannot pass unless we disable strict config schema checking
-   * altogether. Since strict config schema isn't critically important in
-   * testing this functionality, it's okay to disable it for now, but it should
-   * be re-enabled (i.e., this property should be removed) as soon as possible.
-   *
-   * @var bool
-   */
-  // @codingStandardsIgnoreStart
-  protected $strictConfigSchema = FALSE;
-  // @codingStandardsIgnoreEnd
-
-  /**
    * Tests the Google Analytics Form.
    */
   public function testGoogleAnalytics() {

--- a/modules/acquia_cms_tour/tests/src/Functional/GoogleTagManager.php
+++ b/modules/acquia_cms_tour/tests/src/Functional/GoogleTagManager.php
@@ -26,21 +26,6 @@ class GoogleTagManager extends BrowserTestBase {
   ];
 
   /**
-   * Disable strict config schema checks in this test.
-   *
-   * Cohesion has a lot of config schema errors, and until they are all fixed,
-   * this test cannot pass unless we disable strict config schema checking
-   * altogether. Since strict config schema isn't critically important in
-   * testing this functionality, it's okay to disable it for now, but it should
-   * be re-enabled (i.e., this property should be removed) as soon as possible.
-   *
-   * @var bool
-   */
-  // @codingStandardsIgnoreStart
-  protected $strictConfigSchema = FALSE;
-  // @codingStandardsIgnoreEnd
-
-  /**
    * Tests the Google Tag Manager Form.
    */
   public function testGoogleTagManager() {

--- a/modules/acquia_cms_tour/tests/src/Functional/RecaptchaTest.php
+++ b/modules/acquia_cms_tour/tests/src/Functional/RecaptchaTest.php
@@ -26,21 +26,6 @@ class RecaptchaTest extends BrowserTestBase {
   ];
 
   /**
-   * Disable strict config schema checks in this test.
-   *
-   * Cohesion has a lot of config schema errors, and until they are all fixed,
-   * this test cannot pass unless we disable strict config schema checking
-   * altogether. Since strict config schema isn't critically important in
-   * testing this functionality, it's okay to disable it for now, but it should
-   * be re-enabled (i.e., this property should be removed) as soon as possible.
-   *
-   * @var bool
-   */
-  // @codingStandardsIgnoreStart
-  protected $strictConfigSchema = FALSE;
-  // @codingStandardsIgnoreEnd
-
-  /**
    * Tests the Recaptcha Form.
    */
   public function testRecaptcha() {

--- a/modules/acquia_cms_tour/tests/src/Kernel/AcquiaTourDashboardTest.php
+++ b/modules/acquia_cms_tour/tests/src/Kernel/AcquiaTourDashboardTest.php
@@ -23,21 +23,6 @@ class AcquiaTourDashboardTest extends KernelTestBase {
   ];
 
   /**
-   * Disable strict config schema checks in this test.
-   *
-   * Cohesion has a lot of config schema errors, and until they are all fixed,
-   * this test cannot pass unless we disable strict config schema checking
-   * altogether. Since strict config schema isn't critically important in
-   * testing this functionality, it's okay to disable it for now, but it should
-   * be re-enabled (i.e., this property should be removed) as soon as possible.
-   *
-   * @var bool
-   */
-  // @codingStandardsIgnoreStart
-  protected $strictConfigSchema = FALSE;
-  // @codingStandardsIgnoreEnd
-
-  /**
    * Tests AcquiaCMSTour plugins and make sure they are sorted per weights.
    */
   public function testAcquiaCmsTourPlugin() {

--- a/modules/acquia_cms_video/tests/src/Functional/VideoTest.php
+++ b/modules/acquia_cms_video/tests/src/Functional/VideoTest.php
@@ -23,21 +23,6 @@ class VideoTest extends MediaTypeTestBase {
   protected static $modules = ['acquia_cms_video'];
 
   /**
-   * Disable strict config schema checks in this test.
-   *
-   * Cohesion has a lot of config schema errors, and until they are all fixed,
-   * this test cannot pass unless we disable strict config schema checking
-   * altogether. Since strict config schema isn't critically important in
-   * testing this functionality, it's okay to disable it for now, but it should
-   * be re-enabled (i.e., this property should be removed) as soon as possible.
-   *
-   * @var bool
-   */
-  // @codingStandardsIgnoreStart
-  protected $strictConfigSchema = FALSE;
-  // @codingStandardsIgnoreEnd
-
-  /**
    * {@inheritdoc}
    */
   protected $mediaType = 'video';

--- a/modules/acquia_cms_video/tests/src/FunctionalJavascript/VideoEmbedTest.php
+++ b/modules/acquia_cms_video/tests/src/FunctionalJavascript/VideoEmbedTest.php
@@ -21,21 +21,6 @@ class VideoEmbedTest extends MediaEmbedTestBase {
   protected static $modules = ['acquia_cms_video'];
 
   /**
-   * Disable strict config schema checks in this test.
-   *
-   * Cohesion has a lot of config schema errors, and until they are all fixed,
-   * this test cannot pass unless we disable strict config schema checking
-   * altogether. Since strict config schema isn't critically important in
-   * testing this functionality, it's okay to disable it for now, but it should
-   * be re-enabled (i.e., this property should be removed) as soon as possible.
-   *
-   * @var bool
-   */
-  // @codingStandardsIgnoreStart
-  protected $strictConfigSchema = FALSE;
-  // @codingStandardsIgnoreEnd
-
-  /**
    * {@inheritdoc}
    */
   protected $mediaType = 'video';


### PR DESCRIPTION
**Motivation**
Allow strictConfigSchema in tests.

**Proposed changes**
Remove strictConfigSchema check set to false in tests.

**Alternatives considered**
NA

**Testing steps**
<!-- How can we replicate the issue and verify that this PR fixes it? -->

**Merge requirements**
- [ ] _Major change_, _Minor change_, _Bug_, _Enhancement_, and/or _Chore_ label applied
- [ ] Manual testing by a reviewer
