### PR TITLE
ACMS-4288: Fix GitLab CI pipelines of Drupal Starter Kit Modules.

### DIFF
--- a/modules/acquia_cms_article/.gitlab-ci.yml
+++ b/modules/acquia_cms_article/.gitlab-ci.yml
@@ -16,5 +16,5 @@ variables:
   ORCA_PACKAGES_CONFIG_ALTER: $CI_PROJECT_DIR/tests/packages_alter.yml
 
   # Coverage report
-  ORCA_SUT_DIR: "$CI_PROJECT_DIR/../acquia_cms_common"
+  ORCA_SUT_DIR: "$CI_PROJECT_DIR/../acquia_cms_article"
   ORCA_JUNIT_LOG: "$CI_PROJECT_DIR/var/logs/junit.xml"

--- a/modules/acquia_cms_audio/.gitlab-ci.yml
+++ b/modules/acquia_cms_audio/.gitlab-ci.yml
@@ -16,5 +16,5 @@ variables:
   ORCA_PACKAGES_CONFIG_ALTER: $CI_PROJECT_DIR/tests/packages_alter.yml
 
   # Coverage report
-  ORCA_SUT_DIR: "$CI_PROJECT_DIR/../acquia_cms_common"
+  ORCA_SUT_DIR: "$CI_PROJECT_DIR/../acquia_cms_audio"
   ORCA_JUNIT_LOG: "$CI_PROJECT_DIR/var/logs/junit.xml"

--- a/modules/acquia_cms_component/.gitlab-ci.yml
+++ b/modules/acquia_cms_component/.gitlab-ci.yml
@@ -16,5 +16,5 @@ variables:
   ORCA_PACKAGES_CONFIG_ALTER: $CI_PROJECT_DIR/tests/packages_alter.yml
 
   # Coverage report
-  ORCA_SUT_DIR: "$CI_PROJECT_DIR/../acquia_cms_common"
+  ORCA_SUT_DIR: "$CI_PROJECT_DIR/../acquia_cms_component"
   ORCA_JUNIT_LOG: "$CI_PROJECT_DIR/var/logs/junit.xml"

--- a/modules/acquia_cms_dam/.gitlab-ci.yml
+++ b/modules/acquia_cms_dam/.gitlab-ci.yml
@@ -16,5 +16,5 @@ variables:
   ORCA_PACKAGES_CONFIG_ALTER: $CI_PROJECT_DIR/tests/packages_alter.yml
 
   # Coverage report
-  ORCA_SUT_DIR: "$CI_PROJECT_DIR/../acquia_cms_common"
+  ORCA_SUT_DIR: "$CI_PROJECT_DIR/../acquia_cms_dam"
   ORCA_JUNIT_LOG: "$CI_PROJECT_DIR/var/logs/junit.xml"

--- a/modules/acquia_cms_document/.gitlab-ci.yml
+++ b/modules/acquia_cms_document/.gitlab-ci.yml
@@ -16,5 +16,5 @@ variables:
   ORCA_PACKAGES_CONFIG_ALTER: $CI_PROJECT_DIR/tests/packages_alter.yml
 
   # Coverage report
-  ORCA_SUT_DIR: "$CI_PROJECT_DIR/../acquia_cms_common"
+  ORCA_SUT_DIR: "$CI_PROJECT_DIR/../acquia_cms_document"
   ORCA_JUNIT_LOG: "$CI_PROJECT_DIR/var/logs/junit.xml"

--- a/modules/acquia_cms_event/.gitlab-ci.yml
+++ b/modules/acquia_cms_event/.gitlab-ci.yml
@@ -16,5 +16,5 @@ variables:
   ORCA_PACKAGES_CONFIG_ALTER: $CI_PROJECT_DIR/tests/packages_alter.yml
 
   # Coverage report
-  ORCA_SUT_DIR: "$CI_PROJECT_DIR/../acquia_cms_common"
+  ORCA_SUT_DIR: "$CI_PROJECT_DIR/../acquia_cms_event"
   ORCA_JUNIT_LOG: "$CI_PROJECT_DIR/var/logs/junit.xml"

--- a/modules/acquia_cms_headless/.gitlab-ci.yml
+++ b/modules/acquia_cms_headless/.gitlab-ci.yml
@@ -16,7 +16,7 @@ variables:
   ORCA_PACKAGES_CONFIG_ALTER: $CI_PROJECT_DIR/tests/packages_alter.yml
 
   # Coverage report
-  ORCA_SUT_DIR: "$CI_PROJECT_DIR/../acquia_cms_common"
+  ORCA_SUT_DIR: "$CI_PROJECT_DIR/../acquia_cms_headless"
   ORCA_JUNIT_LOG: "$CI_PROJECT_DIR/var/logs/junit.xml"
 
   COMPOSER_PATCHES_FILE: $CI_PROJECT_DIR/.gitlab-ci/patches/patches.json

--- a/modules/acquia_cms_image/.gitlab-ci.yml
+++ b/modules/acquia_cms_image/.gitlab-ci.yml
@@ -16,5 +16,5 @@ variables:
   ORCA_PACKAGES_CONFIG_ALTER: $CI_PROJECT_DIR/tests/packages_alter.yml
 
   # Coverage report
-  ORCA_SUT_DIR: "$CI_PROJECT_DIR/../acquia_cms_common"
+  ORCA_SUT_DIR: "$CI_PROJECT_DIR/../acquia_cms_image"
   ORCA_JUNIT_LOG: "$CI_PROJECT_DIR/var/logs/junit.xml"

--- a/modules/acquia_cms_page/.gitlab-ci.yml
+++ b/modules/acquia_cms_page/.gitlab-ci.yml
@@ -16,5 +16,5 @@ variables:
   ORCA_PACKAGES_CONFIG_ALTER: $CI_PROJECT_DIR/tests/packages_alter.yml
 
   # Coverage report
-  ORCA_SUT_DIR: "$CI_PROJECT_DIR/../acquia_cms_common"
+  ORCA_SUT_DIR: "$CI_PROJECT_DIR/../acquia_cms_page"
   ORCA_JUNIT_LOG: "$CI_PROJECT_DIR/var/logs/junit.xml"

--- a/modules/acquia_cms_person/.gitlab-ci.yml
+++ b/modules/acquia_cms_person/.gitlab-ci.yml
@@ -16,5 +16,5 @@ variables:
   ORCA_PACKAGES_CONFIG_ALTER: $CI_PROJECT_DIR/tests/packages_alter.yml
 
   # Coverage report
-  ORCA_SUT_DIR: "$CI_PROJECT_DIR/../acquia_cms_common"
+  ORCA_SUT_DIR: "$CI_PROJECT_DIR/../acquia_cms_person"
   ORCA_JUNIT_LOG: "$CI_PROJECT_DIR/var/logs/junit.xml"

--- a/modules/acquia_cms_place/.gitlab-ci.yml
+++ b/modules/acquia_cms_place/.gitlab-ci.yml
@@ -16,5 +16,5 @@ variables:
   ORCA_PACKAGES_CONFIG_ALTER: $CI_PROJECT_DIR/tests/packages_alter.yml
 
   # Coverage report
-  ORCA_SUT_DIR: "$CI_PROJECT_DIR/../acquia_cms_common"
+  ORCA_SUT_DIR: "$CI_PROJECT_DIR/../acquia_cms_place"
   ORCA_JUNIT_LOG: "$CI_PROJECT_DIR/var/logs/junit.xml"

--- a/modules/acquia_cms_search/.gitlab-ci.yml
+++ b/modules/acquia_cms_search/.gitlab-ci.yml
@@ -16,7 +16,7 @@ variables:
   ORCA_PACKAGES_CONFIG_ALTER: $CI_PROJECT_DIR/tests/packages_alter.yml
 
   # Coverage report
-  ORCA_SUT_DIR: "$CI_PROJECT_DIR/../acquia_cms_common"
+  ORCA_SUT_DIR: "$CI_PROJECT_DIR/../acquia_cms_search"
   ORCA_JUNIT_LOG: "$CI_PROJECT_DIR/var/logs/junit.xml"
 
   # The 1.6.x release of Acquia CMS Search  doesn't support Drupal 9.5.x.

--- a/modules/acquia_cms_site_studio/.gitlab-ci.yml
+++ b/modules/acquia_cms_site_studio/.gitlab-ci.yml
@@ -17,7 +17,7 @@ variables:
   COMPOSER_PATCHES_FILE: $CI_PROJECT_DIR/.gitlab-ci/patches/patches.json
 
   # Coverage report
-  ORCA_SUT_DIR: "$CI_PROJECT_DIR/../acquia_cms_common"
+  ORCA_SUT_DIR: "$CI_PROJECT_DIR/../acquia_cms_site_studio"
   ORCA_JUNIT_LOG: "$CI_PROJECT_DIR/var/logs/junit.xml"
 
   # Site Studio 8.0.x doesn't support 9.5.x, hence skipping 9.5.x CI jobs now

--- a/modules/acquia_cms_starter/.gitlab-ci.yml
+++ b/modules/acquia_cms_starter/.gitlab-ci.yml
@@ -16,5 +16,5 @@ variables:
   ORCA_PACKAGES_CONFIG_ALTER: $CI_PROJECT_DIR/tests/packages_alter.yml
 
   # Coverage report
-  ORCA_SUT_DIR: "$CI_PROJECT_DIR/../acquia_cms_common"
+  ORCA_SUT_DIR: "$CI_PROJECT_DIR/../acquia_cms_starter"
   ORCA_JUNIT_LOG: "$CI_PROJECT_DIR/var/logs/junit.xml"

--- a/modules/acquia_cms_toolbar/.gitlab-ci.yml
+++ b/modules/acquia_cms_toolbar/.gitlab-ci.yml
@@ -16,5 +16,5 @@ variables:
   ORCA_PACKAGES_CONFIG_ALTER: $CI_PROJECT_DIR/tests/packages_alter.yml
 
   # Coverage report
-  ORCA_SUT_DIR: "$CI_PROJECT_DIR/../acquia_cms_common"
+  ORCA_SUT_DIR: "$CI_PROJECT_DIR/../acquia_cms_toolbar"
   ORCA_JUNIT_LOG: "$CI_PROJECT_DIR/var/logs/junit.xml"

--- a/modules/acquia_cms_tour/.gitlab-ci.yml
+++ b/modules/acquia_cms_tour/.gitlab-ci.yml
@@ -16,5 +16,5 @@ variables:
   ORCA_PACKAGES_CONFIG_ALTER: $CI_PROJECT_DIR/tests/packages_alter.yml
 
   # Coverage report
-  ORCA_SUT_DIR: "$CI_PROJECT_DIR/../acquia_cms_common"
+  ORCA_SUT_DIR: "$CI_PROJECT_DIR/../acquia_cms_tour"
   ORCA_JUNIT_LOG: "$CI_PROJECT_DIR/var/logs/junit.xml"

--- a/modules/acquia_cms_video/.gitlab-ci.yml
+++ b/modules/acquia_cms_video/.gitlab-ci.yml
@@ -16,5 +16,5 @@ variables:
   ORCA_PACKAGES_CONFIG_ALTER: $CI_PROJECT_DIR/tests/packages_alter.yml
 
   # Coverage report
-  ORCA_SUT_DIR: "$CI_PROJECT_DIR/../acquia_cms_common"
+  ORCA_SUT_DIR: "$CI_PROJECT_DIR/../acquia_cms_video"
   ORCA_JUNIT_LOG: "$CI_PROJECT_DIR/var/logs/junit.xml"


### PR DESCRIPTION
**Motivation**
Fixes #ACMS-4288

**Proposed changes**
ACMS-4288: Fix GitLab CI pipelines of Drupal Starter Kit Modules.

**Alternatives considered**
NA

**Testing steps**
Verify CI on project page.

**Merge requirements**
- [ ] _Major change_, _Minor change_, _Bug_, _Enhancement_, and/or _Chore_ label applied
- [ ] Manual testing by a reviewer
