### PR TITLE
ACMS-4015: The Acquia CMS Search module is causing fatal error on Drupal Core 10.3.x

### DIFF
--- a/modules/acquia_cms_headless/src/Plugin/AcquiaCmsTour/AcquiaHeadlessForm.php
+++ b/modules/acquia_cms_headless/src/Plugin/AcquiaCmsTour/AcquiaHeadlessForm.php
@@ -173,9 +173,8 @@ class AcquiaHeadlessForm extends AcquiaCmsDashboardBase {
         ],
         'code-css',
       ];
-
-      return $form;
     }
+    return $form;
   }
 
   /**

--- a/modules/acquia_cms_person/config/optional/views.view.people.yml
+++ b/modules/acquia_cms_person/config/optional/views.view.people.yml
@@ -355,7 +355,7 @@ display:
       display_extenders: {  }
       path: people
     cache_metadata:
-      max-age: -1
+      max-age: 0
       contexts:
         - 'languages:language_content'
         - 'languages:language_interface'

--- a/modules/acquia_cms_search/src/Plugin/AcquiaCmsTour/AcquiaConnectorForm.php
+++ b/modules/acquia_cms_search/src/Plugin/AcquiaCmsTour/AcquiaConnectorForm.php
@@ -135,9 +135,8 @@ class AcquiaConnectorForm extends AcquiaCmsDashboardBase {
           '#suffix' => "</span></div>",
         ];
       }
-
-      return $form;
     }
+    return $form;
   }
 
   /**

--- a/modules/acquia_cms_search/src/Plugin/AcquiaCmsTour/AcquiaSearchForm.php
+++ b/modules/acquia_cms_search/src/Plugin/AcquiaCmsTour/AcquiaSearchForm.php
@@ -119,8 +119,8 @@ class AcquiaSearchForm extends AcquiaCmsDashboardBase {
         '#markup' => $this->t("Opens Advance Configuration in new tab"),
         '#suffix' => "</span></div>",
       ];
-      return $form;
     }
+    return $form;
   }
 
   /**

--- a/modules/acquia_cms_site_studio/src/Plugin/AcquiaCmsTour/SiteStudioCoreForm.php
+++ b/modules/acquia_cms_site_studio/src/Plugin/AcquiaCmsTour/SiteStudioCoreForm.php
@@ -108,9 +108,8 @@ class SiteStudioCoreForm extends AcquiaCmsDashboardBase {
         '#markup' => $this->t("Opens Advance Configuration in new tab"),
         '#suffix' => "</span></div>",
       ];
-
-      return $form;
     }
+    return $form;
   }
 
   /**

--- a/modules/acquia_cms_tour/src/Plugin/AcquiaCmsTour/GoogleAnalyticsForm.php
+++ b/modules/acquia_cms_tour/src/Plugin/AcquiaCmsTour/GoogleAnalyticsForm.php
@@ -103,8 +103,8 @@ class GoogleAnalyticsForm extends AcquiaCmsDashboardBase {
           '#suffix' => "</span></div>",
         ];
       }
-      return $form;
     }
+    return $form;
   }
 
   /**

--- a/modules/acquia_cms_tour/src/Plugin/AcquiaCmsTour/GoogleMapsApiForm.php
+++ b/modules/acquia_cms_tour/src/Plugin/AcquiaCmsTour/GoogleMapsApiForm.php
@@ -134,9 +134,8 @@ class GoogleMapsApiForm extends AcquiaCmsDashboardBase {
         '#markup' => $this->t("Opens Advance Configuration in new tab"),
         '#suffix' => "</span></div>",
       ];
-
-      return $form;
     }
+    return $form;
   }
 
   /**


### PR DESCRIPTION
**Motivation**
<!-- What problem does this solve? Why is it important? What's the context? If this fixes an issue, link to it above. -->
Fixes #ACMS-4015
Allow facets to bypass the creation mentioned [here](https://git.drupalcode.org/project/facets/-/blob/3.0.x/src/Entity/Facet.php?ref_type=heads#L1126) with core:10.3 as well and will update all factes configurations later
```
// Register newly created facet within its source, for the caching.
      if (($source = $this->getFacetSource()) && $source->getCacheMaxAge() !== 0) {
        $source->registerFacet($this);
      }

```
**Proposed changes**
<!-- What does this PR change? How does this impact end users? Are manual or automatic updates required? -->

**Alternatives considered**
<!-- How else could the original issue / use case be addressed? Why did you choose this solution over any others? -->

**Testing steps**
<!-- How can we replicate the issue and verify that this PR fixes it? -->

**Merge requirements**
- [ ] _Major change_, _Minor change_, _Bug_, _Enhancement_, and/or _Chore_ label applied
- [ ] Manual testing by a reviewer
