### PR TITLE
ACMS-4190: Removing patch of subrequests.

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -2586,7 +2586,7 @@
             "dist": {
                 "type": "path",
                 "url": "./modules/acquia_cms_headless",
-                "reference": "e50aec991cf7edc162ec6bdc08372e7431804c0a"
+                "reference": "0ffd629d6b7a45f6ca8a907dd6d5bc59b83eeabb"
             },
             "require": {
                 "drupal/acquia_cms_tour": "^2.1.8",
@@ -2646,9 +2646,6 @@
                 "patches": {
                     "drupal/decoupled_router": {
                         "3111456 - Unable to resolve path on node in other language than default": "https://www.drupal.org/files/issues/2024-07-11/decouple_router-3111456-resolve-language-issue-63--get-translation-re-rolled.patch"
-                    },
-                    "drupal/subrequests": {
-                        "3049395 - Page Cache causes different subrequests to return the same responses": "https://www.drupal.org/files/issues/2019-07-18/change_request_type-63049395-09.patch"
                     }
                 }
             },
@@ -21708,5 +21705,5 @@
     "prefer-lowest": false,
     "platform": [],
     "platform-dev": [],
-    "plugin-api-version": "2.6.0"
+    "plugin-api-version": "2.3.0"
 }

--- a/modules/acquia_cms_headless/composer.json
+++ b/modules/acquia_cms_headless/composer.json
@@ -82,9 +82,6 @@
         "patches": {
             "drupal/decoupled_router": {
                 "3111456 - Unable to resolve path on node in other language than default": "https://www.drupal.org/files/issues/2024-07-11/decouple_router-3111456-resolve-language-issue-63--get-translation-re-rolled.patch"
-            },
-            "drupal/subrequests": {
-                "3049395 - Page Cache causes different subrequests to return the same responses": "https://www.drupal.org/files/issues/2019-07-18/change_request_type-63049395-09.patch"
             }
         }
     }


### PR DESCRIPTION
**Motivation**
<!-- What problem does this solve? Why is it important? What's the context? If this fixes an issue, link to it above. -->
Fixes ACMS-4190

**Proposed changes**
Subrequest patch removed as per new release of subrequest

