### PR TITLE
ACMS-6125:Clear Facet Filters block not rendering in Query String URL…

### DIFF
--- a/modules/acquia_cms_search/src/Plugin/Block/ClearFacetFilters.php
+++ b/modules/acquia_cms_search/src/Plugin/Block/ClearFacetFilters.php
@@ -75,11 +75,19 @@ class ClearFacetFilters extends BlockBase implements BlockPluginInterface, Conta
    * {@inheritdoc}
    */
   public function build() {
-    // Check if any facets_query is present in the url. If yes then display the
-    // reset link.
+    // Pretty paths mode: facets are encoded in the {facets_query} route param.
     if ($this->routeMatch->getParameter('facets_query')) {
-      $url = $this->routeMatch->getRouteName();
-      $link = Link::createFromRoute($this->t('Clear filter(s)'), $url, $this->request->getCurrentRequest()->query->all());
+      $link = Link::createFromRoute($this->t('Clear filter(s)'), $this->routeMatch->getRouteName(), [], ['query' => $this->request->getCurrentRequest()->query->all()]);
+
+      return $link->toRenderable();
+    }
+
+    // Query string mode: check for the 'f' filter key in GET parameters.
+    $request = $this->request->getCurrentRequest();
+    if ($request->query->has('f')) {
+      $query = $request->query->all();
+      unset($query['f']);
+      $link = Link::createFromRoute($this->t('Clear filter(s)'), $this->routeMatch->getRouteName(), [], ['query' => $query]);
 
       return $link->toRenderable();
     }

--- a/modules/acquia_cms_search/tests/src/Unit/ClearFacetFiltersTest.php
+++ b/modules/acquia_cms_search/tests/src/Unit/ClearFacetFiltersTest.php
@@ -1,0 +1,131 @@
+<?php
+
+namespace Drupal\Tests\acquia_cms_search\Unit;
+
+use Drupal\acquia_cms_search\Plugin\Block\ClearFacetFilters;
+use Drupal\Core\DependencyInjection\ContainerBuilder;
+use Drupal\Core\Routing\CurrentRouteMatch;
+use Drupal\Tests\UnitTestCase;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\RequestStack;
+
+/**
+ * Unit tests for the ClearFacetFilters block.
+ *
+ * @group acquia_cms_search
+ * @group low_risk
+ * @group pr
+ * @group push
+ * @coversDefaultClass \Drupal\acquia_cms_search\Plugin\Block\ClearFacetFilters
+ */
+class ClearFacetFiltersTest extends UnitTestCase {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp(): void {
+    parent::setUp();
+
+    $container = new ContainerBuilder();
+    $container->set('string_translation', $this->getStringTranslationStub());
+    \Drupal::setContainer($container);
+  }
+
+  /**
+   * Creates a ClearFacetFilters block instance with given services.
+   *
+   * @param \Drupal\Core\Routing\CurrentRouteMatch $route_match
+   *   The route match service.
+   * @param \Symfony\Component\HttpFoundation\RequestStack $request_stack
+   *   The request stack service.
+   *
+   * @return \Drupal\acquia_cms_search\Plugin\Block\ClearFacetFilters
+   *   The block instance.
+   */
+  protected function createBlock(CurrentRouteMatch $route_match, RequestStack $request_stack): ClearFacetFilters {
+    return new ClearFacetFilters(
+      [],
+      'clear_facet_filters',
+      ['id' => 'clear_facet_filters', 'provider' => 'acquia_cms_search'],
+      $route_match,
+      $request_stack
+    );
+  }
+
+  /**
+   * Tests that the block renders a clear link in query-string mode.
+   *
+   * When the facet source uses the query-string URL processor and a facet is
+   * applied via ?f[...], the block must render a "Clear filter(s)" link.
+   *
+   * @covers ::build
+   */
+  public function testBuildWithQueryStringFacetRendersLink(): void {
+    $route_match = $this->createMock(CurrentRouteMatch::class);
+    $route_match->method('getParameter')
+      ->with('facets_query')
+      ->willReturn(NULL);
+    $route_match->method('getRouteName')->willReturn('acquia_search');
+
+    $request = Request::create('/search', 'GET', [
+      'f' => ['type:article'],
+      'keywords' => 'test',
+    ]);
+    $request_stack = $this->createMock(RequestStack::class);
+    $request_stack->method('getCurrentRequest')->willReturn($request);
+
+    $build = $this->createBlock($route_match, $request_stack)->build();
+
+    $this->assertNotEmpty($build);
+    $this->assertEquals('link', $build['#type']);
+  }
+
+  /**
+   * Tests that the clear link removes the 'f' query parameter from the URL.
+   *
+   * @covers ::build
+   */
+  public function testBuildWithQueryStringFacetRemovesFParam(): void {
+    $route_match = $this->createMock(CurrentRouteMatch::class);
+    $route_match->method('getParameter')
+      ->with('facets_query')
+      ->willReturn(NULL);
+    $route_match->method('getRouteName')->willReturn('acquia_search');
+
+    $request = Request::create('/search', 'GET', [
+      'f' => ['type:article'],
+      'keywords' => 'test',
+    ]);
+    $request_stack = $this->createMock(RequestStack::class);
+    $request_stack->method('getCurrentRequest')->willReturn($request);
+
+    $build = $this->createBlock($route_match, $request_stack)->build();
+
+    /** @var \Drupal\Core\Url $url */
+    $url = $build['#url'];
+    $query = $url->getOption('query');
+    $this->assertArrayNotHasKey('f', $query);
+    $this->assertArrayHasKey('keywords', $query);
+  }
+
+  /**
+   * Tests that the block returns empty when no facets are active.
+   *
+   * @covers ::build
+   */
+  public function testBuildWithoutActiveFacetReturnsEmpty(): void {
+    $route_match = $this->createMock(CurrentRouteMatch::class);
+    $route_match->method('getParameter')
+      ->with('facets_query')
+      ->willReturn(NULL);
+
+    $request = Request::create('/search');
+    $request_stack = $this->createMock(RequestStack::class);
+    $request_stack->method('getCurrentRequest')->willReturn($request);
+
+    $build = $this->createBlock($route_match, $request_stack)->build();
+
+    $this->assertEmpty($build);
+  }
+
+}


### PR DESCRIPTION
… processor mode

**Motivation**

The "Clear Facet Filters" block only renders when the facet source uses the Pretty Paths URL processor. When switched to the default Query String processor, the block returns empty and the "Clear filter(s)" link never appears.


<!-- What problem does this solve? Why is it important? What's the context? If this fixes an issue, link to it above. -->
Fixes #NNN

**Proposed changes**
<!-- What does this PR change? How does this impact end users? Are manual or automatic updates required? -->

**Alternatives considered**
<!-- How else could the original issue / use case be addressed? Why did you choose this solution over any others? -->

**Testing steps**
<!-- How can we replicate the issue and verify that this PR fixes it? -->

Add the "Clear Facet Filters" block to a Site Studio View and keep Query String processor in facets, the Clear Facet Filters will work after these changes.

**Merge requirements**
- [ ] _Major change_, _Minor change_, _Bug_, _Enhancement_, and/or _Chore_ label applied
- [ ] Manual testing by a reviewer
