### PR TITLE
ACMS-4497: Upgrade support for Autologout module in acquia_cms_common.

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -2396,7 +2396,7 @@
                 "drupal/acquia_connector": "^4.0",
                 "drupal/acquia_purge": "^1.3",
                 "drupal/acquia_search": "^3.1",
-                "drupal/autologout": "^1.4",
+                "drupal/autologout": "^1.4 || ^2",
                 "drupal/config_ignore": "^3.0@beta",
                 "drupal/config_rewrite": "^1.5",
                 "drupal/core": "^10.2.2 || ^11",

--- a/composer.lock
+++ b/composer.lock
@@ -2396,7 +2396,7 @@
                 "drupal/acquia_connector": "^4.0",
                 "drupal/acquia_purge": "^1.3",
                 "drupal/acquia_search": "^3.1",
-                "drupal/autologout": "^1.4 || ^2",
+                "drupal/autologout": ">=1",
                 "drupal/config_ignore": "^3.0@beta",
                 "drupal/config_rewrite": "^1.5",
                 "drupal/core": "^10.2.2 || ^11",

--- a/modules/acquia_cms_common/composer.json
+++ b/modules/acquia_cms_common/composer.json
@@ -9,7 +9,7 @@
         "drupal/acquia_connector": "^4.0",
         "drupal/acquia_purge": "^1.3",
         "drupal/acquia_search": "^3.1",
-        "drupal/autologout": "^1.4",
+        "drupal/autologout": "^1.4 || ^2",
         "drupal/config_ignore": "^3.0@beta",
         "drupal/config_rewrite": "^1.5",
         "drupal/core": "^10.2.2 || ^11",

--- a/modules/acquia_cms_common/composer.json
+++ b/modules/acquia_cms_common/composer.json
@@ -9,7 +9,7 @@
         "drupal/acquia_connector": "^4.0",
         "drupal/acquia_purge": "^1.3",
         "drupal/acquia_search": "^3.1",
-        "drupal/autologout": "^1.4 || ^2",
+        "drupal/autologout": ">=1",
         "drupal/config_ignore": "^3.0@beta",
         "drupal/config_rewrite": "^1.5",
         "drupal/core": "^10.2.2 || ^11",


### PR DESCRIPTION
This pull request updates the version constraint for the `drupal/autologout` dependency in the `composer.json` file of the `acquia_cms_common` module. The change ensures compatibility with both version 1 and version 2 of the dependency.

Dependency updates:

* [`modules/acquia_cms_common/composer.json`](diffhunk://#diff-23e1fe87680badf5f17710c96b8c12298ab8276162fb40fb74fb937897c17925L12-R12): Updated the `drupal/autologout` dependency version constraint from `^1.4` to `^1.4 || ^2` to allow compatibility with version 2.