### PR TITLE
ACMS-4229: Update google_tag form on tour dashboard.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -263,6 +263,7 @@
             "php-http/discovery": true,
             "phpro/grumphp-shim": true,
             "phpstan/extension-installer": true,
+            "tbachert/spi": true,
             "webdriver-binary/binary-chromedriver": true,
             "wikimedia/composer-merge-plugin": true
         },

--- a/composer.lock
+++ b/composer.lock
@@ -2323,7 +2323,7 @@
             "dist": {
                 "type": "path",
                 "url": "./modules/acquia_cms_common",
-                "reference": "2e9464aa5f9e5f0be09e1726c3276319be0b8c5e"
+                "reference": "36ebfe06447b4f28301a18995d197336fb6ce1f3"
             },
             "require": {
                 "acquia/drupal-environment-detector": "^1.5",
@@ -2777,7 +2777,7 @@
             "dist": {
                 "type": "path",
                 "url": "./modules/acquia_cms_toolbar",
-                "reference": "1b719afab9745ba4f3d212a025cc9d9486d6a0e8"
+                "reference": "0cc6f26997c253705d6d7087a8878f7e690a29a0"
             },
             "require": {
                 "drupal/acquia_cms_common": "^1.9 || ^2.1 || ^3.1",

--- a/modules/acquia_cms_common/composer.json
+++ b/modules/acquia_cms_common/composer.json
@@ -35,8 +35,8 @@
     "require-dev": {
         "acquia/cohesion": "^7.4 || ^8.0",
         "drupal/acquia_claro": "^1.3",
-        "drupal/node_revision_delete":"^2",
-        "drupal/reroute_email":"^2.2",
+        "drupal/node_revision_delete": "^2",
+        "drupal/reroute_email": "^2.2",
         "drupal/shield": "^1.7"
     },
     "conflict": {

--- a/modules/acquia_cms_toolbar/composer.json
+++ b/modules/acquia_cms_toolbar/composer.json
@@ -7,6 +7,9 @@
         "drupal/acquia_cms_common": "^1.9 || ^2.1 || ^3.1",
         "drupal/admin_toolbar": "^3.3"
     },
+    "conflict": {
+        "drupal/acquia_claro": "<1.4"
+    },
     "repositories": {
         "assets": {
             "type": "composer",
@@ -16,9 +19,6 @@
             "type": "composer",
             "url": "https://packages.drupal.org/8"
         }
-    },
-    "conflict": {
-        "drupal/acquia_claro": "<1.4"
     },
     "config": {
         "allow-plugins": {

--- a/modules/acquia_cms_tour/css/acquia_cms_tour_dashboard.css
+++ b/modules/acquia_cms_tour/css/acquia_cms_tour_dashboard.css
@@ -73,6 +73,14 @@
 .acms-dashboard-form-wrapper  .js-form-wrapper {
   border: 1px solid #808080;
 }
+.acms-dashboard-form-wrapper  .js-form-wrapper .js-form-wrapper {
+  border: 0px;
+  padding: 0;
+  margin: 0;
+}
+.acms-dashboard-form-wrapper  .js-form-wrapper .js-form-wrapper .fieldset__wrapper{
+  margin-left: 0;
+}
 .section-top {
   display: flex;
   align-items: center;

--- a/modules/acquia_cms_tour/src/Plugin/AcquiaCmsTour/GoogleTagManagerForm.php
+++ b/modules/acquia_cms_tour/src/Plugin/AcquiaCmsTour/GoogleTagManagerForm.php
@@ -261,7 +261,7 @@ class GoogleTagManagerForm extends AcquiaCmsDashboardBase {
    * {@inheritdoc}
    */
   public function checkMinConfiguration(): bool {
-    $uri = $this->config('google_tag.settings')->get('uri');
+    $uri = $this->config('google_tag.settings')->get('default_google_tag_entity');
     return (bool) $uri;
   }
 

--- a/modules/acquia_cms_tour/src/Plugin/AcquiaCmsTour/GoogleTagManagerForm.php
+++ b/modules/acquia_cms_tour/src/Plugin/AcquiaCmsTour/GoogleTagManagerForm.php
@@ -69,7 +69,9 @@ class GoogleTagManagerForm extends AcquiaCmsDashboardBase {
       $account_default_value = $this->config('google_tag.settings')->get('default_google_tag_entity');
       $form[$module]['accounts_wrapper'] = [
         '#type' => 'fieldset',
-        '#prefix' => '<div class="dashboard-fields-wrapper remove-fieldset-boundary" id="' . $accounts_wrapper_id . '">',
+        '#prefix' => '<div class="dashboard-fields-wrapper remove-fieldset-boundary" id="' . $accounts_wrapper_id . '">
+        Effortlessly configure and manage Google Tag Manager containers to
+        seamlessly track application insights.',
         '#suffix' => '</div>',
       ];
       // Filter order (tabledrag).

--- a/modules/acquia_cms_tour/src/Plugin/AcquiaCmsTour/GoogleTagManagerForm.php
+++ b/modules/acquia_cms_tour/src/Plugin/AcquiaCmsTour/GoogleTagManagerForm.php
@@ -92,9 +92,11 @@ class GoogleTagManagerForm extends AcquiaCmsDashboardBase {
       if ($accounts === []) {
         $config_name = 'google_tag.container.'. $account_default_value;
         $entity_accounts = $this->config($config_name)->get('tag_container_ids');
-        foreach ($entity_accounts as $index => $account) {
-          $accounts[$index]['value'] = $account;
-          $accounts[$index]['weight'] = $index;
+        if ($entity_accounts){
+          foreach ($entity_accounts as $index => $account) {
+            $accounts[$index]['value'] = $account;
+            $accounts[$index]['weight'] = $index;
+          }
         }
         // Default fallback.
         if (count($accounts) === 0) {

--- a/modules/acquia_cms_tour/src/Plugin/AcquiaCmsTour/GoogleTagManagerForm.php
+++ b/modules/acquia_cms_tour/src/Plugin/AcquiaCmsTour/GoogleTagManagerForm.php
@@ -90,7 +90,7 @@ class GoogleTagManagerForm extends AcquiaCmsDashboardBase {
 
       $accounts = $form_state->getValue('accounts', []);
       if ($accounts === []) {
-        $config_name = 'google_tag.container.'. $account_default_value;
+        $config_name = 'google_tag.container.' . $account_default_value;
         $entity_accounts = $this->config($config_name)->get('tag_container_ids');
         if ($entity_accounts){
           foreach ($entity_accounts as $index => $account) {
@@ -211,7 +211,7 @@ class GoogleTagManagerForm extends AcquiaCmsDashboardBase {
     $tag_container_ids = [];
     $default_id = '';
     $account_default_value = $this->config('google_tag.settings')->get('default_google_tag_entity');
-    $config_name = 'google_tag.container.'. $account_default_value;
+    $config_name = 'google_tag.container.' . $account_default_value;
     foreach ($form_state->getValue('accounts') as $account) {
       if (!$default_id) {
         $default_id = $account['value'];

--- a/modules/acquia_cms_tour/tests/src/Functional/GoogleTagManager.php
+++ b/modules/acquia_cms_tour/tests/src/Functional/GoogleTagManager.php
@@ -56,13 +56,13 @@ class GoogleTagManager extends BrowserTestBase {
     // Assert that save and advanced buttons are present on form.
     $assert_session->buttonExists('Save');
     // Save Snippet parent URI.
-    $dummy_tag = 'GTM-000000';
+    $dummy_tag = 'GT-XXXXXXXXX';
     $container->fillField('edit-accounts-0-value', $dummy_tag);
     $container->pressButton('Save');
     $assert_session->pageTextContains('The configuration options have been saved.');
     // Test that the config values we expect are set correctly.
-    $google_tag_uri = $this->config('google_tag.settings')->get('uri');
-    $this->assertSame($google_tag_uri, $dummy_tag);
+    $tag_id = $this->config($this->config('google_tag.settings')->get('default_google_tag_entity'))->get('tag_container_ids');
+    $this->assertEquals($tag_id, [$dummy_tag]);
   }
 
 }

--- a/modules/acquia_cms_tour/tests/src/Functional/GoogleTagManager.php
+++ b/modules/acquia_cms_tour/tests/src/Functional/GoogleTagManager.php
@@ -55,16 +55,14 @@ class GoogleTagManager extends BrowserTestBase {
     $container = $assert_session->elementExists('css', '.acquia-cms-google-tag-manager-form');
     // Assert that save and advanced buttons are present on form.
     $assert_session->buttonExists('Save');
-    // Assert that the expected fields show up.
-    $assert_session->fieldExists('Snippet parent URI');
     // Save Snippet parent URI.
-    $dummy_uri = 'public://tempdir';
-    $container->fillField('edit-snippet-parent-uri', $dummy_uri);
+    $dummy_tag = 'GTM-000000';
+    $container->fillField('edit-accounts-0-value', $dummy_tag);
     $container->pressButton('Save');
     $assert_session->pageTextContains('The configuration options have been saved.');
     // Test that the config values we expect are set correctly.
     $google_tag_uri = $this->config('google_tag.settings')->get('uri');
-    $this->assertSame($google_tag_uri, $dummy_uri);
+    $this->assertSame($google_tag_uri, $dummy_tag);
   }
 
 }


### PR DESCRIPTION
**Motivation**
<!-- What problem does this solve? Why is it important? What's the context? If this fixes an issue, link to it above. -->
Fixes #ACMS-4229

**Proposed changes**
introduction of form from google_tag module which includes usage of google tag id now.

**Testing steps**
install site using this branch and run drush site:install and enable acquia_cms_tour
visit page /admin/tour/dashboard and check section google tag


