### PR TITLE
ACMS-5776:Fix partial field config causing install failure

### DIFF
--- a/modules/acquia_cms_page/acquia_cms_page.module
+++ b/modules/acquia_cms_page/acquia_cms_page.module
@@ -18,7 +18,7 @@ function acquia_cms_page_modules_installed($modules, $is_syncing) {
   if (in_array('acquia_cms_site_studio', $modules)) {
     $config_factory = \Drupal::service('config.factory');
     $config = $config_factory->getEditable('field.field.node.page.body');
-    if ($config) {
+    if ($config && !$config->isNew()) {
       $config->set('label', 'Search Description')
         ->set('description', 'A short description or teaser which will be displayed in search results.')
         ->save();

--- a/modules/acquia_cms_site_studio/acquia_cms_site_studio.install
+++ b/modules/acquia_cms_site_studio/acquia_cms_site_studio.install
@@ -176,7 +176,7 @@ function _acquia_cms_site_studio_set_theme() {
 function acquia_cms_site_studio_uninstall($is_syncing) {
   if (!$is_syncing) {
     $config = \Drupal::service('config.factory')->getEditable('field.field.node.page.body');
-    if ($config) {
+    if ($config && !$config->isNew()) {
       $config->set('label', 'Body');
       $config->set('description', '');
       $config->save();


### PR DESCRIPTION
**Motivation**
<!-- What problem does this solve? Why is it important? What's the context? If this fixes an issue, link to it above. -->
Fixes #NNN

[ACMS-5776](https://acquia.atlassian.net/browse/ACMS-5776)

When acquia_cms_site_studio is installed, acquia_cms_page updates
field.field.node.page.body label/description. If that config does not
exist yet (optional config not installed), the update created a partial
config missing field_type, breaking the install.

Add !$config->isNew() checks before modifying the config in both
acquia_cms_page_modules_installed() and acquia_cms_site_studio_uninstall()
to update only when the config already exists.

**Proposed changes**
<!-- What does this PR change? How does this impact end users? Are manual or automatic updates required? -->

**Alternatives considered**
<!-- How else could the original issue / use case be addressed? Why did you choose this solution over any others? -->

**Testing steps**
<!-- How can we replicate the issue and verify that this PR fixes it? -->

**Merge requirements**
- [ ] _Major change_, _Minor change_, _Bug_, _Enhancement_, and/or _Chore_ label applied
- [ ] Manual testing by a reviewer
