### PR TITLE
`COMMIT REMOVED` Revert "ACMS-4373: Make Acquia CMS Toolbar and Tour work independent."

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -2866,10 +2866,10 @@
             "dist": {
                 "type": "path",
                 "url": "./modules/acquia_cms_toolbar",
-                "reference": "be6fe88d08fdf50135d62a79fc3217b69bc6aa6b"
+                "reference": "0cc6f26997c253705d6d7087a8878f7e690a29a0"
             },
             "require": {
-                "acquia/drupal-environment-detector": "^1.5",
+                "drupal/acquia_cms_common": "^1.9 || ^2.1 || ^3.1",
                 "drupal/admin_toolbar": "^3.3"
             },
             "conflict": {
@@ -2898,13 +2898,12 @@
                 "reference": "2dc8408687738551fc43e34939381eca3d905c56"
             },
             "require": {
+                "drupal/acquia_cms_common": "^1.9 || ^2.1 || ^3.1",
                 "drupal/checklistapi": "^2.1"
             },
             "require-dev": {
-                "drupal/geocoder": "^3.35 || ^4.10",
-                "drupal/google_tag": "^2",
-                "drupal/recaptcha": "^3",
-                "geocoder-php/google-maps-provider": "^4.7"
+                "drupal/acquia_cms_place": "^1",
+                "drupal/recaptcha": "^3"
             },
             "type": "drupal-module",
             "extra": {

--- a/modules/acquia_cms_toolbar/acquia_cms_toolbar.install
+++ b/modules/acquia_cms_toolbar/acquia_cms_toolbar.install
@@ -5,16 +5,25 @@
  * Contains hook code for the Acquia CMS Toolbar.
  */
 
-use Drupal\acquia_cms_toolbar\EntityOperations\PermissionManager;
+use Drupal\user\Entity\Role;
 
 /**
- * Implements hook_install().
+ * Update role permission handler.
  */
-function acquia_cms_toolbar_install($is_syncing) {
-  if (!$is_syncing) {
-    $class_resolver = \Drupal::service('class_resolver');
-    $class_resolver->getInstanceFromDefinition(PermissionManager::class)
-      ->grantPermissionToRoles();
+function update_toolbar_role_permission() {
+  $get_all_roles = Role::loadMultiple();
+  $roles = [
+    'content_administrator',
+    'content_author',
+    'content_editor',
+    'developer',
+    'site_builder',
+    'user_administrator',
+  ];
+  foreach ($roles as $role) {
+    if (isset($get_all_roles[$role])) {
+      user_role_grant_permissions($role, ['access toolbar']);
+    }
   }
 }
 
@@ -22,7 +31,5 @@ function acquia_cms_toolbar_install($is_syncing) {
  * Update role permissions.
  */
 function acquia_cms_toolbar_update_8001() {
-  $class_resolver = \Drupal::service('class_resolver');
-  $class_resolver->getInstanceFromDefinition(PermissionManager::class)
-    ->grantPermissionToRoles();
+  update_toolbar_role_permission();
 }

--- a/modules/acquia_cms_toolbar/acquia_cms_toolbar.module
+++ b/modules/acquia_cms_toolbar/acquia_cms_toolbar.module
@@ -6,7 +6,6 @@
  */
 
 use Acquia\DrupalEnvironmentDetector\AcquiaDrupalEnvironmentDetector as Environment;
-use Drupal\acquia_cms_toolbar\EntityOperations\PermissionManager;
 use Drupal\Core\Url;
 use Drupal\user\RoleInterface;
 
@@ -103,12 +102,17 @@ function _acquia_cms_toolbar_get_environment_indicator_color_config(): array {
 }
 
 /**
- * Implements hook_entity_insert().
+ * Implements hook_content_model_role_presave_alter().
  */
-function acquia_cms_toolbar_user_role_insert(RoleInterface $role) {
-  if (!$role->isSyncing()) {
-    $class_resolver = \Drupal::service('class_resolver');
-    $class_resolver->getInstanceFromDefinition(PermissionManager::class)
-      ->grantPermissionToRoles([$role->id()]);
+function acquia_cms_toolbar_content_model_role_presave_alter(RoleInterface &$role) {
+  switch ($role->id()) {
+    case 'content_administrator':
+    case 'content_author':
+    case 'content_editor':
+    case 'developer':
+    case 'site_builder':
+    case 'user_administrator':
+      $role->grantPermission('access toolbar');
+      break;
   }
 }

--- a/modules/acquia_cms_toolbar/composer.json
+++ b/modules/acquia_cms_toolbar/composer.json
@@ -4,7 +4,7 @@
     "license": "GPL-2.0-or-later",
     "type": "drupal-module",
     "require": {
-        "acquia/drupal-environment-detector": "^1.5",
+        "drupal/acquia_cms_common": "^1.9 || ^2.1 || ^3.1",
         "drupal/admin_toolbar": "^3.3"
     },
     "conflict": {

--- a/modules/acquia_cms_tour/acquia_cms_tour.info.yml
+++ b/modules/acquia_cms_tour/acquia_cms_tour.info.yml
@@ -3,3 +3,5 @@ package: "Acquia CMS"
 description: "Provides a tour page for Acquia CMS."
 type: module
 core_version_requirement: ^9.4 || ^10 || ^11
+dependencies:
+  - acquia_cms_common:acquia_cms_common

--- a/modules/acquia_cms_tour/acquia_cms_tour.install
+++ b/modules/acquia_cms_tour/acquia_cms_tour.install
@@ -8,18 +8,6 @@
 use Drupal\user\Entity\Role;
 
 /**
- * Implements hook_install().
- */
-function acquia_cms_tour_install($is_syncing) {
-  if (!$is_syncing) {
-    $role = \Drupal::entityTypeManager()->getStorage('user_role')->load('content_administrator');
-    if ($role) {
-      $role->grantPermission('access acquia cms tour dashboard')->trustData()->save();
-    }
-  }
-}
-
-/**
  * Add state key for existing sites with Acquia CMS profile.
  */
 function acquia_cms_tour_update_8001() {

--- a/modules/acquia_cms_tour/acquia_cms_tour.module
+++ b/modules/acquia_cms_tour/acquia_cms_tour.module
@@ -57,13 +57,12 @@ function acquia_cms_tour_modules_uninstalled(array $modules) {
 }
 
 /**
- * Implements hook_cms_tour_entity_insert().
+ * Implements hook_content_model_role_presave_alter().
  */
-function acquia_cms_tour_user_role_insert(RoleInterface $role) {
-  if (!$role->isSyncing() &&
-    $role->id() == 'content_administrator'
-  ) {
-    $role = \Drupal::entityTypeManager()->getStorage('user_role')->load('content_administrator');
-    $role->grantPermission('access acquia cms tour dashboard')->trustData()->save();
+function acquia_cms_tour_content_model_role_presave_alter(RoleInterface &$role) {
+  switch ($role->id()) {
+    case 'content_administrator':
+      $role->grantPermission('access acquia cms tour dashboard');
+      break;
   }
 }

--- a/modules/acquia_cms_tour/composer.json
+++ b/modules/acquia_cms_tour/composer.json
@@ -4,13 +4,12 @@
     "license": "GPL-2.0-or-later",
     "type": "drupal-module",
     "require": {
+        "drupal/acquia_cms_common": "^1.9 || ^2.1 || ^3.1",
         "drupal/checklistapi": "^2.1"
     },
     "require-dev": {
-        "drupal/geocoder": "^3.35 || ^4.10",
-        "drupal/google_tag": "^2",
-        "drupal/recaptcha": "^3",
-        "geocoder-php/google-maps-provider": "^4.7"
+        "drupal/acquia_cms_place": "^1",
+        "drupal/recaptcha": "^3"
     },
     "config": {
         "allow-plugins": {

--- a/modules/acquia_cms_tour/tests/src/Functional/AcquiaGoogleMapsTest.php
+++ b/modules/acquia_cms_tour/tests/src/Functional/AcquiaGoogleMapsTest.php
@@ -1,0 +1,78 @@
+<?php
+
+namespace Drupal\Tests\acquia_cms_tour\Functional;
+
+use Drupal\geocoder\Entity\GeocoderProvider;
+use Drupal\Tests\BrowserTestBase;
+
+/**
+ * Tests the Acquia CMS Tour module's integration with Google Maps.
+ *
+ * @group acquia_cms
+ * @group acquia_cms_tour
+ * @group risky
+ */
+class AcquiaGoogleMapsTest extends BrowserTestBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected $defaultTheme = 'stark';
+
+  /**
+   * {@inheritdoc}
+   */
+  protected static $modules = [
+    'acquia_cms_tour',
+    'acquia_cms_place',
+  ];
+
+  /**
+   * Disable strict config schema checks in this test.
+   *
+   * Cohesion has a lot of config schema errors, and until they are all fixed,
+   * this test cannot pass unless we disable strict config schema checking
+   * altogether. Since strict config schema isn't critically important in
+   * testing this functionality, it's okay to disable it for now, but it should
+   * be re-enabled (i.e., this property should be removed) as soon as possible.
+   *
+   * @var bool
+   */
+  // @codingStandardsIgnoreStart
+  protected $strictConfigSchema = FALSE;
+  // @codingStandardsIgnoreEnd
+
+  /**
+   * Tests that the Google Maps API key can be set on the tour page.
+   */
+  public function testAcquiaGoogleMaps() {
+    $assert_session = $this->assertSession();
+
+    $account = $this->drupalCreateUser(['access acquia cms tour dashboard']);
+    $this->drupalLogin($account);
+
+    // Visit the tour page.
+    $this->drupalGet('/admin/tour/dashboard');
+    $assert_session->statusCodeEquals(200);
+
+    $container = $assert_session->elementExists('css', '[data-drupal-selector="edit-geocoder"]');
+    // API key should be blank to start.
+    $assert_session->fieldValueEquals('maps_api_key', '', $container);
+    $container->pressButton('Save');
+    $assert_session->pageTextContains('Maps API key field is required.');
+
+    // Save a dummmy API key.
+    $dummy_key = 'keykeykey123';
+    $container->fillField('edit-maps-api-key', $dummy_key);
+    $container->pressButton('Save');
+    $assert_session->pageTextContains('The Google Maps API key has been set.');
+
+    // Now test that the config values we expect are set correctly.
+    $cohesion_map_key = $this->config('cohesion.settings')->get('google_map_api_key');
+    $this->assertSame($cohesion_map_key, $dummy_key);
+
+    $configuration = GeocoderProvider::load('googlemaps')->get('configuration');
+    $this->assertSame($configuration['apiKey'], $dummy_key);
+  }
+
+}


### PR DESCRIPTION
This reverts commit 0c2add3a655fa422fdfe09992bff8743347a2beb.

**Motivation**
Reverted the Removal of Acquia CMS Common dependency from Acquia CMS Tour module as that should be done in 3.x release of Acquia CMS Tour module & from Acquia CMS Toolbar module as that should done in 2.x release of Acquia CMS Toolbar module.

**Proposed changes**
Reverted commit: 0c2add3a655fa422fdfe09992bff8743347a2beb

**Alternatives considered**
N/A.